### PR TITLE
fix: environment stop

### DIFF
--- a/arbiter-core/Cargo.toml
+++ b/arbiter-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arbiter-core"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 
 # Dependencies for the release build

--- a/arbiter-core/Cargo.toml
+++ b/arbiter-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arbiter-core"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 # Dependencies for the release build

--- a/arbiter-core/src/environment.rs
+++ b/arbiter-core/src/environment.rs
@@ -322,7 +322,7 @@ impl Environment {
 
                     // Receive new transactions
                     State::Running => {
-                        if let Ok((to_transact, tx, sender)) = tx_receiver.recv() {
+                        if let Ok((to_transact, tx, sender)) = tx_receiver.try_recv() {
                             // Check whether we need to increment the block number given the amount
                             // of transactions that have occured on the current block and increment
                             // if need be and draw a new sample from the `SeededPoisson`

--- a/arbiter-core/src/lib.rs
+++ b/arbiter-core/src/lib.rs
@@ -32,7 +32,7 @@
 #![warn(missing_docs, unsafe_code)]
 
 pub mod bindings; // TODO: Add better documentation here and some kind of overwrite protection.
-mod environment;
+pub mod environment;
 pub mod manager;
 pub mod math;
 pub mod middleware;

--- a/arbiter-core/src/manager.rs
+++ b/arbiter-core/src/manager.rs
@@ -11,9 +11,7 @@ use std::collections::HashMap;
 use log::{info, warn};
 use thiserror::Error;
 
-use crate::environment::EnvironmentParameters;
-use crate::environment::{Environment, State};
-
+use crate::environment::{Environment, EnvironmentParameters, State};
 #[cfg_attr(doc, doc(hidden))]
 #[cfg_attr(doc, allow(unused_imports))]
 #[cfg(doc)]
@@ -109,8 +107,7 @@ impl Manager {
     /// # Examples
     ///
     /// ```rust
-    /// use arbiter_core::manager::Manager;
-    /// use arbiter_core::environment::EnvironmentParameters;
+    /// use arbiter_core::{environment::EnvironmentParameters, manager::Manager};
     ///
     /// let mut manager = Manager::new();
     /// let params = EnvironmentParameters {
@@ -163,8 +160,7 @@ impl Manager {
     /// # Examples
     ///
     /// ```rust
-    /// use arbiter_core::manager::Manager;
-    /// use arbiter_core::environment::EnvironmentParameters;
+    /// use arbiter_core::{environment::EnvironmentParameters, manager::Manager};
     ///
     /// let mut manager = Manager::new();
     /// let params = EnvironmentParameters {
@@ -239,8 +235,7 @@ impl Manager {
     /// # Examples
     ///
     /// ```rust
-    /// use arbiter_core::manager::Manager;
-    /// use arbiter_core::environment::EnvironmentParameters;
+    /// use arbiter_core::{environment::EnvironmentParameters, manager::Manager};
     ///
     /// let mut manager = Manager::new();
     /// let params = EnvironmentParameters {
@@ -311,8 +306,7 @@ impl Manager {
     /// # Examples
     ///
     /// ```rust
-    /// use arbiter_core::manager::Manager;
-    /// use arbiter_core::environment::EnvironmentParameters;
+    /// use arbiter_core::{environment::EnvironmentParameters, manager::Manager};
     ///
     /// let mut manager = Manager::new();
     /// let params = EnvironmentParameters {

--- a/arbiter-core/src/middleware.rs
+++ b/arbiter-core/src/middleware.rs
@@ -67,7 +67,9 @@ use crate::environment::{
 /// // Import `Arc` if you need to create a client instance
 /// use std::sync::Arc;
 ///
-/// use arbiter_core::{manager::Manager, middleware::RevmMiddleware, environment::EnvironmentParameters};
+/// use arbiter_core::{
+///     environment::EnvironmentParameters, manager::Manager, middleware::RevmMiddleware,
+/// };
 ///
 /// // Create a manager and add an environment
 /// let mut manager = Manager::new();
@@ -171,7 +173,9 @@ impl RevmMiddleware {
     ///
     /// # Examples
     /// ```
-    /// use arbiter_core::{manager::Manager, middleware::RevmMiddleware, environment::EnvironmentParameters};
+    /// use arbiter_core::{
+    ///     environment::EnvironmentParameters, manager::Manager, middleware::RevmMiddleware,
+    /// };
     ///
     /// let mut manager = Manager::new();
     /// let params = EnvironmentParameters {


### PR DESCRIPTION
**Give an overview of the tasks completed**
This PR provides a quick fix to the `Manager::stop_environment()` method by replacing `tx_receiver.recv()` with `tx_receiver.try_recv()`. 

**Link to issue(s) that this PR closes**
Closes #456 

---

Please merge after #458 
