### PR TITLE
feat: Add `EnvironmentParameters` struct for improved environment initialization

### DIFF
--- a/arbiter-core/src/environment.rs
+++ b/arbiter-core/src/environment.rs
@@ -157,7 +157,7 @@ pub struct EnvironmentParameters {
     pub block_rate: f64,
 
     /// A value chosen to generate randomly chosen block sizes
-    /// for the environment..
+    /// for the environment.
     pub seed: u64,
 }
 

--- a/arbiter-core/src/environment.rs
+++ b/arbiter-core/src/environment.rs
@@ -151,10 +151,13 @@ pub struct Environment {
 /// This structure holds configuration details or other parameters that might
 /// be required when instantiating or updating an `Environment`.
 pub struct EnvironmentParameters {
-    /// The rate at which blocks are produced or some meaningful description.
+    /// The mean of the rate at which the environment will
+    /// process blocks (e.g., the rate parameter in the Poisson distribution
+    /// used in the [`SeededPoisson`] field of an [`Environment`]).
     pub block_rate: f64,
 
-    /// A seed value used for ... (provide a meaningful description here).
+    /// A value chosen to generate randomly chosen block sizes
+    /// for the environment..
     pub seed: u64,
 }
 

--- a/arbiter-core/src/environment.rs
+++ b/arbiter-core/src/environment.rs
@@ -146,6 +146,18 @@ pub struct Environment {
     pub(crate) handle: Option<JoinHandle<Result<(), EnvironmentError>>>,
 }
 
+/// Parameters necessary for creating or modifying an `Environment`.
+///
+/// This structure holds configuration details or other parameters that might
+/// be required when instantiating or updating an `Environment`.
+pub struct EnvironmentParameters {
+    /// The rate at which blocks are produced or some meaningful description.
+    pub block_rate: f64,
+
+    /// A seed value used for ... (provide a meaningful description here).
+    pub seed: u64,
+}
+
 /// Allow the end user to be able to access a debug printout for the
 /// [`Environment`]. Note that the [`EVM`] does not implement debug display,
 /// hence the implementation by hand here.
@@ -209,7 +221,7 @@ impl Environment {
     /// Privately accessible constructor function for creating an
     /// [`Environment`]. This function should be accessed by the
     /// [`Manager`].
-    pub(crate) fn new<S: Into<String>>(label: S, block_rate: f64, seed: u64) -> Self {
+    pub(crate) fn new<S: Into<String>>(label: S, params: EnvironmentParameters) -> Self {
         // Initialize the EVM used
         let mut evm = EVM::new();
         let db = CacheDB::new(EmptyDB {});
@@ -219,7 +231,7 @@ impl Environment {
         evm.env.cfg.limit_contract_code_size = Some(0x100000);
         evm.env.block.gas_limit = U256::MAX;
 
-        let seeded_poisson = SeededPoisson::new(block_rate, seed);
+        let seeded_poisson = SeededPoisson::new(params.block_rate, params.seed);
 
         let (tx_sender, tx_receiver) = unbounded();
         let socket = Socket {
@@ -534,7 +546,11 @@ pub(crate) mod tests {
 
     #[test]
     fn new() {
-        let environment = Environment::new(TEST_ENV_LABEL.to_string(), 1.0, 1);
+        let params = EnvironmentParameters {
+            block_rate: 1.0,
+            seed: 1,
+        };
+        let environment = Environment::new(TEST_ENV_LABEL.to_string(), params);
         assert_eq!(environment.label, TEST_ENV_LABEL);
         let state = environment.state.load(std::sync::atomic::Ordering::SeqCst);
         assert_eq!(state, State::Initialization);
@@ -542,7 +558,11 @@ pub(crate) mod tests {
 
     #[test]
     fn run() {
-        let mut environment = Environment::new(TEST_ENV_LABEL.to_string(), 1.0, 1);
+        let params = EnvironmentParameters {
+            block_rate: 1.0,
+            seed: 1,
+        };
+        let mut environment = Environment::new(TEST_ENV_LABEL.to_string(), params);
         environment.run();
         let state = environment.state.load(std::sync::atomic::Ordering::SeqCst);
         assert_eq!(state, State::Running);

--- a/arbiter-core/src/manager.rs
+++ b/arbiter-core/src/manager.rs
@@ -11,8 +11,8 @@ use std::collections::HashMap;
 use log::{info, warn};
 use thiserror::Error;
 
-use crate::environment::{Environment, State};
 use crate::environment::EnvironmentParameters;
+use crate::environment::{Environment, State};
 
 #[cfg_attr(doc, doc(hidden))]
 #[cfg_attr(doc, allow(unused_imports))]
@@ -125,16 +125,16 @@ impl Manager {
         params: EnvironmentParameters,
     ) -> Result<(), ManagerError> {
         let label_str = environment_label.clone().into();
-    
+
         if self.environments.contains_key(&label_str) {
             return Err(ManagerError::EnvironmentAlreadyExists(label_str));
         }
-    
+
         self.environments.insert(
             label_str.clone(),
             Environment::new(environment_label, params),
         );
-    
+
         info!("Added environment labeled {}", label_str);
         Ok(())
     }

--- a/arbiter-core/src/manager.rs
+++ b/arbiter-core/src/manager.rs
@@ -91,7 +91,8 @@ impl Manager {
 
     /// Adds a new environment to the manager with the specified label.
     ///
-    /// This method creates a new environment with given parameters.
+    /// This method creates a new environment with given parameters and
+    /// associates it with a label.
     ///
     /// # Parameters
     ///

--- a/arbiter-core/src/middleware.rs
+++ b/arbiter-core/src/middleware.rs
@@ -67,11 +67,15 @@ use crate::environment::{
 /// // Import `Arc` if you need to create a client instance
 /// use std::sync::Arc;
 ///
-/// use arbiter_core::{manager::Manager, middleware::RevmMiddleware};
+/// use arbiter_core::{manager::Manager, middleware::RevmMiddleware, environment::EnvironmentParameters};
 ///
 /// // Create a manager and add an environment
 /// let mut manager = Manager::new();
-/// manager.add_environment("example_env", 1.0, 42).unwrap();
+/// let params = EnvironmentParameters {
+///     block_rate: 1.0,
+///     seed: 1,
+/// };
+/// manager.add_environment("example_env", params).unwrap();
 ///
 /// // Retrieve the environment to create a new middleware instance
 /// let environment = manager.environments.get("example_env").unwrap();
@@ -167,10 +171,14 @@ impl RevmMiddleware {
     ///
     /// # Examples
     /// ```
-    /// use arbiter_core::{manager::Manager, middleware::RevmMiddleware};
+    /// use arbiter_core::{manager::Manager, middleware::RevmMiddleware, environment::EnvironmentParameters};
     ///
     /// let mut manager = Manager::new();
-    /// manager.add_environment("example_env", 1.0, 42).unwrap();
+    /// let params = EnvironmentParameters {
+    ///     block_rate: 1.0,
+    ///     seed: 1,
+    /// };
+    /// manager.add_environment("example_env", params).unwrap();
     /// let environment = manager.environments.get("example_env").unwrap();
     /// let middleware = RevmMiddleware::new(&environment, Some("test_label".to_string()));
     ///

--- a/arbiter-core/src/tests/contracts.rs
+++ b/arbiter-core/src/tests/contracts.rs
@@ -15,7 +15,11 @@ pub const LIQUID_EXCHANGE_PRICE: f64 = 420.69;
 
 fn startup() -> Result<(Manager, Arc<RevmMiddleware>)> {
     let mut manager = Manager::new();
-    manager.add_environment(TEST_ENV_LABEL, TEST_BLOCK_RATE, TEST_ENV_SEED)?;
+    let params = EnvironmentParameters {
+        block_rate: 1.0,
+        seed: 1,
+    };
+    manager.add_environment(TEST_ENV_LABEL, params).unwrap();
     let environment = manager.environments.get(TEST_ENV_LABEL).unwrap();
     let client = Arc::new(RevmMiddleware::new(
         environment,

--- a/arbiter-core/src/tests/interaction.rs
+++ b/arbiter-core/src/tests/interaction.rs
@@ -263,7 +263,11 @@ async fn transaction_loop() -> Result<()> {
 #[tokio::test]
 async fn pause_prevents_processing_transactions() {
     let mut manager = Manager::new();
-    manager.add_environment(TEST_ENV_LABEL, 1.0, 1).unwrap();
+    let params = EnvironmentParameters {
+        block_rate: 1.0,
+        seed: 1,
+    };
+    manager.add_environment(TEST_ENV_LABEL, params).unwrap();
     let client = Arc::new(RevmMiddleware::new(
         manager.environments.get(TEST_ENV_LABEL).unwrap(),
         Some(TEST_SIGNER_SEED_AND_LABEL.to_string()),

--- a/arbiter-core/src/tests/management.rs
+++ b/arbiter-core/src/tests/management.rs
@@ -3,7 +3,11 @@ use super::*;
 #[test_log::test]
 fn add_environment() {
     let mut manager = Manager::new();
-    manager.add_environment(TEST_ENV_LABEL, 1.0, 1).unwrap();
+    let params = EnvironmentParameters {
+        block_rate: 1.0,
+        seed: 1,
+    };
+    manager.add_environment(TEST_ENV_LABEL, params).unwrap();
     assert!(manager
         .environments
         .contains_key(&TEST_ENV_LABEL.to_string()));
@@ -21,7 +25,11 @@ fn add_environment() {
 #[test_log::test]
 fn run_environment() {
     let mut manager = Manager::new();
-    manager.add_environment(TEST_ENV_LABEL, 1.0, 1).unwrap();
+    let params = EnvironmentParameters {
+        block_rate: 1.0,
+        seed: 1,
+    };
+    manager.add_environment(TEST_ENV_LABEL, params).unwrap();
     manager.start_environment(TEST_ENV_LABEL).unwrap();
     assert_eq!(
         manager
@@ -37,7 +45,11 @@ fn run_environment() {
 #[test_log::test]
 fn pause_environment() {
     let mut manager = Manager::new();
-    manager.add_environment(TEST_ENV_LABEL, 1.0, 1).unwrap();
+    let params = EnvironmentParameters {
+        block_rate: 1.0,
+        seed: 1,
+    };
+    manager.add_environment(TEST_ENV_LABEL, params).unwrap();
     manager.start_environment(TEST_ENV_LABEL).unwrap();
     manager.pause_environment(TEST_ENV_LABEL).unwrap();
     std::thread::sleep(std::time::Duration::from_millis(100));
@@ -66,7 +78,11 @@ fn pause_environment() {
 #[test_log::test]
 fn stop_environment() {
     let mut manager = Manager::new();
-    manager.add_environment(TEST_ENV_LABEL, 1.0, 1).unwrap();
+    let params = EnvironmentParameters {
+        block_rate: 1.0,
+        seed: 1,
+    };
+    manager.add_environment(TEST_ENV_LABEL, params).unwrap();
     manager.start_environment(TEST_ENV_LABEL).unwrap();
     manager.stop_environment(TEST_ENV_LABEL).unwrap();
     assert_eq!(

--- a/arbiter-core/src/tests/mod.rs
+++ b/arbiter-core/src/tests/mod.rs
@@ -43,7 +43,11 @@ async fn deploy_and_start() -> Result<(
     Environment,
     Arc<RevmMiddleware>,
 )> {
-    let mut environment = Environment::new(TEST_ENV_LABEL, TEST_BLOCK_RATE, TEST_ENV_SEED);
+    let params = EnvironmentParameters {
+        block_rate: TEST_BLOCK_RATE,
+        seed: TEST_ENV_SEED,
+    };
+    let mut environment = Environment::new(TEST_ENV_LABEL, params);
     let client = Arc::new(RevmMiddleware::new(
         &environment,
         Some(TEST_SIGNER_SEED_AND_LABEL.to_string()),

--- a/arbiter-core/src/tests/signer.rs
+++ b/arbiter-core/src/tests/signer.rs
@@ -33,7 +33,11 @@ fn multiple_signer_addresses() {
 
 #[test]
 fn signer_collision() {
-    let environment = &mut Environment::new(TEST_ENV_LABEL, 1.0, 1);
+    let params = EnvironmentParameters {
+        block_rate: 1.0,
+        seed: 1,
+    };
+    let environment = &mut Environment::new(TEST_ENV_LABEL, params);
     let client_1 = Arc::new(RevmMiddleware::new(environment, Some("0".to_string())));
     let client_2 = Arc::new(RevmMiddleware::new(environment, Some("0".to_string())));
     assert_eq!(client_1.default_sender(), client_2.default_sender());

--- a/arbiter-core/src/tests/signer.rs
+++ b/arbiter-core/src/tests/signer.rs
@@ -4,7 +4,11 @@ use super::*;
 
 #[test]
 fn simulation_signer() {
-    let environment = &mut Environment::new(TEST_ENV_LABEL, 1.0, 1);
+    let params = EnvironmentParameters {
+        block_rate: 1.0,
+        seed: 1,
+    };
+    let environment = &mut Environment::new(TEST_ENV_LABEL, params);
     let client = Arc::new(RevmMiddleware::new(
         environment,
         Some(TEST_SIGNER_SEED_AND_LABEL.to_string()),
@@ -17,7 +21,11 @@ fn simulation_signer() {
 
 #[test]
 fn multiple_signer_addresses() {
-    let environment = &mut Environment::new(TEST_ENV_LABEL, 1.0, 1);
+    let params = EnvironmentParameters {
+        block_rate: 1.0,
+        seed: 1,
+    };
+    let environment = &mut Environment::new(TEST_ENV_LABEL, params);
     let client_1 = Arc::new(RevmMiddleware::new(environment, Some("0".to_string())));
     let client_2 = Arc::new(RevmMiddleware::new(environment, Some("1".to_string())));
     assert_ne!(client_1.default_sender(), client_2.default_sender());


### PR DESCRIPTION
**Give an overview of the tasks completed**
Introduced a new struct EnvironmentParameters to streamline the process of initializing environments in the Manager. This refactoring effort encapsulates block_rate and seed parameters within the new struct, making the code more readable and scalable for future additions.

**Link to issue(s) that this PR closes**
Closes #449
