### PR TITLE
chore: bump minor version

### DIFF
--- a/arbiter-core/Cargo.toml
+++ b/arbiter-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arbiter-core"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 
 # Dependencies for the release build


### PR DESCRIPTION
The last PR #449 make some changes to end user API, we neglected to bump the minor version to indicate this.