### PR TITLE
Fixed build error

### DIFF
--- a/bin/visualize/mod.rs
+++ b/bin/visualize/mod.rs
@@ -94,7 +94,7 @@ pub fn plot_price_data(configuration_file_path: &str) -> Result<(), Box<dyn Erro
         show: true,
     };
 
-    transparent_plot(Some(curves), None, axes, title, display);
+    transparent_plot(Some(curves), None, axes, title, display, None);
 
     Ok(())
 }


### PR DESCRIPTION
A recent change to `visualization-rs` changed the argument count for `transparent_plot()`. This breaks the build/check for arbiter. Adding `None` as the missing argument allows you to build and use the program.