### PR TITLE
bind on init

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ This will install the Arbiter binary on your machine. You can then run `arbiter 
 
 ## Command Line Interface 
 
-The Arbiter binary provides a CLI for creating new projects much like [Foundry](https://github.com/foundry-rs/foundry), which Arbiter aims to work alongside with. To create a new project, you can run:
+The Arbiter binary provides a CLI for creating new projects much like [Foundry](https://github.com/foundry-rs/foundry), which Arbiter aims to work alongside with. This requires you to have foundry installed. If you do not have foundry installed you can install it [here](https://getfoundry.sh/). To create a new project, you can run:
 
 ```bash
 arbiter init your-project-name
 cd your-project-name
 ```
 
-This initializes a new Arbiter project with a template. The next step require you to have foundry installed. If you do not have foundry installed you can install it [here](https://getfoundry.sh/). Then you can generate the template bindings by running:
+This initializes a new Arbiter project with a template. You can generate the bindings again by running:
 
 ```bash
 arbiter bind

--- a/bin/init.rs
+++ b/bin/init.rs
@@ -56,6 +56,29 @@ pub(crate) fn init_project(name: &str) -> io::Result<()> {
         ));
     }
 
+    let output = Command::new("forge")
+        .arg("bind")
+        .arg("--revert-strings")
+        .arg("debug")
+        .arg("-b")
+        .arg("src/bindings/")
+        .arg("--module")
+        .arg("--overwrite")
+        .output()?;
+
+    if output.status.success() {
+        let output_str = String::from_utf8_lossy(&output.stdout);
+        println!("Command output: {}", output_str);
+        println!("Note: revert strings are on");
+    } else {
+        let err_str = String::from_utf8_lossy(&output.stderr);
+        println!("Command failed, error: {}, is forge installed?", err_str);
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "Command failed",
+        ));
+    }
+
     println!(
         "Your Arbiter project '{}' has been successfully initialized!",
         name


### PR DESCRIPTION
This pull request implements the changes requested in issue #428 by changing the `init` command to also redo the contract bindings.