### PR TITLE
Add `sim` subcommand for GBM

### DIFF
--- a/crates/cli/src/config.toml
+++ b/crates/cli/src/config.toml
@@ -4,3 +4,13 @@ rpc_url = "https://eth-mainnet.g.alchemy.com/v2/I93POQk49QE9O-NuOz7nj7sbiluW76it
 token0 = "ETH"
 token1 = "USDC"
 bp = "30"
+
+[sim]
+timestep = 1.0
+timescale = "day"
+num_steps = 365
+initial_price = 1196.54
+drift = 0.1
+volatility = 2.0
+seed = 888
+

--- a/crates/cli/src/config/mod.rs
+++ b/crates/cli/src/config/mod.rs
@@ -25,6 +25,8 @@ struct ConfigToml {
     rpc_url: String,
     /// Parameters for the `clairvoyance` module of arbiter.
     see: ConfigTomlSee,
+    /// Parameters for the `sim` module of arbiter.
+    sim: ConfigTomlSim
 }
 
 /// Representation of the `see` section of the config file.
@@ -36,6 +38,24 @@ struct ConfigTomlSee {
     token1: String,
     /// Basis points of the pool.
     bp: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct ConfigTomlSim {
+    /// Numerical timestep for the simulation (typically `1`)
+    timestep: f64,
+    /// Time in string interpretation 
+    timescale: String,
+    /// Number of timesteps
+    num_steps: usize,
+    /// Initial asset price
+    initial_price: f64,
+    /// Asset price drift
+    drift: f64,
+    /// Asset volatility
+    volatility: f64,
+    /// Seed for varying price path
+    seed: u64,
 }
 
 /// Representation of the config file that other modules have access to.
@@ -50,6 +70,20 @@ pub struct Config {
     pub token1: String,
     /// Pool basis points.
     pub bp: String,
+    /// Numerical timestep for the simulation (typically `1`)
+    pub timestep: f64,
+    /// Time in string interpretation 
+    pub timescale: String,
+    /// Number of timesteps
+    pub num_steps: usize,
+    /// Initial asset price
+    pub initial_price: f64,
+    /// Asset price drift
+    pub drift: f64,
+    /// Asset volatility
+    pub volatility: f64,
+    /// Seed for varying price path
+    pub seed: u64,
 }
 
 impl Config {
@@ -71,6 +105,13 @@ impl Config {
             token0: config_toml.see.token0,
             token1: config_toml.see.token1,
             bp: config_toml.see.bp,
+            timestep: config_toml.sim.timestep,
+            timescale: config_toml.sim.timescale,
+            num_steps: config_toml.sim.num_steps,
+            initial_price: config_toml.sim.initial_price,
+            drift: config_toml.sim.drift,
+            volatility: config_toml.sim.volatility,
+            seed: config_toml.sim.seed,
         })
     }
 }

--- a/crates/cli/src/config/mod.rs
+++ b/crates/cli/src/config/mod.rs
@@ -26,7 +26,7 @@ struct ConfigToml {
     /// Parameters for the `clairvoyance` module of arbiter.
     see: ConfigTomlSee,
     /// Parameters for the `sim` module of arbiter.
-    sim: ConfigTomlSim
+    sim: ConfigTomlSim,
 }
 
 /// Representation of the `see` section of the config file.
@@ -44,7 +44,7 @@ struct ConfigTomlSee {
 struct ConfigTomlSim {
     /// Numerical timestep for the simulation (typically `1`)
     timestep: f64,
-    /// Time in string interpretation 
+    /// Time in string interpretation
     timescale: String,
     /// Number of timesteps
     num_steps: usize,
@@ -72,7 +72,7 @@ pub struct Config {
     pub bp: String,
     /// Numerical timestep for the simulation (typically `1`)
     pub timestep: f64,
-    /// Time in string interpretation 
+    /// Time in string interpretation
     pub timescale: String,
     /// Number of timesteps
     pub num_steps: usize,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -45,10 +45,10 @@ enum Commands {
     },
 
     Sim {
-        /// Path to config.toml containing simulation parameterization (optional) 
+        /// Path to config.toml containing simulation parameterization (optional)
         #[arg(short, long, default_value = "./crates/cli/src/config.toml", num_args = 0..=1)]
         config: String,
-    }
+    },
 }
 
 #[tokio::main]
@@ -96,10 +96,17 @@ async fn main() -> Result<()> {
                 join!(pool.monitor_pool());
             }
         }
-        Some(Commands::Sim {
-            config,
-        }) => {
-            let config::Config { timestep, timescale, num_steps, initial_price, drift, volatility, seed, .. } = config::Config::new(config).unwrap();
+        Some(Commands::Sim { config }) => {
+            let config::Config {
+                timestep,
+                timescale,
+                num_steps,
+                initial_price,
+                drift,
+                volatility,
+                seed,
+                ..
+            } = config::Config::new(config).unwrap();
             let test_sim = simulation::Simulation::new(
                 timestep,
                 timescale,


### PR DESCRIPTION
Adds `sim` subcommand for generating gbm instead of it running every time arbiter cli is invoked