### PR TITLE
Fixed GBM in price_simulation.rs

### DIFF
--- a/crates/cli/src/config.toml
+++ b/crates/cli/src/config.toml
@@ -6,11 +6,11 @@ token1 = "USDC"
 bp = "30"
 
 [sim]
-timestep = 1.0
-timescale = "day"
+timestep = 0.0027397
+timescale = "years"
 num_steps = 365
 initial_price = 1196.54
 drift = 0.1
-volatility = 2.0
-seed = 888
+volatility = 0.7
+seed = 887
 

--- a/crates/simulate/src/price_simulation.rs
+++ b/crates/simulate/src/price_simulation.rs
@@ -105,9 +105,10 @@ fn generate_gbm(
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
     for index in 1..num_steps {
         let normal_sample: f64 = StandardNormal.sample(&mut rng);
+        let weiner: f64 = normal_sample * timestep.sqrt() * volatility.sqrt();
         let geometric_sample =
-            f64::exp((drift - volatility.powi(2) / 2.) * timestep + volatility * normal_sample);
-        price_path.push(geometric_sample * price_path[index - 1]);
+            f64::exp((drift - volatility.powi(2) / 2.) * timestep * index as f64 + weiner);
+        price_path.push(geometric_sample * initial_price);
     }
     price_path
 }


### PR DESCRIPTION
fixed the GBM process in price_simulation.rs and changed the config to match units of time between sigma timestep and mu. Closes #163  