### PR TITLE
Bug/filter test termination

### DIFF
--- a/arbiter-core/Cargo.toml
+++ b/arbiter-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arbiter-core"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 # Dependencies for the release build

--- a/arbiter-core/Cargo.toml
+++ b/arbiter-core/Cargo.toml
@@ -39,3 +39,5 @@ hex = { version = "0.4.3", default-features = false }
 anyhow = "1.0.71"
 env_logger = "0.10.0"
 test-log = "0.2.12"
+futures = "0.3.28"
+assert_matches = "1.5"

--- a/arbiter-core/src/middleware.rs
+++ b/arbiter-core/src/middleware.rs
@@ -448,7 +448,7 @@ impl Middleware for RevmMiddleware {
         };
         let filter = args.clone();
         let mut hasher = Sha256::new();
-        hasher.update(serde_json::to_string(&args).map_err(|e| RevmMiddlewareError::Json(e))?);
+        hasher.update(serde_json::to_string(&args).map_err(RevmMiddlewareError::Json)?);
         let hash = hasher.finalize();
         let id = ethers::types::U256::from(ethers::types::H256::from_slice(&hash).as_bytes());
         let (event_sender, event_receiver) =


### PR DESCRIPTION
This PR Closes #423 by fixing our filter watcher watcher tests that were initially commented out here:
https://github.com/primitivefinance/arbiter/blob/bb4b7af1d985739751de385336f7bdfe9058610a/arbiter-core/src/tests/interaction.rs#L104-L218

They now pass and terminate with the expected behavior. This was done by manually polling the stream and matching on the poll. 