### PR TITLE
Alex/ci workflows

### DIFF
--- a/.github/workflows/cargo-audit.yaml
+++ b/.github/workflows/cargo-audit.yaml
@@ -1,11 +1,6 @@
-name: cargo-audit
+on: [push]
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-      - main
+name: cargo-audit
 
 jobs:
   cargo-audit:

--- a/.github/workflows/cargo-audit.yaml
+++ b/.github/workflows/cargo-audit.yaml
@@ -1,0 +1,14 @@
+name: cargo-audit
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+      - main
+
+
+jobs:
+  steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1

--- a/.github/workflows/cargo-deny.yaml
+++ b/.github/workflows/cargo-deny.yaml
@@ -1,4 +1,4 @@
-name: cargo-audit
+name: cargo-deny
 
 on:
   push:
@@ -8,8 +8,8 @@ on:
       - main
 
 jobs:
-  cargo-audit:
+  cargo-deny:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/audit-check@v1
+    - uses: actions/checkout@v3
+    - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/cargo-deny.yaml
+++ b/.github/workflows/cargo-deny.yaml
@@ -1,11 +1,7 @@
+on: [push]
+
 name: cargo-deny
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-      - main
 
 jobs:
   cargo-deny:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,8 +1,9 @@
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
+      - main
 
 name: Rust
 

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,9 +1,4 @@
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-      - main
+on: [push]
 
 name: Rust
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,53 @@
+# cargo-deny is really only ever intended to run on the "normal" tier-1 targets
+targets = [
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "aarch64-unknown-linux-gnu" },
+    { triple = "x86_64-unknown-linux-musl" },
+    { triple = "aarch64-apple-darwin" },
+    { triple = "x86_64-apple-darwin" },
+    { triple = "x86_64-pc-windows-msvc" },
+]
+
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+notice = "deny"
+unsound = "deny"
+ignore = [
+    # potential unaligned pointer read on windows. Doesn't happen in practice, don't
+    # care
+    "RUSTSEC-2021-0145",
+]
+
+[bans]
+multiple-versions = "deny"
+deny = []
+skip = [
+    # cargo depends on two versions of these crates
+    { name = "hex", version = "=0.3.2" },
+    { name = "bstr", version = "=0.2.17" },
+]
+skip-tree = [
+    # windows-sys minor version bumps are still incredibly tedious
+    { name = "windows-sys", version = "=0.36.1" },
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+
+[sources.allow-org]
+github = ["EmbarkStudios"]
+
+[licenses]
+unlicensed = "deny"
+allow-osi-fsf-free = "neither"
+copyleft = "deny"
+# We want really high confidence when inferring licenses from text
+confidence-threshold = 0.93
+allow = ["Apache-2.0", "Apache-2.0 WITH LLVM-exception", "MIT", "MPL-2.0", "AGPL-3.0-or-later"]
+
+exceptions = [
+    { allow = ["Zlib"], name = "tinyvec" },
+    { allow = ["Unicode-DFS-2016"], name = "unicode-ident" },
+]


### PR DESCRIPTION
# Changes
- Adds `cargo-audit` ci workflow to run https://docs.rs/cargo-audit/latest/cargo_audit/
- Adds `cargo-deny` ci workflow to run https://github.com/marketplace/actions/cargo-deny
- Misc: fixes current CI workflow `rust` to run on `main` instead of master.

## Todo:
- There is a workflow that would make a PR for us to fix bad results from `cargo audit`, but I wasn't sure if we really wanted that so I left it out.