### PR TITLE
feat: derives for `EnvironmentParameters` and move label

### DIFF
--- a/arbiter-core/benches/bench.rs
+++ b/arbiter-core/benches/bench.rs
@@ -159,10 +159,11 @@ async fn anvil_startup() -> Result<(
 async fn arbiter_startup() -> Result<(Arc<RevmMiddleware>, Manager)> {
     let mut manager = Manager::new();
     let params = EnvironmentParameters {
+        label: ENV_LABEL.to_string(),
         block_rate: 10.0,
         seed: 0,
     };
-    manager.add_environment(ENV_LABEL, params)?;
+    manager.add_environment(params)?;
 
     let client = Arc::new(RevmMiddleware::new(
         manager.environments.get(ENV_LABEL).unwrap(),

--- a/arbiter-core/src/environment.rs
+++ b/arbiter-core/src/environment.rs
@@ -153,6 +153,11 @@ pub struct Environment {
 /// be required when instantiating or updating an `Environment`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EnvironmentParameters {
+    /// A label for the [`Environment`].
+    /// Used to allow the [`Manager`] to locate the [`Environment`] in order to
+    /// control it. Also used to be able to organize, track progress, and
+    /// post-process results.
+    pub label: String,
     /// The mean of the rate at which the environment will
     /// process blocks (e.g., the rate parameter in the Poisson distribution
     /// used in the [`SeededPoisson`] field of an [`Environment`]).
@@ -226,7 +231,7 @@ impl Environment {
     /// Privately accessible constructor function for creating an
     /// [`Environment`]. This function should be accessed by the
     /// [`Manager`].
-    pub(crate) fn new<S: Into<String>>(label: S, params: EnvironmentParameters) -> Self {
+    pub(crate) fn new(params: EnvironmentParameters) -> Self {
         // Initialize the EVM used
         let mut evm = EVM::new();
         let db = CacheDB::new(EmptyDB {});
@@ -246,7 +251,7 @@ impl Environment {
         };
 
         Self {
-            label: label.into(),
+            label: params.label,
             state: Arc::new(AtomicState::new(State::Initialization)),
             evm,
             socket,
@@ -552,10 +557,11 @@ pub(crate) mod tests {
     #[test]
     fn new() {
         let params = EnvironmentParameters {
+            label: TEST_ENV_LABEL.to_string(),
             block_rate: 1.0,
             seed: 1,
         };
-        let environment = Environment::new(TEST_ENV_LABEL.to_string(), params);
+        let environment = Environment::new(params);
         assert_eq!(environment.label, TEST_ENV_LABEL);
         let state = environment.state.load(std::sync::atomic::Ordering::SeqCst);
         assert_eq!(state, State::Initialization);
@@ -564,10 +570,11 @@ pub(crate) mod tests {
     #[test]
     fn run() {
         let params = EnvironmentParameters {
+            label: TEST_ENV_LABEL.to_string(),
             block_rate: 1.0,
             seed: 1,
         };
-        let mut environment = Environment::new(TEST_ENV_LABEL.to_string(), params);
+        let mut environment = Environment::new(params);
         environment.run();
         let state = environment.state.load(std::sync::atomic::Ordering::SeqCst);
         assert_eq!(state, State::Running);

--- a/arbiter-core/src/environment.rs
+++ b/arbiter-core/src/environment.rs
@@ -34,6 +34,7 @@ use revm::{
     primitives::{EVMError, ExecutionResult, Log, TxEnv, U256},
     EVM,
 };
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::math::SeededPoisson;
@@ -150,6 +151,7 @@ pub struct Environment {
 ///
 /// This structure holds configuration details or other parameters that might
 /// be required when instantiating or updating an `Environment`.
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EnvironmentParameters {
     /// The mean of the rate at which the environment will
     /// process blocks (e.g., the rate parameter in the Poisson distribution

--- a/arbiter-core/src/manager.rs
+++ b/arbiter-core/src/manager.rs
@@ -117,20 +117,15 @@ impl Manager {
     /// };
     /// manager.add_environment(params).unwrap();
     /// ```
-    pub fn add_environment(
-        &mut self,
-        params: EnvironmentParameters,
-    ) -> Result<(), ManagerError> {
+    pub fn add_environment(&mut self, params: EnvironmentParameters) -> Result<(), ManagerError> {
         let environment_label = params.label.clone();
 
         if self.environments.contains_key(&environment_label) {
             return Err(ManagerError::EnvironmentAlreadyExists(environment_label));
         }
 
-        self.environments.insert(
-            environment_label.clone(),
-            Environment::new(params),
-        );
+        self.environments
+            .insert(environment_label.clone(), Environment::new(params));
 
         info!("Added environment labeled {}", environment_label);
         Ok(())

--- a/arbiter-core/src/manager.rs
+++ b/arbiter-core/src/manager.rs
@@ -111,28 +111,28 @@ impl Manager {
     ///
     /// let mut manager = Manager::new();
     /// let params = EnvironmentParameters {
+    ///     label: "example_env".to_string(),
     ///     block_rate: 1.0,
     ///     seed: 1,
     /// };
-    /// manager.add_environment("example_env", params).unwrap();
+    /// manager.add_environment(params).unwrap();
     /// ```
-    pub fn add_environment<S: Into<String> + Clone>(
+    pub fn add_environment(
         &mut self,
-        environment_label: S,
         params: EnvironmentParameters,
     ) -> Result<(), ManagerError> {
-        let label_str = environment_label.clone().into();
+        let environment_label = params.label.clone();
 
-        if self.environments.contains_key(&label_str) {
-            return Err(ManagerError::EnvironmentAlreadyExists(label_str));
+        if self.environments.contains_key(&environment_label) {
+            return Err(ManagerError::EnvironmentAlreadyExists(environment_label));
         }
 
         self.environments.insert(
-            label_str.clone(),
-            Environment::new(environment_label, params),
+            environment_label.clone(),
+            Environment::new(params),
         );
 
-        info!("Added environment labeled {}", label_str);
+        info!("Added environment labeled {}", environment_label);
         Ok(())
     }
 
@@ -164,10 +164,11 @@ impl Manager {
     ///
     /// let mut manager = Manager::new();
     /// let params = EnvironmentParameters {
+    ///     label: "example_env".to_string(),
     ///     block_rate: 1.0,
     ///     seed: 1,
     /// };
-    /// manager.add_environment("example_env", params).unwrap();
+    /// manager.add_environment(params).unwrap();
     ///
     /// // Now, let's start the environment
     /// manager.start_environment("example_env").unwrap();
@@ -239,10 +240,11 @@ impl Manager {
     ///
     /// let mut manager = Manager::new();
     /// let params = EnvironmentParameters {
+    ///     label: "example_env".to_string(),
     ///     block_rate: 1.0,
     ///     seed: 1,
     /// };
-    /// manager.add_environment("example_env", params).unwrap();
+    /// manager.add_environment(params).unwrap();
     /// manager.start_environment("example_env").unwrap();
     ///
     /// // Now, let's pause the environment
@@ -310,10 +312,11 @@ impl Manager {
     ///
     /// let mut manager = Manager::new();
     /// let params = EnvironmentParameters {
+    ///     label: "example_env".to_string(),
     ///     block_rate: 1.0,
     ///     seed: 1,
     /// };
-    /// manager.add_environment("example_env", params).unwrap();
+    /// manager.add_environment(params).unwrap();
     /// manager.start_environment("example_env").unwrap();
     ///
     /// // Now, let's stop the environment

--- a/arbiter-core/src/middleware.rs
+++ b/arbiter-core/src/middleware.rs
@@ -74,10 +74,11 @@ use crate::environment::{
 /// // Create a manager and add an environment
 /// let mut manager = Manager::new();
 /// let params = EnvironmentParameters {
+///     label: "example_env".to_string(),
 ///     block_rate: 1.0,
 ///     seed: 1,
 /// };
-/// manager.add_environment("example_env", params).unwrap();
+/// manager.add_environment(params).unwrap();
 ///
 /// // Retrieve the environment to create a new middleware instance
 /// let environment = manager.environments.get("example_env").unwrap();
@@ -179,10 +180,11 @@ impl RevmMiddleware {
     ///
     /// let mut manager = Manager::new();
     /// let params = EnvironmentParameters {
+    ///     label: "example_env".to_string(),
     ///     block_rate: 1.0,
     ///     seed: 1,
     /// };
-    /// manager.add_environment("example_env", params).unwrap();
+    /// manager.add_environment(params).unwrap();
     /// let environment = manager.environments.get("example_env").unwrap();
     /// let middleware = RevmMiddleware::new(&environment, Some("test_label".to_string()));
     ///

--- a/arbiter-core/src/tests/contracts.rs
+++ b/arbiter-core/src/tests/contracts.rs
@@ -16,10 +16,11 @@ pub const LIQUID_EXCHANGE_PRICE: f64 = 420.69;
 fn startup() -> Result<(Manager, Arc<RevmMiddleware>)> {
     let mut manager = Manager::new();
     let params = EnvironmentParameters {
+        label: TEST_ENV_LABEL.to_string(),
         block_rate: 1.0,
         seed: 1,
     };
-    manager.add_environment(TEST_ENV_LABEL, params).unwrap();
+    manager.add_environment(params).unwrap();
     let environment = manager.environments.get(TEST_ENV_LABEL).unwrap();
     let client = Arc::new(RevmMiddleware::new(
         environment,

--- a/arbiter-core/src/tests/interaction.rs
+++ b/arbiter-core/src/tests/interaction.rs
@@ -264,10 +264,11 @@ async fn transaction_loop() -> Result<()> {
 async fn pause_prevents_processing_transactions() {
     let mut manager = Manager::new();
     let params = EnvironmentParameters {
+        label: TEST_ENV_LABEL.to_string(),
         block_rate: 1.0,
         seed: 1,
     };
-    manager.add_environment(TEST_ENV_LABEL, params).unwrap();
+    manager.add_environment(params).unwrap();
     let client = Arc::new(RevmMiddleware::new(
         manager.environments.get(TEST_ENV_LABEL).unwrap(),
         Some(TEST_SIGNER_SEED_AND_LABEL.to_string()),

--- a/arbiter-core/src/tests/management.rs
+++ b/arbiter-core/src/tests/management.rs
@@ -4,10 +4,11 @@ use super::*;
 fn add_environment() {
     let mut manager = Manager::new();
     let params = EnvironmentParameters {
+        label: TEST_ENV_LABEL.to_string(),
         block_rate: 1.0,
         seed: 1,
     };
-    manager.add_environment(TEST_ENV_LABEL, params).unwrap();
+    manager.add_environment(params).unwrap();
     assert!(manager
         .environments
         .contains_key(&TEST_ENV_LABEL.to_string()));
@@ -26,10 +27,11 @@ fn add_environment() {
 fn run_environment() {
     let mut manager = Manager::new();
     let params = EnvironmentParameters {
+        label: TEST_ENV_LABEL.to_string(),
         block_rate: 1.0,
         seed: 1,
     };
-    manager.add_environment(TEST_ENV_LABEL, params).unwrap();
+    manager.add_environment(params).unwrap();
     manager.start_environment(TEST_ENV_LABEL).unwrap();
     assert_eq!(
         manager
@@ -46,10 +48,11 @@ fn run_environment() {
 fn pause_environment() {
     let mut manager = Manager::new();
     let params = EnvironmentParameters {
+        label: TEST_ENV_LABEL.to_string(),
         block_rate: 1.0,
         seed: 1,
     };
-    manager.add_environment(TEST_ENV_LABEL, params).unwrap();
+    manager.add_environment(params).unwrap();
     manager.start_environment(TEST_ENV_LABEL).unwrap();
     manager.pause_environment(TEST_ENV_LABEL).unwrap();
     std::thread::sleep(std::time::Duration::from_millis(100));
@@ -79,10 +82,11 @@ fn pause_environment() {
 fn stop_environment() {
     let mut manager = Manager::new();
     let params = EnvironmentParameters {
+        label: TEST_ENV_LABEL.to_string(),
         block_rate: 1.0,
         seed: 1,
     };
-    manager.add_environment(TEST_ENV_LABEL, params).unwrap();
+    manager.add_environment(params).unwrap();
     manager.start_environment(TEST_ENV_LABEL).unwrap();
     manager.stop_environment(TEST_ENV_LABEL).unwrap();
     assert_eq!(
@@ -100,10 +104,11 @@ fn stop_environment() {
 async fn stop_environment_after_transactions() -> Result<()> {
     let mut manager = Manager::new();
     let params = EnvironmentParameters {
+        label: TEST_ENV_LABEL.to_string(),
         block_rate: 1.0,
         seed: 1,
     };
-    manager.add_environment(TEST_ENV_LABEL, params).unwrap();
+    manager.add_environment(params).unwrap();
     manager.start_environment(TEST_ENV_LABEL).unwrap();
 
     // Send some transactions (e.g., deploy `ArbiterMath` which is easy and has no

--- a/arbiter-core/src/tests/mod.rs
+++ b/arbiter-core/src/tests/mod.rs
@@ -44,10 +44,11 @@ async fn deploy_and_start() -> Result<(
     Arc<RevmMiddleware>,
 )> {
     let params = EnvironmentParameters {
+        label: TEST_ENV_LABEL.to_string(),
         block_rate: TEST_BLOCK_RATE,
         seed: TEST_ENV_SEED,
     };
-    let mut environment = Environment::new(TEST_ENV_LABEL, params);
+    let mut environment = Environment::new(params);
     let client = Arc::new(RevmMiddleware::new(
         &environment,
         Some(TEST_SIGNER_SEED_AND_LABEL.to_string()),

--- a/arbiter-core/src/tests/signer.rs
+++ b/arbiter-core/src/tests/signer.rs
@@ -5,10 +5,11 @@ use super::*;
 #[test]
 fn simulation_signer() {
     let params = EnvironmentParameters {
+        label: TEST_ENV_LABEL.to_string(),
         block_rate: 1.0,
         seed: 1,
     };
-    let environment = &mut Environment::new(TEST_ENV_LABEL, params);
+    let environment = &mut Environment::new(params);
     let client = Arc::new(RevmMiddleware::new(
         environment,
         Some(TEST_SIGNER_SEED_AND_LABEL.to_string()),
@@ -22,10 +23,11 @@ fn simulation_signer() {
 #[test]
 fn multiple_signer_addresses() {
     let params = EnvironmentParameters {
+        label: TEST_ENV_LABEL.to_string(),
         block_rate: 1.0,
         seed: 1,
     };
-    let environment = &mut Environment::new(TEST_ENV_LABEL, params);
+    let environment = &mut Environment::new(params);
     let client_1 = Arc::new(RevmMiddleware::new(environment, Some("0".to_string())));
     let client_2 = Arc::new(RevmMiddleware::new(environment, Some("1".to_string())));
     assert_ne!(client_1.default_sender(), client_2.default_sender());
@@ -34,10 +36,11 @@ fn multiple_signer_addresses() {
 #[test]
 fn signer_collision() {
     let params = EnvironmentParameters {
+        label: TEST_ENV_LABEL.to_string(),
         block_rate: 1.0,
         seed: 1,
     };
-    let environment = &mut Environment::new(TEST_ENV_LABEL, params);
+    let environment = &mut Environment::new(params);
     let client_1 = Arc::new(RevmMiddleware::new(environment, Some("0".to_string())));
     let client_2 = Arc::new(RevmMiddleware::new(environment, Some("0".to_string())));
     assert_eq!(client_1.default_sender(), client_2.default_sender());


### PR DESCRIPTION
**Give an overview of the tasks completed**
Added derives for `EnvironmentParams` so that they may be read in via toml and handled more easily. We now have:
```rust
#[derive(Clone, Debug, Deserialize, Serialize)]
pub struct EnvironmentParameters
```

Furthermore, placed the label in the `EnvironmentParameters` struct.

**Link to issue(s) that this PR closes**
Closes #470 and closes #471
