### PR TITLE
Colin/deploy contract abstraction

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,4 +1,3 @@
-use std::{env, str::FromStr, sync::Arc};
 use clairvoyance::Clairvoyance;
 use clap::{CommandFactory, Parser, Subcommand};
 use ethers::{
@@ -12,6 +11,7 @@ use simulate::{
     execution::{ExecutionManager, SimulationContract},
     price_simulation::PriceSimulation,
 };
+use std::{env, str::FromStr, sync::Arc};
 use utils::chain_tools::get_provider;
 mod config;
 
@@ -102,12 +102,13 @@ async fn main() -> Result<()> {
             // Create a `ExecutionManager` where we can run simulations.
             let mut manager = ExecutionManager::new();
             // Generate a user account to mint tokens to.
-            let user_address = B160::from_str("0x0000000000000000000000000000000000000001").unwrap();
+            let user_address =
+                B160::from_str("0x0000000000000000000000000000000000000001").unwrap();
             manager
-            .evm
-            .db()
-            .unwrap()
-            .insert_account_info(user_address, AccountInfo::default());
+                .evm
+                .db()
+                .unwrap()
+                .insert_account_info(user_address, AccountInfo::default());
             // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
             // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -215,7 +216,7 @@ async fn main() -> Result<()> {
                 .base_contract
                 .decode_output("balanceOf", value.unwrap())?;
 
-            print!("Balance of user {user_address:#?}: {response:#?}\n")
+            println!("Balance of user {user_address:#?}: {response:#?}")
             // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }
         Some(Commands::Gbm { config }) => {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,3 +1,5 @@
+use std::{env, str::FromStr, sync::Arc};
+
 use clairvoyance::Clairvoyance;
 use clap::{CommandFactory, Parser, Subcommand};
 use ethers::{
@@ -11,7 +13,6 @@ use simulate::{
     execution::{ExecutionManager, SimulationContract},
     price_simulation::PriceSimulation,
 };
-use std::{env, str::FromStr, sync::Arc};
 use utils::chain_tools::get_provider;
 mod config;
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,5 +1,4 @@
 use std::{env, str::FromStr, sync::Arc};
-
 use clairvoyance::Clairvoyance;
 use clap::{CommandFactory, Parser, Subcommand};
 use ethers::{
@@ -102,14 +101,13 @@ async fn main() -> Result<()> {
             // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             // Create a `ExecutionManager` where we can run simulations.
             let mut manager = ExecutionManager::new();
-            // Generate a user account to mint tokens to. (TODO: MOVE INTO EXECUTION?)
-            let user_address =
-                B160::from_str("0x0000000000000000000000000000000000000001").unwrap();
+            // Generate a user account to mint tokens to.
+            let user_address = B160::from_str("0x0000000000000000000000000000000000000001").unwrap();
             manager
-                .evm
-                .db()
-                .unwrap()
-                .insert_account_info(user_address, AccountInfo::default());
+            .evm
+            .db()
+            .unwrap()
+            .insert_account_info(user_address, AccountInfo::default());
             // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
             // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -196,7 +194,7 @@ async fn main() -> Result<()> {
                 .collect();
 
             // Call the 'balanceOf' function.
-            let result3 = manager.execute(
+            let result = manager.execute(
                 user_address,
                 call_data,
                 TransactTo::Call(arbiter_token.address.unwrap()),
@@ -204,7 +202,7 @@ async fn main() -> Result<()> {
             );
 
             // unpack output call enum into raw bytes
-            let value = match result3 {
+            let value = match result {
                 ExecutionResult::Success { output, .. } => match output {
                     Output::Call(value) => Some(value),
                     Output::Create(_, Some(_)) => None,
@@ -217,7 +215,7 @@ async fn main() -> Result<()> {
                 .base_contract
                 .decode_output("balanceOf", value.unwrap())?;
 
-            print!("Balance of user {user_address:#?}: {response:#?}")
+            print!("Balance of user {user_address:#?}: {response:#?}\n")
             // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }
         Some(Commands::Gbm { config }) => {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -110,19 +110,13 @@ async fn main() -> Result<()> {
                 .db()
                 .unwrap()
                 .insert_account_info(user_address, AccountInfo::default());
-
-            println!(
-                "Database after adding account: {:#?}",
-                manager.evm.db().unwrap()
-            );
             // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
             // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             // Deploy the Arbiter Token ERC-20 contract.
             // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            // Get a BaseContract for the Arbiter Token ERC-20 instance from the ABI.
-
-            let arbitertoken_contract = SimulationContract<NotDeployed>::new(
+            // Get a SimulationContract for the Arbiter Token ERC-20 instance from the ABI.
+            let arbitertoken_contract = SimulationContract::new(
                 BaseContract::from(bindings::arbiter_token::ARBITERTOKEN_ABI.clone()),
                 Bytes::copy_from_slice(&bindings::arbiter_token::ARBITERTOKEN_BYTECODE).into(),
             );

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -155,54 +155,52 @@ async fn main() -> Result<()> {
             println!("Token Name: {response:#?}");
             // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-            // // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            // // Mint tokens to the user.
-            // // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            // // Allocating new tokens to user by calling Arbiter Token's ERC20 'mint' instance.
-            // let mint_amount = U256::from(1000);
+            // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            // Mint tokens to the user.
+            // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            // Allocating new tokens to user by calling Arbiter Token's ERC20 'mint' instance.
+            let mint_amount = U256::from(1000);
 
-            // // Set up the calldata for the 'increaseAllowance' function.
-            // let user_address_recast: [u8; 20] = user_address.as_bytes().try_into()?;
-            // let user_address_recast: Address = Address::from(user_address_recast);
-            // let input_arguments = (user_address_recast, mint_amount);
-            // println!("Input args for mint: {:#?}", input_arguments);
-            // let mint_bytes = arbitertoken_contract.encode("mint", input_arguments);
-            // let mint_bytes = Bytes::from(hex::decode(hex::encode(mint_bytes?))?);
+            // Set up the calldata for the 'increaseAllowance' function.
+            let user_address_recast: [u8; 20] = user_address.as_bytes().try_into()?;
+            let user_address_recast: Address = Address::from(user_address_recast);
+            let input_arguments = (user_address_recast, mint_amount);
+            println!("Input args for mint: {:#?}", input_arguments);
+            let call_data = arbitertoken_contract.base_contract.encode("mint", input_arguments)?.into_iter().collect();
 
-            // // Call the 'mint' function.
-            // let _result = manager.execute(
-            //     user_address,
-            //     mint_bytes,
-            //     TransactTo::Call(arbitertoken_contract_address),
-            //     Uint::from(0),
-            // ); // TODO: SOME KIND OF ERROR HANDLING IS NECESSARY FOR THESE TYPES OF CALLS
+            // Call the 'mint' function.
+            let _result = manager.execute(
+                user_address,
+                call_data,
+                TransactTo::Call(arbitertoken_contract.address.unwrap()),
+                Uint::from(0),
+            ); // TODO: SOME KIND OF ERROR HANDLING IS NECESSARY FOR THESE TYPES OF CALLS
 
-            // let balance_of_bytes = arbitertoken_contract.encode("balanceOf", user_address_recast);
-            // let balance_of_bytes = Bytes::from(hex::decode(hex::encode(balance_of_bytes?))?);
+            let call_data = arbitertoken_contract.base_contract.encode("balanceOf", user_address_recast)?.into_iter().collect();
 
-            // // Call the 'balanceOf' function.
-            // let result3 = manager.execute(
-            //     user_address,
-            //     balance_of_bytes,
-            //     TransactTo::Call(arbitertoken_contract_address),
-            //     Uint::from(0),
-            // );
+            // Call the 'balanceOf' function.
+            let result3 = manager.execute(
+                user_address,
+                call_data,
+                TransactTo::Call(arbitertoken_contract.address.unwrap()),
+                Uint::from(0),
+            );
 
-            // // unpack output call enum into raw bytes
-            // let value = match result3 {
-            //     ExecutionResult::Success { output, .. } => match output {
-            //         Output::Call(value) => Some(value),
-            //         Output::Create(_, Some(_)) => None,
-            //         _ => None,
-            //     },
-            //     _ => None,
-            // };
+            // unpack output call enum into raw bytes
+            let value = match result3 {
+                ExecutionResult::Success { output, .. } => match output {
+                    Output::Call(value) => Some(value),
+                    Output::Create(_, Some(_)) => None,
+                    _ => None,
+                },
+                _ => None,
+            };
 
-            // let response: U256 =
-            //     arbitertoken_contract.decode_output("balanceOf", value.unwrap())?;
+            let response: U256 =
+                arbitertoken_contract.base_contract.decode_output("balanceOf", value.unwrap())?;
 
-            // print!("Balance of user {user_address:#?}: {response:#?}")
-            // // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            print!("Balance of user {user_address:#?}: {response:#?}")
+            // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }
         Some(Commands::Gbm { config }) => {
             // Plot a GBM price path

--- a/crates/simulate/src/execution.rs
+++ b/crates/simulate/src/execution.rs
@@ -12,7 +12,8 @@ use revm::{
 pub struct NotDeployed;
 pub struct IsDeployed;
 
-pub struct SimulationContract<Deployed = NotDeployed> {
+#[derive(Debug)]
+pub struct SimulationContract<Deployed> {
     pub base_contract: BaseContract,
     pub bytecode: Vec<u8>,
     pub address: Option<B160>,

--- a/crates/simulate/src/execution.rs
+++ b/crates/simulate/src/execution.rs
@@ -1,9 +1,43 @@
 use bytes::Bytes;
+use ethers::{
+    abi::{Abi, Address, Tokenizable, Tokenize},
+    prelude::BaseContract,
+};
 use revm::{
     db::{CacheDB, EmptyDB},
-    primitives::{ExecutionResult, TransactTo, B160, U256},
+    primitives::{ruint::Uint, ExecutionResult, TransactTo, B160, U256},
     EVM,
 };
+
+pub struct NotDeployed;
+pub struct IsDeployed;
+
+pub struct SimulationContract<Deployed = NotDeployed> {
+    pub base_contract: BaseContract,
+    pub bytecode: Vec<u8>,
+    pub address: Option<B160>,
+    pub deployed: std::marker::PhantomData<Deployed>,
+}
+
+impl SimulationContract<NotDeployed> {
+    pub fn new(base_contract: BaseContract, bytecode: Vec<u8>) -> Self {
+        Self {
+            base_contract,
+            bytecode,
+            address: None,
+            deployed: std::marker::PhantomData,
+        }
+    }
+
+    fn to_deployed(self, address: B160) -> SimulationContract<IsDeployed> {
+        SimulationContract {
+            base_contract: self.base_contract,
+            bytecode: self.bytecode,
+            address: self.address,
+            deployed: std::marker::PhantomData,
+        }
+    }
+}
 
 #[derive(Default)]
 pub struct ExecutionManager {
@@ -24,14 +58,14 @@ impl ExecutionManager {
     /// Execute a transaction.
     pub fn execute(
         &mut self,
-        caller: B160,
-        data: Bytes,
+        sender: B160,
+        data: Vec<u8>,
         transact_to: TransactTo,
         value: U256,
     ) -> ExecutionResult {
-        self.evm.env.tx.caller = caller;
+        self.evm.env.tx.caller = sender;
         self.evm.env.tx.transact_to = transact_to;
-        self.evm.env.tx.data = data;
+        self.evm.env.tx.data = data.into();
         self.evm.env.tx.value = value;
 
         match self.evm.transact_commit() {
@@ -39,6 +73,39 @@ impl ExecutionManager {
             // URGENT: change this to a custom error
             Err(_) => panic!("failed"),
         }
+    }
+
+    /// Deploy a contract.
+    pub fn deploy<T: Tokenizable>(
+        &mut self,
+        sender: B160,
+        contract: SimulationContract,
+        args: T,
+    ) -> SimulationContract<IsDeployed> {
+        let args = args.into_tokens();
+        // Append to generate the deploy bytecode;
+        let bytecode = contract
+            .base_contract
+            .abi()
+            .constructor()
+            .unwrap()
+            .encode_input(contract.bytecode.clone(), &args)
+            .unwrap(); // TODO: Need to catch this if error
+
+        self.execute(sender, bytecode, TransactTo::create(), Uint::from(0));
+
+        let contract_address = self
+            .evm
+            .db()
+            .unwrap()
+            .clone()
+            .accounts
+            .into_iter()
+            .nth(2)
+            .unwrap()
+            .0;
+
+        contract.to_deployed(contract_address)
     }
 
     /// Give an address a specified amount of raw ether.

--- a/crates/simulate/src/execution.rs
+++ b/crates/simulate/src/execution.rs
@@ -1,9 +1,11 @@
 use ethers::{abi::Tokenize, prelude::BaseContract};
 use revm::{
     db::{CacheDB, EmptyDB},
-    primitives::{ruint::Uint, ExecutionResult, TransactTo, B160, U256},
+    primitives::{ruint::Uint, ExecutionResult, TransactTo, B160, U256, AccountInfo},
     EVM,
 };
+use std::{env, str::FromStr, sync::Arc};
+
 
 #[derive(Debug)]
 pub struct NotDeployed;

--- a/crates/simulate/src/execution.rs
+++ b/crates/simulate/src/execution.rs
@@ -9,7 +9,9 @@ use revm::{
     EVM,
 };
 
+#[derive(Debug)]
 pub struct NotDeployed;
+#[derive(Debug)]
 pub struct IsDeployed;
 
 #[derive(Debug)]
@@ -34,7 +36,7 @@ impl SimulationContract<NotDeployed> {
         SimulationContract {
             base_contract: self.base_contract,
             bytecode: self.bytecode,
-            address: self.address,
+            address: Some(address),
             deployed: std::marker::PhantomData,
         }
     }
@@ -80,7 +82,7 @@ impl ExecutionManager {
     pub fn deploy<T: Tokenizable>(
         &mut self,
         sender: B160,
-        contract: SimulationContract,
+        contract: SimulationContract<NotDeployed>,
         args: T,
     ) -> SimulationContract<IsDeployed> {
         let args = args.into_tokens();

--- a/crates/simulate/src/execution.rs
+++ b/crates/simulate/src/execution.rs
@@ -1,11 +1,9 @@
 use ethers::{abi::Tokenize, prelude::BaseContract};
 use revm::{
     db::{CacheDB, EmptyDB},
-    primitives::{ruint::Uint, ExecutionResult, TransactTo, B160, U256, AccountInfo},
+    primitives::{ruint::Uint, ExecutionResult, TransactTo, B160, U256},
     EVM,
 };
-use std::{env, str::FromStr, sync::Arc};
-
 
 #[derive(Debug)]
 pub struct NotDeployed;

--- a/crates/simulate/src/lib.rs
+++ b/crates/simulate/src/lib.rs
@@ -1,6 +1,17 @@
 pub mod execution;
 pub mod price_simulation;
 
+use bytes::Bytes;
+use ethers::{
+    abi::{Abi, Address, Tokenizable},
+    prelude::BaseContract,
+};
+use revm::{
+    db::{CacheDB, EmptyDB},
+    primitives::{ExecutionResult, TransactTo, B160, U256},
+    EVM,
+};
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;


### PR DESCRIPTION
Took a stab at abstracting the deployment process. This could surely be cleaned up more, but it gets the job done!

I created a struct `SimulationContract<Deployed>` to mimic (in some way) the ethers contract struct but without any provider. You can begin by calling `SimulationContract::new(...)` which will return `SimulationContract<NotDeployed>`.  Only after calling `ExecutionManager::deploy(...)` will you receive back a `SimulationContract<IsDeployed>`. The contract will also be in the relevant db.

Closes #105 