### PR TITLE
PR for Issue #22. Adding steth and reth to arbiter.

### DIFF
--- a/app/src/tokens/mod.rs
+++ b/app/src/tokens/mod.rs
@@ -21,6 +21,8 @@ pub fn get_tokens() -> HashMap<String, Token> {
         name: "ETH".to_string(),
         is_stable: false,
     };
+
+    // Wrapped Bitcoin
     //wBTC https://wbtc.network/
     let wbtc_address = "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
         .parse::<Address>()
@@ -31,6 +33,7 @@ pub fn get_tokens() -> HashMap<String, Token> {
         name: "WBTC".to_string(),
         is_stable: false,
     };
+
     // DAI https://makerdao.com/en/
     let dai_address = "0x6B175474E89094C44Da98b954EedeAC495271d0F"
         .parse::<Address>()
@@ -41,6 +44,7 @@ pub fn get_tokens() -> HashMap<String, Token> {
         name: "DAI".to_string(),
         is_stable: true,
     };
+    
     // USDT https://tether.to/
     let tether_address = "0xdAC17F958D2ee523a2206206994597C13D831ec7"
         .parse::<Address>()
@@ -74,6 +78,7 @@ pub fn get_tokens() -> HashMap<String, Token> {
         is_stable: true,
     };
 
+    // Chainlink
     // LINK https://chain.link/
     let link_address = "0x853d955aCEf822Db058eb8505911ED77F175b99e"
         .parse::<Address>()
@@ -107,6 +112,7 @@ pub fn get_tokens() -> HashMap<String, Token> {
         is_stable: true,
     };
 
+    // Binance US Dollar
     // BUSD https://paxos.com/busd/
     let busd_address = "0x4Fabb145d64652a948d72533023f6E7A623C7C53"
         .parse::<Address>()
@@ -117,6 +123,8 @@ pub fn get_tokens() -> HashMap<String, Token> {
         name: "USDM".to_string(),
         is_stable: true,
     };
+
+    // Uniswap
     // UNI https://uniswap.org/
     let uni_address = "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
         .parse::<Address>()
@@ -127,6 +135,7 @@ pub fn get_tokens() -> HashMap<String, Token> {
         name: "UNI".to_string(),
         is_stable: false,
     };
+
     // BTT https://www.bittorrent.com/
     let btt_address = "0xC669928185DbCE49d2230CC9B0979BE6DC797957"
         .parse::<Address>()
@@ -137,6 +146,8 @@ pub fn get_tokens() -> HashMap<String, Token> {
         name: "BTT".to_string(),
         is_stable: false,
     };
+
+    // Wrapped Staked Ethereum
     // wsETH https://www.lido.fi/
     let wseth_address = "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"
         .parse::<Address>()
@@ -147,6 +158,8 @@ pub fn get_tokens() -> HashMap<String, Token> {
         name: "WSTETH".to_string(),
         is_stable: false,
     };
+
+    // Staked Ethereum
     // stETH https://www.lido.fi/
     // Etherscan: https://etherscan.io/token/0xae7ab96520de3a18e5e111b5eaab095312d7fe84
     let steth_address = "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"
@@ -156,6 +169,18 @@ pub fn get_tokens() -> HashMap<String, Token> {
         address: steth_address,
         decimals: 18,
         name: "STETH".to_string(),
+        is_stable: false,
+    };
+    // Rocket Pool Ethereum
+    // rETH https://rocketpool.net/#header
+    // Etherscan: https://etherscan.io/token/0xae78736cd615f374d3085123a210448e74fc6393
+    let reth_address = "0xae78736Cd615f374D3085123A210448E74Fc6393"
+        .parse::<Address>()
+        .unwrap();
+    let steth = Token {
+        address: reth_address,
+        decimals: 18,
+        name: "RETH".to_string(),
         is_stable: false,
     };
 
@@ -174,6 +199,7 @@ pub fn get_tokens() -> HashMap<String, Token> {
     tokens.insert("BTT".to_string(), btt);
     tokens.insert("WSTETH".to_string(), wsteth);
     tokens.insert("STETH".to_string(), steth);
+    tokens.insert("RETH".to_string(), steth);
 
     tokens
 }

--- a/app/src/tokens/mod.rs
+++ b/app/src/tokens/mod.rs
@@ -11,7 +11,7 @@ pub struct Token {
 
 // return hashmap, name = key, value = token object
 pub fn get_tokens() -> HashMap<String, Token> {
-    // Ether
+    // ETH
     let eth_address = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
         .parse::<Address>()
         .unwrap();
@@ -31,7 +31,7 @@ pub fn get_tokens() -> HashMap<String, Token> {
         name: "WBTC".to_string(),
         is_stable: false,
     };
-    // Dai https://makerdao.com/en/
+    // DAI https://makerdao.com/en/
     let dai_address = "0x6B175474E89094C44Da98b954EedeAC495271d0F"
         .parse::<Address>()
         .unwrap();
@@ -63,7 +63,7 @@ pub fn get_tokens() -> HashMap<String, Token> {
         is_stable: true,
     };
 
-    // Frax https://frax.finance/
+    // FRAX https://frax.finance/
     let frax_address = "0x853d955aCEf822Db058eb8505911ED77F175b99e"
         .parse::<Address>()
         .unwrap();
@@ -74,7 +74,7 @@ pub fn get_tokens() -> HashMap<String, Token> {
         is_stable: true,
     };
 
-    // link https://chain.link/
+    // LINK https://chain.link/
     let link_address = "0x853d955aCEf822Db058eb8505911ED77F175b99e"
         .parse::<Address>()
         .unwrap();
@@ -96,7 +96,7 @@ pub fn get_tokens() -> HashMap<String, Token> {
         is_stable: false,
     };
 
-    // usdm https://www.mappedswap.io/
+    // USDM https://www.mappedswap.io/
     let usdm_address = "0xbbAec992fc2d637151dAF40451f160bF85f3C8C1"
         .parse::<Address>()
         .unwrap();
@@ -137,7 +137,7 @@ pub fn get_tokens() -> HashMap<String, Token> {
         name: "BTT".to_string(),
         is_stable: false,
     };
-    // wseth https://www.lido.fi/
+    // wsETH https://www.lido.fi/
     let wseth_address = "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"
         .parse::<Address>()
         .unwrap();

--- a/app/src/tokens/mod.rs
+++ b/app/src/tokens/mod.rs
@@ -44,7 +44,7 @@ pub fn get_tokens() -> HashMap<String, Token> {
         name: "DAI".to_string(),
         is_stable: true,
     };
-    
+
     // USDT https://tether.to/
     let tether_address = "0xdAC17F958D2ee523a2206206994597C13D831ec7"
         .parse::<Address>()
@@ -177,7 +177,7 @@ pub fn get_tokens() -> HashMap<String, Token> {
     let reth_address = "0xae78736Cd615f374D3085123A210448E74Fc6393"
         .parse::<Address>()
         .unwrap();
-    let steth = Token {
+    let reth = Token {
         address: reth_address,
         decimals: 18,
         name: "RETH".to_string(),

--- a/app/src/tokens/mod.rs
+++ b/app/src/tokens/mod.rs
@@ -171,6 +171,7 @@ pub fn get_tokens() -> HashMap<String, Token> {
         name: "STETH".to_string(),
         is_stable: false,
     };
+    
     // Rocket Pool Ethereum
     // rETH https://rocketpool.net/#header
     // Etherscan: https://etherscan.io/token/0xae78736cd615f374d3085123a210448e74fc6393

--- a/app/src/tokens/mod.rs
+++ b/app/src/tokens/mod.rs
@@ -171,7 +171,7 @@ pub fn get_tokens() -> HashMap<String, Token> {
         name: "STETH".to_string(),
         is_stable: false,
     };
-    
+
     // Rocket Pool Ethereum
     // rETH https://rocketpool.net/#header
     // Etherscan: https://etherscan.io/token/0xae78736cd615f374d3085123a210448e74fc6393
@@ -200,7 +200,7 @@ pub fn get_tokens() -> HashMap<String, Token> {
     tokens.insert("BTT".to_string(), btt);
     tokens.insert("WSTETH".to_string(), wsteth);
     tokens.insert("STETH".to_string(), steth);
-    tokens.insert("RETH".to_string(), steth);
+    tokens.insert("RETH".to_string(), reth);
 
     tokens
 }

--- a/app/src/tokens/mod.rs
+++ b/app/src/tokens/mod.rs
@@ -147,6 +147,17 @@ pub fn get_tokens() -> HashMap<String, Token> {
         name: "WSTETH".to_string(),
         is_stable: false,
     };
+    // stETH https://www.lido.fi/
+    // Etherscan: https://etherscan.io/token/0xae7ab96520de3a18e5e111b5eaab095312d7fe84
+    let steth_address = "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"
+        .parse::<Address>()
+        .unwrap();
+    let steth = Token {
+        address: steth_address,
+        decimals: 18,
+        name: "STETH".to_string(),
+        is_stable: false,
+    };
 
     let mut tokens = HashMap::new();
     tokens.insert("ETH".to_string(), eth);
@@ -162,6 +173,7 @@ pub fn get_tokens() -> HashMap<String, Token> {
     tokens.insert("UNI".to_string(), uni);
     tokens.insert("BTT".to_string(), btt);
     tokens.insert("WSTETH".to_string(), wsteth);
+    tokens.insert("STETH".to_string(), steth);
 
     tokens
 }


### PR DESCRIPTION
Did Issue #22 
- Added steth and reth
- Made some small formatting changes (whitespace between tokens inits in `tokens/mod.rs`)

Ran arbiter locally on the new tokens and found that pools w/ ETH existed for both.

[RETH ETH Pool on Etherscan](https://etherscan.io/token/0xae78736cd615f374d3085123a210448e74fc6393#tokenTrade)

[STETH ETH Pool on Uniswap analytics](https://info.uniswap.org/#/pools/0xeacdf56d530a4ec6639c2c86f1915f4956446b5c)


Interestingly the only activity on the STETH ETH pool were two deposits and withdrawals  one for 200k and another for 2k (looks like [most of the STETH liquidity is on Curve](https://curve.fi/#/ethereum/pools/steth/deposit))

![Screen Shot 2022-11-23 at 9 26 31 PM](https://user-images.githubusercontent.com/56851203/203680460-9d31bb04-c8ca-43bb-bed4-3e6072897417.png)
