### PR TITLE
Wrap `environments` in `RefCell`

### DIFF
--- a/arbiter-core/src/manager.rs
+++ b/arbiter-core/src/manager.rs
@@ -113,7 +113,7 @@ impl Manager {
     /// ```rust
     /// use arbiter_core::manager::Manager;
     ///
-    /// let mut manager = Manager::new();
+    /// let manager = Manager::new();
     /// manager.add_environment("example_env", 1.0, 42).unwrap();
     /// ```
     pub fn add_environment<S: Into<String> + Clone>(
@@ -166,7 +166,7 @@ impl Manager {
     /// ```rust
     /// use arbiter_core::manager::Manager;
     ///
-    /// let mut manager = Manager::new();
+    /// let manager = Manager::new();
     /// manager.add_environment("example_env", 1.0, 42).unwrap();
     ///
     /// // Now, let's start the environment
@@ -241,7 +241,7 @@ impl Manager {
     /// ```rust
     /// use arbiter_core::manager::Manager;
     ///
-    /// let mut manager = Manager::new();
+    /// let manager = Manager::new();
     /// manager.add_environment("example_env", 1.0, 42).unwrap();
     /// manager.start_environment("example_env").unwrap();
     ///
@@ -312,7 +312,7 @@ impl Manager {
     /// ```rust
     /// use arbiter_core::manager::Manager;
     ///
-    /// let mut manager = Manager::new();
+    /// let manager = Manager::new();
     /// manager.add_environment("example_env", 1.0, 42).unwrap();
     /// manager.start_environment("example_env").unwrap();
     ///

--- a/arbiter-core/src/middleware.rs
+++ b/arbiter-core/src/middleware.rs
@@ -70,12 +70,11 @@ use crate::environment::{
 /// use arbiter_core::{manager::Manager, middleware::RevmMiddleware};
 ///
 /// // Create a manager and add an environment
-/// let mut manager = Manager::new();
+/// let manager = Manager::new();
 /// manager.add_environment("example_env", 1.0, 42).unwrap();
 ///
 /// // Retrieve the environment to create a new middleware instance
-/// let environment = manager.environments.get("example_env").unwrap();
-/// let middleware = RevmMiddleware::new(&environment, Some("test_label".to_string()));
+/// let middleware = RevmMiddleware::new(manager.environments.borrow().get("example_env").unwrap(), Some("test_label".to_string()));
 /// let client = Arc::new(&middleware);
 /// ```
 /// The client can now be used for transactions with the environment.
@@ -169,13 +168,14 @@ impl RevmMiddleware {
     /// ```
     /// use arbiter_core::{manager::Manager, middleware::RevmMiddleware};
     ///
-    /// let mut manager = Manager::new();
+    /// let manager = Manager::new();
     /// manager.add_environment("example_env", 1.0, 42).unwrap();
-    /// let environment = manager.environments.get("example_env").unwrap();
-    /// let middleware = RevmMiddleware::new(&environment, Some("test_label".to_string()));
+    /// let middleware =
+    /// RevmMiddleware::new(manager.environments.borrow().get("example_env").unwrap(), Some("test_label".to_string()));
     ///
     /// // We can create a middleware instance without a seed by doing the following
-    /// let no_seed_middleware = RevmMiddleware::new(&environment, None);
+    /// let no_seed_middleware =
+    /// RevmMiddleware::new(manager.environments.borrow().get("example_env").unwrap(), None);
     /// ```
     /// Use a seed if you want to have a constant address across simulations as
     /// well as a label for a client. This can be useful for debugging.

--- a/arbiter-core/src/tests/contracts.rs
+++ b/arbiter-core/src/tests/contracts.rs
@@ -14,11 +14,10 @@ pub const ARBITER_TOKEN_Y_DECIMALS: u8 = 18;
 pub const LIQUID_EXCHANGE_PRICE: f64 = 420.69;
 
 fn startup() -> Result<(Manager, Arc<RevmMiddleware>)> {
-    let mut manager = Manager::new();
+    let manager = Manager::new();
     manager.add_environment(TEST_ENV_LABEL, TEST_BLOCK_RATE, TEST_ENV_SEED)?;
-    let environment = manager.environments.get(TEST_ENV_LABEL).unwrap();
     let client = Arc::new(RevmMiddleware::new(
-        environment,
+        manager.environments.borrow().get(TEST_ENV_LABEL).unwrap(),
         Some(TEST_SIGNER_SEED_AND_LABEL.to_string()),
     ));
     manager.start_environment(TEST_ENV_LABEL)?;

--- a/arbiter-core/src/tests/interaction.rs
+++ b/arbiter-core/src/tests/interaction.rs
@@ -257,10 +257,10 @@ async fn transaction_loop() -> Result<()> {
 
 #[tokio::test]
 async fn pause_prevents_processing_transactions() {
-    let mut manager = Manager::new();
+    let manager = Manager::new();
     manager.add_environment(TEST_ENV_LABEL, 1.0, 1).unwrap();
     let client = Arc::new(RevmMiddleware::new(
-        manager.environments.get(TEST_ENV_LABEL).unwrap(),
+        manager.environments.borrow().get(TEST_ENV_LABEL).unwrap(),
         Some(TEST_SIGNER_SEED_AND_LABEL.to_string()),
     ));
 

--- a/arbiter-core/src/tests/management.rs
+++ b/arbiter-core/src/tests/management.rs
@@ -2,14 +2,16 @@ use super::*;
 
 #[test_log::test]
 fn add_environment() {
-    let mut manager = Manager::new();
+    let manager = Manager::new();
     manager.add_environment(TEST_ENV_LABEL, 1.0, 1).unwrap();
     assert!(manager
         .environments
+        .borrow()
         .contains_key(&TEST_ENV_LABEL.to_string()));
     assert_eq!(
         manager
             .environments
+            .borrow()
             .get(&TEST_ENV_LABEL.to_string())
             .unwrap()
             .state
@@ -20,12 +22,13 @@ fn add_environment() {
 
 #[test_log::test]
 fn run_environment() {
-    let mut manager = Manager::new();
+    let manager = Manager::new();
     manager.add_environment(TEST_ENV_LABEL, 1.0, 1).unwrap();
     manager.start_environment(TEST_ENV_LABEL).unwrap();
     assert_eq!(
         manager
             .environments
+            .borrow()
             .get(&TEST_ENV_LABEL.to_string())
             .unwrap()
             .state
@@ -36,7 +39,7 @@ fn run_environment() {
 
 #[test_log::test]
 fn pause_environment() {
-    let mut manager = Manager::new();
+    let manager = Manager::new();
     manager.add_environment(TEST_ENV_LABEL, 1.0, 1).unwrap();
     manager.start_environment(TEST_ENV_LABEL).unwrap();
     manager.pause_environment(TEST_ENV_LABEL).unwrap();
@@ -44,6 +47,7 @@ fn pause_environment() {
     assert_eq!(
         manager
             .environments
+            .borrow()
             .get(&TEST_ENV_LABEL.to_string())
             .unwrap()
             .state
@@ -55,6 +59,7 @@ fn pause_environment() {
     assert_eq!(
         manager
             .environments
+            .borrow()
             .get(&TEST_ENV_LABEL.to_string())
             .unwrap()
             .state
@@ -65,13 +70,14 @@ fn pause_environment() {
 
 #[test_log::test]
 fn stop_environment() {
-    let mut manager = Manager::new();
+    let manager = Manager::new();
     manager.add_environment(TEST_ENV_LABEL, 1.0, 1).unwrap();
     manager.start_environment(TEST_ENV_LABEL).unwrap();
     manager.stop_environment(TEST_ENV_LABEL).unwrap();
     assert_eq!(
         manager
             .environments
+            .borrow()
             .get(&TEST_ENV_LABEL.to_string())
             .unwrap()
             .state


### PR DESCRIPTION
Currently in order to add environments to the manager one must carry a mutable reference to the manager. Using `RefCell` allows you to track an immutable reference to the manager while allowing for interior mutability on the environments.