### PR TITLE
Documentation: Initialize and Outline a Mdbook

### DIFF
--- a/documentation/book.toml
+++ b/documentation/book.toml
@@ -1,0 +1,6 @@
+[book]
+authors = ["Amnot"]
+language = "en"
+multilingual = false
+src = "src"
+title = "Arbiter Documentation"

--- a/documentation/src/SUMMARY.md
+++ b/documentation/src/SUMMARY.md
@@ -1,0 +1,3 @@
+# Summary
+
+- [Chapter 1](./chapter_1.md)

--- a/documentation/src/SUMMARY.md
+++ b/documentation/src/SUMMARY.md
@@ -1,3 +1,5 @@
 # Summary
 
 - [Chapter 1](./chapter_1.md)
+- [Chapter 2](./chapter_2.md)
+- [Chapter 3](./chapter_3.md)

--- a/documentation/src/chapter_1.md
+++ b/documentation/src/chapter_1.md
@@ -1,0 +1,1 @@
+# Chapter 1

--- a/documentation/src/chapter_1.md
+++ b/documentation/src/chapter_1.md
@@ -20,6 +20,8 @@ The primary features of the `simulate` crate are as follows:
 
 * **Historic Module:** The `historic.rs` file is key for generating price paths for a simulation, allowing managers to alter prices for infinitely liquid pools. This module also allows for the importation of price data from a CSV file.
 
+* **Utility Module:** The `utils.rs` file is a utility module that contains various tools for streamlining the development process. This includes error handling through the `UnpackError` type and functions for recasting addresses, converting floats to U256 and vice versa, and unpacking execution results.
+
 The `simulate` crate constitutes a key component of our Rust ecosystem, primarily dealing with agent-based simulations, price paths, and middleware that interfaces with the `revm`.
 
 ## Primary Submodules
@@ -30,7 +32,9 @@ There are two primary submodules in the `simulate` crate:
 
 * **Stochastic:** As a pivotal submodule of the `simulate` crate, `stochastic` is where price paths and other stochastic processes crucial for simulations are defined. Currently, we support Gaussian Geometric Brownian Motion (GBM) and Ornstein-Uhlenbeck (OU) price paths.
 
-Aside from these two submodules, the `simulate` crate also includes a variety of middleware utilities and tools designed to interface with `revm`. This includes tools for backtesting using historical data.
+* **Utils:** The `utils` module provides various utility functions and error handling for streamlining the development process. This includes tools for recasting addresses, converting floats to U256 and vice versa, and unpacking execution results.
+
+Aside from these submodules, the `simulate` crate also includes a variety of middleware utilities and tools designed to interface with `revm`. This includes tools for backtesting using historical data.
 
 ## Crate Features
 
@@ -38,7 +42,7 @@ Given the `simulate` crate's role in interfacing with `revm`, its key features c
 
 * **Customizable Agent Behavior:** The `simulate` crate allows for the definition of various agent behaviors, enabling unique simulation scenarios.
 
-* **Diverse Stochastic Processes:** The crate supports various stochastic processes, such as GBM and OU price paths, providing a wide array of possibilities for simulations.
+* **Diverse Stochastic Processes:** The crate supports various stochastic processes , such as GBM and OU price paths, providing a wide array of possibilities for simulations.
 
 * **Robust Middleware Tools:** With a suite of middleware utilities, `simulate` facilitates interaction with `revm` and enables backtesting with historical data.
 
@@ -49,3 +53,19 @@ Given the `simulate` crate's role in interfacing with `revm`, its key features c
 * **Historic Price Data:** The crate supports importing price data from CSV files. This feature is crucial for generating price paths for simulations and for working with historical price data.
 
 * **Optimal Routing Algorithm:** The crate is in the process of developing an optimal routing algorithm. When completed, this feature will enhance efficiency and performance in interacting with the Ethereum network.
+
+## Utility Module
+
+The `utils.rs` module provides utility functionality for the `simulate` crate. It contains the following functions:
+
+* `recast_address`: Recasts a `B160` type into an `Address` type.
+* `float_to_wad`: Converts a `f64` float into a WAD fixed point prepared `U256` number.
+* `wad_to_float`: Converts a WAD fixed point prepared `U256` number into a `f64` float.
+* `unpack_execution`: Takes an `ExecutionResult` and returns the raw bytes of the output that can be decoded.
+
+Additionally, the module includes the `UnpackError` struct, which represents an error encountered during simulation execution. It contains an error message and an optional byte output.
+
+These utility functions and error handling mechanisms streamline the development process and enhance the functionality of the `simulate` crate.
+
+The `simulate` crate, with its various submodules and utility module, provides a comprehensive framework for agent-based simulations, price paths, and middleware integration with the `revm`. It offers a wide range of features and customization options, making it a powerful tool for developers in the Rust ecosystem.
+

--- a/documentation/src/chapter_1.md
+++ b/documentation/src/chapter_1.md
@@ -1,1 +1,40 @@
-# Chapter 1
+# Chapter 1: Interface over revm (simulate crate)
+
+```revm``` is an EVM written is Rust that focuses on **speed** and **simplicity**.
+
+Features, **interfacing** - ```no_std``` so that it can be used as a wasm lib to integrate with Javascript and cpp bindings if necessary.
+
+## Features of the simulate crate
+
+The primary features of the `simulate` crate are as follows:
+
+* **Interfacing:** Designed with an open API, the `simulate` crate provides an accesible gateway to `revm` functionality, thus allowing developers to easily incorpate EVM capabilities into their applications.
+
+* **Compatibility:** With a `no_std` design, `simulate` can be compiled to a WebAssembly (wasm) library, facilitating seamless integration with Javascript. Furthermore, this design also provides C++ bindings if required, thereby enhancing its cross-language adaptability.
+
+
+The `simulate` crate constitutes a key component of our Rust ecosystem, primarily dealing with agent-based simulations, price paths, and middleware that interfaces with the `revm`.
+
+## Primary Submodules
+
+There are two primary submodules in the `simulate` crate:
+
+* **Agents:** This module plays host to the various agents that form an integral part of our simulations. Agent behavior is distinctly defined here and even though a number of pre-built agents are included, we expect users to leverage this module to create and incorporate their own agents. This paves the way for continued growth and diverse use cases.
+
+* **Stochastic:** As a pivotal submodule of the `simulate` crate, `stochastic` is where price paths and other stochastic processes crucial for simulations are defined. Currently, we support Gaussian Geometric Brownian Motion (GBM) and Ornstein-Uhlenbeck (OU) price paths.
+
+Aside from these two submodules, the `simulate` crate also includes a variety of middleware utilities and tools designed to interface with `revm`. This includes tools for backtesting using historical data.
+
+## Crate Features
+
+Given the `simulate` crate's role in interfacing with `revm`, its key features can be outlined as follows:
+
+* **Customizable Agent Behavior:** The `simulate` crate allows for the definition of various agent behaviors, enabling unique simulation scenarios.
+
+* **Diverse Stochastic Processes:** The crate supports various stochastic processes, such as GBM and OU price paths, providing a wide array of possibilities for simulations.
+
+* **Robust Middleware Tools:** With a suite of middleware utilities, `simulate` facilitates interaction with `revm` and enables backtesting with historical data.
+
+* **Extensibility:** The crate is designed with user customization in mind, enabling developers to define their own agents and processes to expand upon the existing pre-built options.
+
+

--- a/documentation/src/chapter_1.md
+++ b/documentation/src/chapter_1.md
@@ -1,10 +1,10 @@
-# Chapter 1: Interface over revm (simulate crate)
+# Chapter 1: Simulate Crate (Interface over revm)
 
 ```revm``` is an EVM written is Rust that focuses on **speed** and **simplicity**.
 
 Features, **interfacing** - ```no_std``` so that it can be used as a wasm lib to integrate with Javascript and cpp bindings if necessary.
 
-## Features of the simulate crate
+## Features of the Simulate Crate
 
 The primary features of the `simulate` crate are as follows:
 

--- a/documentation/src/chapter_1.md
+++ b/documentation/src/chapter_1.md
@@ -12,6 +12,13 @@ The primary features of the `simulate` crate are as follows:
 
 * **Compatibility:** With a `no_std` design, `simulate` can be compiled to a WebAssembly (wasm) library, facilitating seamless integration with Javascript. Furthermore, this design also provides C++ bindings if required, thereby enhancing its cross-language adaptability.
 
+* **Manager Module:** The `manager.rs` file contains the `SimulationManager` structure, which is responsible for managing simulations. The `SimulationManager` oversees the simulation environment, activates agents, handles contract deployment, calls contracts, and reads logs.
+
+* **Lib Crate Integration:** The `lib` crate provides foundational structures and mechanisms for simulations, integrating closely with the `onchain` crate for efficient, live Ethereum interaction.
+
+* **Exchange Module:** The `Exchange` and `Cfmm` traits from the `exchange.rs` file describe the functionality of any contract that can be used to swap tokens.
+
+* **Historic Module:** The `historic.rs` file is key for generating price paths for a simulation, allowing managers to alter prices for infinitely liquid pools. This module also allows for the importation of price data from a CSV file.
 
 The `simulate` crate constitutes a key component of our Rust ecosystem, primarily dealing with agent-based simulations, price paths, and middleware that interfaces with the `revm`.
 
@@ -37,4 +44,8 @@ Given the `simulate` crate's role in interfacing with `revm`, its key features c
 
 * **Extensibility:** The crate is designed with user customization in mind, enabling developers to define their own agents and processes to expand upon the existing pre-built options.
 
+* **Interactive Simulations:** The crate allows the management and running of simulations, making it a valuable tool for testing and development. The `SimulationManager` structure oversees the simulation environment and controls various operations, including agent activation, contract deployment, contract calling, and log reading.
 
+* **Historic Price Data:** The crate supports importing price data from CSV files. This feature is crucial for generating price paths for simulations and for working with historical price data.
+
+* **Optimal Routing Algorithm:** The crate is in the process of developing an optimal routing algorithm. When completed, this feature will enhance efficiency and performance in interacting with the Ethereum network.

--- a/documentation/src/chapter_2.md
+++ b/documentation/src/chapter_2.md
@@ -1,2 +1,35 @@
-# Chapter 2: Simulations Directory in ```/bin```
+# Chapter 2: On-Chain Crate
+
+The `onchain` crate plays a significant role within our project, primarily focusing on interacting with live Ethereum RPCs. This crate comprises three modules: the `monitor`, the `executor`, and the `objectives`.
+
+## Monitor Module
+
+The `monitor` module's main purpose is to monitor Ethereum logs for specific types of information. Users have the flexibility to filter based on contract address, event name, and block range. Its primary function is data collection and real-time analysis, playing a critical role in the real-time decision-making process.
+
+## Executor Module
+
+The `executor` module deals with the creation and execution of transactions. It is designed to support both Flashbots relayer bundles and standard transactions. The executor module interacts with the blockchain based on the information obtained from the monitor module, thus performing actions in response to real-time data.
+
+## Objectives Module
+
+The `objectives` module defines the objective functions for convex optimization. This module is currently under development with the goal of implementing optimal routing algorithms in Rust.
+
+## Future Directions
+
+We envision that real-time risk monitoring will become crucial for decentralized applications. The `onchain` crate provides a solid foundation to develop this functionality, enabling swift response to real-time data. The crate aims to provide a shared framework for sophisticated on-chain actors, thus accelerating innovation in the space.
+
+## Crate Features
+
+In relation to the `onchain` crate's role in Ethereum RPC interaction, its prominent features are:
+
+* **Real-Time Data Monitoring:** The crate facilitates the real-time analysis of Ethereum logs, with filters based on contract address, event name, and block range.
+
+* **Flexible Transaction Execution:** The crate supports the creation and execution of both Flashbots relayer bundles and standard transactions.
+
+* **Convex Optimization:** The crate provides objective functions for convex optimization, aiding in the development of optimal routing algorithms.
+
+* **Real-Time Risk Monitoring:** A future direction for this crate is real-time risk monitoring, critical for decentralized applications, offering swift responses to real-time data.
+
+* **Accelerated Innovation:** By providing a common framework for on-chain actors, the crate aims to stimulate innovation in the blockchain space.
+
 

--- a/documentation/src/chapter_2.md
+++ b/documentation/src/chapter_2.md
@@ -14,6 +14,26 @@ The `executor` module deals with the creation and execution of transactions. It 
 
 The `objectives` module defines the objective functions for convex optimization. This module is currently under development with the goal of implementing optimal routing algorithms in Rust.
 
+## Lib Crate Integration
+
+The `lib` crate provides the foundational structures and mechanisms for simulations, integrating closely with the `onchain` crate to enable efficient, live Ethereum interaction.
+
+* The `agent` module in the `lib` crate works alongside the `executor` module in the `onchain` crate to create and execute transactions based on the agent's characteristics and actions.
+  
+* The `environment` module provides the `SimulationContract` structure used to represent and interact with live contracts on the Ethereum network. It cooperates with the `monitor` module from the `onchain` crate to retrieve real-time data from these contracts.
+  
+* The `exchange` module in the `lib` crate complements the `Exchange` trait in the `onchain` crate, providing additional functionality for token swaps.
+  
+* The `historic` module, found in both the `lib` and `onchain` crates, works together to provide an extensive mechanism for working with historical price data.
+
+## Exchange Module
+
+A notable inclusion in our project is the `Exchange` and `Cfmm` traits from the `exchange.rs` file. They describe the functionality of any contract that can be used to swap tokens.
+
+## Historic Module
+
+The `historic.rs` file is essential for generating price paths for a simulation. This allows managers to alter prices for infinitely liquid pools. The public function `import_price_from_csv` allows the importation of price data from a CSV file. This module provides a simple and efficient way to use historical price data in simulations.
+
 ## Future Directions
 
 We envision that real-time risk monitoring will become crucial for decentralized applications. The `onchain` crate provides a solid foundation to develop this functionality, enabling swift response to real-time data. The crate aims to provide a shared framework for sophisticated on-chain actors, thus accelerating innovation in the space.
@@ -28,8 +48,10 @@ In relation to the `onchain` crate's role in Ethereum RPC interaction, its promi
 
 * **Convex Optimization:** The crate provides objective functions for convex optimization, aiding in the development of optimal routing algorithms.
 
+* **Token Swapping Functionality:** Through the `Exchange` and `Cfmm` traits, the crate provides a robust framework for implementing token swapping functionality in contracts.
+
+* **Historical Price Data Utilization:** The `historic` module allows importing price data from from CSV files, facilitating the use of this data in simulations.
+
 * **Real-Time Risk Monitoring:** A future direction for this crate is real-time risk monitoring, critical for decentralized applications, offering swift responses to real-time data.
 
 * **Accelerated Innovation:** By providing a common framework for on-chain actors, the crate aims to stimulate innovation in the blockchain space.
-
-

--- a/documentation/src/chapter_2.md
+++ b/documentation/src/chapter_2.md
@@ -1,0 +1,2 @@
+# Chapter 2: Simulations Directory in ```/bin```
+

--- a/documentation/src/chapter_2.md
+++ b/documentation/src/chapter_2.md
@@ -14,30 +14,6 @@ The `executor` module deals with the creation and execution of transactions. It 
 
 The `objectives` module defines the objective functions for convex optimization. This module is currently under development with the goal of implementing optimal routing algorithms in Rust.
 
-## Manager Module
-
-The `manager.rs` file contains the `SimulationManager` structure, which is responsible for managing simulations. The `SimulationManager` oversees the simulation environment, activates agents, handles contract deployment, calls contracts, and reads logs. It contains key functions such as `activate_agent`, which adds and activates an agent in the simulation environment, `auto_deploy`, which deploys all contracts necessary for any simulation, and `_deploy_contracts`, a generic contract deployment function.
-
-## Lib Crate Integration
-
-The `lib` crate provides the foundational structures and mechanisms for simulations, integrating closely with the `onchain` crate to enable efficient, live Ethereum interaction.
-
-* The `agent` module in the `lib` crate works alongside the `executor` module in the `onchain` crate to create and execute transactions based on the agent's characteristics and actions.
-  
-* The `environment` module provides the `SimulationContract` structure used to represent and interact with live contracts on the Ethereum network. It cooperates with the `monitor` module from the `onchain` crate to retrieve real-time data from these contracts.
-  
-* The `exchange` module in the `lib` crate complements the `Exchange` trait in the `onchain` crate, providing additional functionality for token swaps.
-  
-* The `historic` module, found in both the `lib` and `onchain` crates, works together to provide an extensive mechanism for working with historical price data.
-
-## Exchange Module
-
-A notable inclusion in our project is the `Exchange` and `Cfmm` traits from the `exchange.rs` file. They describe the functionality of any contract that can be used to swap tokens.
-
-## Historic Module
-
-The `historic.rs` file is essential for generating price paths for a simulation. This allows managers to alter prices for infinitely liquid pools. The public function `import_price_from_csv` allows the importation of price data from a CSV file. This module provides a simple and efficient way to use historical price data in simulations.
-
 ## Future Directions
 
 We envision that real-time risk monitoring will become crucial for decentralized applications. The `onchain` crate provides a solid foundation to develop this functionality, enabling swift response to real-time data. The crate aims to provide a shared framework for sophisticated on-chain actors, thus accelerating innovation in the space.
@@ -50,10 +26,4 @@ In relation to the `onchain` crate's role in Ethereum RPC interaction, its promi
 
 * **Flexible Transaction Execution:** The crate supports both Flashbots relayer bundles and standard transactions, thus offering versatility in transaction execution.
 
-* **Optimal Routing Algorithm:** The crate is in the process of developing an optimal routing algorithm. When completed, this feature will enhance efficiency and performance in interacting with the Ethereum network.
-
-* **Interactive Simulations:** The crate allows the management and running of simulations, making it a valuable tool for testing and development. The `SimulationManager` structure oversees the simulation environment and controls various operations, including agent activation, contract deployment, contract calling, and log reading.
-
 * **Contract Deployment:** The crate provides a comprehensive contract deployment system, where all necessary contracts for any simulation can be automatically deployed.
-
-* **Historic Price Data:** The crate supports importing price data from CSV files. This feature is crucial for generating price paths for simulations and for working with historical price data.

--- a/documentation/src/chapter_2.md
+++ b/documentation/src/chapter_2.md
@@ -14,6 +14,10 @@ The `executor` module deals with the creation and execution of transactions. It 
 
 The `objectives` module defines the objective functions for convex optimization. This module is currently under development with the goal of implementing optimal routing algorithms in Rust.
 
+## Manager Module
+
+The `manager.rs` file contains the `SimulationManager` structure, which is responsible for managing simulations. The `SimulationManager` oversees the simulation environment, activates agents, handles contract deployment, calls contracts, and reads logs. It contains key functions such as `activate_agent`, which adds and activates an agent in the simulation environment, `auto_deploy`, which deploys all contracts necessary for any simulation, and `_deploy_contracts`, a generic contract deployment function.
+
 ## Lib Crate Integration
 
 The `lib` crate provides the foundational structures and mechanisms for simulations, integrating closely with the `onchain` crate to enable efficient, live Ethereum interaction.
@@ -44,14 +48,12 @@ In relation to the `onchain` crate's role in Ethereum RPC interaction, its promi
 
 * **Real-Time Data Monitoring:** The crate facilitates the real-time analysis of Ethereum logs, with filters based on contract address, event name, and block range.
 
-* **Flexible Transaction Execution:** The crate supports the creation and execution of both Flashbots relayer bundles and standard transactions.
+* **Flexible Transaction Execution:** The crate supports both Flashbots relayer bundles and standard transactions, thus offering versatility in transaction execution.
 
-* **Convex Optimization:** The crate provides objective functions for convex optimization, aiding in the development of optimal routing algorithms.
+* **Optimal Routing Algorithm:** The crate is in the process of developing an optimal routing algorithm. When completed, this feature will enhance efficiency and performance in interacting with the Ethereum network.
 
-* **Token Swapping Functionality:** Through the `Exchange` and `Cfmm` traits, the crate provides a robust framework for implementing token swapping functionality in contracts.
+* **Interactive Simulations:** The crate allows the management and running of simulations, making it a valuable tool for testing and development. The `SimulationManager` structure oversees the simulation environment and controls various operations, including agent activation, contract deployment, contract calling, and log reading.
 
-* **Historical Price Data Utilization:** The `historic` module allows importing price data from from CSV files, facilitating the use of this data in simulations.
+* **Contract Deployment:** The crate provides a comprehensive contract deployment system, where all necessary contracts for any simulation can be automatically deployed.
 
-* **Real-Time Risk Monitoring:** A future direction for this crate is real-time risk monitoring, critical for decentralized applications, offering swift responses to real-time data.
-
-* **Accelerated Innovation:** By providing a common framework for on-chain actors, the crate aims to stimulate innovation in the blockchain space.
+* **Historic Price Data:** The crate supports importing price data from CSV files. This feature is crucial for generating price paths for simulations and for working with historical price data.

--- a/documentation/src/chapter_3.md
+++ b/documentation/src/chapter_3.md
@@ -1,0 +1,1 @@
+# Chapter 3

--- a/documentation/src/chapter_3.md
+++ b/documentation/src/chapter_3.md
@@ -1,1 +1,13 @@
-# Chapter 3: Simulations Directory in ```/bin```
+# Chapter 3: Simulations Directory in `/bin`
+
+The `bin` directory in our project contains the simulations module, which is responsible for running various simulations using the `simulate` crate. This module serves as the entry point for executing simulations and generating results.
+
+## Customizing Simulations
+The simulations module provides a flexible framework for defining and customizing simulations. You can modify the simulation parameters, agent behaviors, and price processes to suit your specific requirements. The various simulation-related modules in the simulations directory allow you to configure different aspects of the simulations, such as startup scripts, arbitrage strategies, and price processes.
+
+Feel free to explore and modify the simulation code in the simulations directory to create your own simulation scenarios and analyze the results.
+
+
+
+## Summary
+The bin directory in our project houses the simulations module, which serves as the entry point for running simulations. It provides a structured framework for defining and customizing simulations, allowing developers to explore various scenarios and analyze the outcomes. By executing the simulations, valuable insights can be gained into the behavior and performance of the simulated systems.

--- a/documentation/src/chapter_3.md
+++ b/documentation/src/chapter_3.md
@@ -1,1 +1,1 @@
-# Chapter 3
+# Chapter 3: Simulations Directory in ```/bin```


### PR DESCRIPTION
## Description

Begin Mdbook-based documentation. Resolves #169 

## Future Work 

* Add a section for the `portfolio` subdirectory of ```/bin/simulations/```
* Improve [mdBook](https://github.com/rust-lang/mdBook) formatting