### PR TITLE
feat: version change for `RustQuant` with "seedable" feature

### DIFF
--- a/arbiter-core/Cargo.toml
+++ b/arbiter-core/Cargo.toml
@@ -13,7 +13,7 @@ revm = "3.3.0"
 # Serialization
 bytes = "1.4.0"
 serde = { version = "1.0.163", features= ["derive"]}
-serde_json = { version = "1.0.96" }
+serde_json ="1.0.96"
 
 # Concurrency/async
 tokio = { version = "1.28.1", features = ["macros", "full"] }
@@ -25,7 +25,7 @@ atomic_enum = "0.2.0"
 rand = "0.8.5"  
 rand_distr = "0.4.3"
 statrs = "0.16.0"
-RustQuant = "*"
+RustQuant = { version = "0.0.26", features = ["seedable"]}
 
 # Errors
 thiserror = "1.0.30"


### PR DESCRIPTION
**Give an overview of the tasks completed**
Updated `RustQuant` import so that we can take advantage of the "seedable" feature flag for seeding stochastic processes.

**Link to issue(s) that this PR closes**
Closes #474 