### PR TITLE
Implemented an event buffer

### DIFF
--- a/crates/simulate/src/agent.rs
+++ b/crates/simulate/src/agent.rs
@@ -26,25 +26,7 @@ pub trait Agent {
     ) -> TxEnv;
     fn read_logs(
         &mut self,
-        contract: SimulationContract<IsDeployed>,
-        event_name: &str,
-        execution_result: ExecutionResult,
-    ) -> &Vec<revm::primitives::Log>; // TODO: Not sure this needs to be mutable self
+    ) -> Vec<Vec<Log>>; // TODO: Not sure this needs to be mutable self
 
     // TODO: Should agents be labeled as `active` or `inactive` similarly to `IsDeployed` and `NotDeployed`?
-
-    // TODO: We may never actually need to return logs here depending on how we handle echoing to a buffer.
-    fn unpack_execution(&self, execution_result: ExecutionResult) -> (Bytes, Vec<Log>) {
-        // unpack output call enum into raw bytes
-        match execution_result {
-            ExecutionResult::Success { output, logs, .. } => match output {
-                Output::Call(value) => (value, logs),
-                Output::Create(_, Some(_)) => {
-                    panic!("Failed. This was a 'Create' call, use 'Deploy' instead.")
-                }
-                _ => panic!("This call has failed."),
-            },
-            _ => panic!("This call generated no execution result. This should not happen."),
-        }
-    }
 }

--- a/crates/simulate/src/agent.rs
+++ b/crates/simulate/src/agent.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use revm::primitives::{ExecutionResult, Log, Output, TxEnv, B160, U256};
+use revm::primitives::{ExecutionResult, Log, TxEnv, B160, U256};
 
 use crate::environment::{IsDeployed, SimulationContract};
 
@@ -24,9 +24,7 @@ pub trait Agent {
         call_data: Bytes,
         value: U256,
     ) -> TxEnv;
-    fn read_logs(
-        &mut self,
-    ) -> Vec<Log>; // TODO: Not sure this needs to be mutable self
+    fn read_logs(&mut self) -> Vec<Log>; // TODO: Not sure this needs to be mutable self
 
     // TODO: Should agents be labeled as `active` or `inactive` similarly to `IsDeployed` and `NotDeployed`?
 }

--- a/crates/simulate/src/agent.rs
+++ b/crates/simulate/src/agent.rs
@@ -26,7 +26,7 @@ pub trait Agent {
     ) -> TxEnv;
     fn read_logs(
         &mut self,
-    ) -> Vec<Vec<Log>>; // TODO: Not sure this needs to be mutable self
+    ) -> Vec<Log>; // TODO: Not sure this needs to be mutable self
 
     // TODO: Should agents be labeled as `active` or `inactive` similarly to `IsDeployed` and `NotDeployed`?
 }

--- a/crates/simulate/src/environment.rs
+++ b/crates/simulate/src/environment.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, str::FromStr, sync::{Arc, RwLock}};
+use std::{
+    collections::HashMap,
+    str::FromStr,
+    sync::{Arc, RwLock},
+};
 
 use bytes::Bytes;
 use ethers::{
@@ -48,7 +52,7 @@ impl SimulationEnvironment {
             Err(_) => panic!("failed"),
         };
 
-        let logs = execution_result.clone().logs();
+        let logs = execution_result.logs();
         self.echo_logs(logs);
         execution_result
     }
@@ -89,9 +93,7 @@ impl Agent for SimulationManager {
     }
     // TODO: Handle the output of the execution result and decode?
 
-    fn read_logs(
-        &mut self,
-    ) -> Vec<Log> {
+    fn read_logs(&mut self) -> Vec<Log> {
         self.environment.event_buffer.read().unwrap().to_vec()
     }
 
@@ -131,21 +133,20 @@ impl Default for SimulationManager {
 }
 
 impl SimulationManager {
-
-        // TODO: Unpacking should probably be defined on ExecutionResult type. But that will be in the crate.
-        pub fn unpack_execution(&self, execution_result: ExecutionResult) -> Bytes {
-            // unpack output call enum into raw bytes
-            match execution_result {
-                ExecutionResult::Success { output, logs, .. } => match output {
-                    Output::Call(value) => value,
-                    Output::Create(_, Some(_)) => {
-                        panic!("Failed. This was a 'Create' call, use 'Deploy' instead.")
-                    }
-                    _ => panic!("This call has failed."),
-                },
-                _ => panic!("This call generated no execution result. This should not happen."),
-            }
+    // TODO: Unpacking should probably be defined on ExecutionResult type. But that will be in the crate.
+    pub fn unpack_execution(&self, execution_result: ExecutionResult) -> Bytes {
+        // unpack output call enum into raw bytes
+        match execution_result {
+            ExecutionResult::Success { output, .. } => match output {
+                Output::Call(value) => value,
+                Output::Create(_, Some(_)) => {
+                    panic!("Failed. This was a 'Create' call, use 'Deploy' instead.")
+                }
+                _ => panic!("This call has failed."),
+            },
+            _ => panic!("This call generated no execution result. This should not happen."),
         }
+    }
     /// Used in the deploy function to create a transaction environment for deploying a contract.
     fn build_deploy_transaction(&self, bytecode: Bytes) -> TxEnv {
         TxEnv {

--- a/crates/simulate/src/lib.rs
+++ b/crates/simulate/src/lib.rs
@@ -46,9 +46,7 @@ mod tests {
 
         // Call the 'echoString' function.
         let execution_result = manager.call_contract(&writer, call_data, Uint::from(0));
-
-        // unpack output call enum into raw bytes
-        let (value, _) = manager.unpack_execution(execution_result);
+        let value = manager.unpack_execution(execution_result);
 
         let response: String = writer
             .base_contract
@@ -95,8 +93,7 @@ mod tests {
 
         // Execute the call to retrieve the token name as a test.
         let execution_result = manager.call_contract(&arbiter_token, call_data, Uint::from(0));
-
-        let (value, _) = manager.unpack_execution(execution_result);
+        let value = manager.unpack_execution(execution_result);
 
         let response: String = arbiter_token
             .base_contract
@@ -134,9 +131,7 @@ mod tests {
 
         // Call the 'balanceOf' function.
         let execution_result = manager.call_contract(&arbiter_token, call_data, Uint::from(0)); // TODO: SOME KIND OF ERROR HANDLING IS NECESSARY FOR THESE TYPES OF CALLS
-
-        // unpack output call enum into raw bytes
-        let (value, _) = manager.unpack_execution(execution_result);
+        let value = manager.unpack_execution(execution_result);
 
         let response: U256 = arbiter_token
             .base_contract
@@ -175,8 +170,8 @@ mod tests {
 
         // Call the 'echoString' function.
         let execution_result = manager.call_contract(&writer, call_data, Uint::from(0));
-        let (_, logs) = manager.unpack_execution(execution_result);
-
+        let logs = manager.read_logs();
+        let logs = logs[1].clone();
         // Get the logs from the execution manager.
         let log_topics: Vec<H256> = logs.clone()[0]
             .topics

--- a/crates/simulate/src/lib.rs
+++ b/crates/simulate/src/lib.rs
@@ -7,9 +7,9 @@ mod tests {
     // use core::slice::SlicePattern;
     use std::str::FromStr;
 
-    use bindings::{self, arbiter_token};
+    // use bindings::{self, arbiter_token};
     use ethers::prelude::{BaseContract, H256, U256};
-    use revm::primitives::{ruint::Uint, ExecutionResult, Log, Output, B160, B256};
+    use revm::primitives::{ruint::Uint, B160};
 
     use crate::{
         agent::Agent,
@@ -169,9 +169,8 @@ mod tests {
             .collect();
 
         // Call the 'echoString' function.
-        let execution_result = manager.call_contract(&writer, call_data, Uint::from(0));
+        let _execution_result = manager.call_contract(&writer, call_data, Uint::from(0));
         let logs = manager.read_logs();
-        let logs = logs[1].clone();
         // Get the logs from the execution manager.
         let log_topics: Vec<H256> = logs.clone()[0]
             .topics


### PR DESCRIPTION
Event logging will be important for agents to act upon. So, what I tried to do here was implement a buffer called `event_buffer` that the `SimulationEnvironment` owns (as an attribute) write access to and, upon execution, echoes out logs into this buffer. Other agents can freely read at any time. Due to this write protection, the buffer is not mutex. We can get away with `Arc<RwLock<...>>`.

I'm not sure this is the best way to handle it, but it seems to work well for now! Some other changes came along with this. 

To see this in action, just investigate `test_event_logging` in Simulation's lib.