### PR TITLE
chore: improve environment errors

### DIFF
--- a/arbiter-core/src/environment.rs
+++ b/arbiter-core/src/environment.rs
@@ -50,11 +50,11 @@ pub(crate) type ToTransact = bool;
 
 /// Alias for the sender of the channel for transmitting [`RevmResult`] emitted
 /// from transactions.
-pub(crate) type ResultSender = Sender<RevmResult>;
+pub(crate) type ResultSender = Sender<Result<(ExecutionResult, U64), EnvironmentError>>;
 
 /// Alias for the receiver of the channel for transmitting [`RevmResult`]
 /// emitted from transactions.
-pub(crate) type ResultReceiver = Receiver<RevmResult>;
+pub(crate) type ResultReceiver = Receiver<Result<(ExecutionResult, U64), EnvironmentError>>;
 
 /// Alias for the sender of the channel for transmitting transactions.
 pub(crate) type TxSender = Sender<(ToTransact, TxEnv, ResultSender)>;
@@ -206,7 +206,7 @@ pub enum EnvironmentError {
     /// [`EnvironmentError::Pause`] is thrown when the [`Environment`]
     /// fails to pause. This should likely never occur, but if it does,
     /// please report this error!
-    #[error("error pausing! the source error is: {0}")]
+    #[error("error pausing! the source error is: {0:?}")]
     Pause(String),
 
     /// [`EnvironmentError::Communication`] is thrown when a channel for
@@ -217,6 +217,9 @@ pub enum EnvironmentError {
     #[error("error communicating! the source error is: {0}")]
     Communication(String),
 
+    #[error("error broadcasting! the source error is: {0}")]
+    Broadcast(#[from] crossbeam_channel::SendError<Vec<Log>>),
+
     /// [`EnvironmentError::Conversion`] is thrown when a type fails to
     /// convert into another (typically a type used in `revm` versus a type used
     /// in [`ethers-rs`](https://github.com/gakonst/ethers-rs)).
@@ -225,6 +228,9 @@ pub enum EnvironmentError {
     /// this will be (hopefully) unnecessary!
     #[error("conversion error! the source error is: {0}")]
     Conversion(String),
+
+    #[error("transaction was received while the environment was paused. this transaction was not processed.")]
+    TransactionReceivedWhilePaused,
 }
 
 impl Environment {
@@ -300,30 +306,20 @@ impl Environment {
                         let (lock, cvar) = &*pausevar;
                         let mut guard = lock
                             .lock()
-                            .map_err(|e| EnvironmentError::Pause(format!("{:?}", e)))?;
+                            .map_err(|e| EnvironmentError::Pause(e.to_string()))?;
 
-                        // this logic here ensures we catch any edge case last transactions and send
-                        // the appropriate error so that we dont hang in
-                        // limbo forever
+                        // This logic here ensures we catch any last transactions and send
+                        // the appropriate error so that we dont hang on the `tx_receiver`
                         while let Ok((_, _, sender)) = tx_receiver.try_recv() {
-                            let error_outcome = TransactionOutcome::Error(EnvironmentError::Pause(
-                                "Environment is paused".into(),
-                            ));
-                            let revm_result = RevmResult {
-                                outcome: error_outcome,
-                                block_number: convert_uint_to_u64(evm.env.block.number).map_err(
-                                    |e| EnvironmentError::Conversion(format!("{:?}", e)),
-                                )?,
-                            };
                             sender
-                                .send(revm_result)
-                                .map_err(|e| EnvironmentError::Communication(format!("{:?}", e)))?;
+                                .send(Err(EnvironmentError::TransactionReceivedWhilePaused))
+                                .map_err(|e| EnvironmentError::Communication(e.to_string()))?;
                         }
 
                         while state.load(std::sync::atomic::Ordering::SeqCst) == State::Paused {
                             guard = cvar
                                 .wait(guard)
-                                .map_err(|e| EnvironmentError::Pause(format!("{:?}", e)))?;
+                                .map_err(|e| EnvironmentError::Pause(e.to_string()))?;
                         }
                     }
 
@@ -346,66 +342,24 @@ impl Environment {
                             // If the transaction is a state-changing transaction, `to_transact ==
                             // true` and the state will be written to the database via a
                             // `transact_commit()` Otherwise it must be
-                            // a read-only call, so we will not update the database
-                            // Calls will not have events to emit
-                            if to_transact {
-                                let execution_result = match evm.transact_commit() {
-                                    // Check for an error in execution ([`EVMError<Infallible>`]),
-                                    // but pass to the middleware to determine if the result is
-                                    // [`ExecutionResult::Success`], [`ExecutionResult::Revert`], or
-                                    // [`ExecutionResult::Halt`].
-                                    Ok(val) => val,
-                                    Err(e) => {
-                                        state.store(
-                                            State::Paused,
-                                            std::sync::atomic::Ordering::SeqCst,
-                                        );
-                                        error!("Pausing the environment labeled {} due to an execution error: {:#?}", label, e);
-                                        return Err(EnvironmentError::Execution(e));
-                                    }
-                                };
-                                let event_broadcaster = event_broadcaster.lock().map_err(|e| {
-                                    EnvironmentError::Communication(format!("{:?}", e))
-                                })?;
+                            // a read-only call, so we will not update the database.
+                            // Calls will not have events to emit.
+                            let execution_result = if to_transact {
+                                let execution_result =
+                                    evm.transact_commit().map_err(EnvironmentError::Execution)?;
+                                let event_broadcaster = event_broadcaster
+                                    .lock()
+                                    .map_err(|e| EnvironmentError::Communication(e.to_string()))?;
                                 event_broadcaster.broadcast(execution_result.logs())?;
-                                let revm_result = RevmResult {
-                                    outcome: TransactionOutcome::Success(execution_result),
-                                    block_number: convert_uint_to_u64(evm.env.block.number)
-                                        .map_err(|e| {
-                                            EnvironmentError::Conversion(format!("{:?}", e))
-                                        })?,
-                                };
-                                sender.send(revm_result).map_err(|e| {
-                                    EnvironmentError::Communication(format!("{:?}", e))
-                                })?;
                                 counter += 1;
+                                execution_result
                             } else {
-                                let result = match evm.transact() {
-                                    // Check for an error in execution ([`EVMError<Infallible>`]),
-                                    // but pass to the middleware to determine if the result is
-                                    // [`ExecutionResult::Success`], [`ExecutionResult::Revert`], or
-                                    // [`ExecutionResult::Halt`].
-                                    Ok(result_and_state) => result_and_state.result,
-                                    Err(e) => {
-                                        state.store(
-                                            State::Paused,
-                                            std::sync::atomic::Ordering::SeqCst,
-                                        );
-                                        error!("Pausing the environment labeled {} due to an execution error: {:#?}", label, e);
-                                        return Err(EnvironmentError::Execution(e));
-                                    }
-                                };
-                                let result_and_block = RevmResult {
-                                    outcome: TransactionOutcome::Success(result),
-                                    block_number: convert_uint_to_u64(evm.env.block.number)
-                                        .map_err(|e| {
-                                            EnvironmentError::Conversion(format!("{:?}", e))
-                                        })?,
-                                };
-                                sender.send(result_and_block).map_err(|e| {
-                                    EnvironmentError::Communication(format!("{:?}", e))
-                                })?;
-                            }
+                                evm.transact().map_err(EnvironmentError::Execution)?.result
+                            };
+                            let block_number = convert_uint_to_u64(evm.env.block.number)?;
+                            sender
+                                .send(Ok((execution_result, block_number)))
+                                .map_err(|e| EnvironmentError::Communication(e.to_string()))?;
                         }
                     }
                     State::Initialization => {
@@ -466,41 +420,6 @@ pub(crate) struct Socket {
     pub(crate) event_broadcaster: Arc<Mutex<EventBroadcaster>>,
 }
 
-/// Represents the possible outcomes of an EVM transaction.
-///
-/// This enum is used to encapsulate both successful transaction results and
-/// potential errors.
-/// - `Success`: Indicates that the transaction was executed successfully and
-///   contains the result of the execution. The wrapped `ExecutionResult`
-///   provides detailed information about the transaction's execution, such as
-///   returned values or changes made to the state.
-/// - `Error`: Indicates that the transaction failed due to some error
-///   condition. The wrapped `EnvironmentError` provides specifics about the
-///   error, allowing callers to take appropriate action or relay more
-///   informative error messages.
-#[derive(Debug, Clone)]
-pub(crate) enum TransactionOutcome {
-    /// Represents a successfully executed transaction.
-    ///
-    /// Contains the result of the transaction's execution.
-    Success(ExecutionResult),
-
-    /// Represents a failed transaction due to some error.
-    ///
-    /// Contains information about the error that caused the transaction
-    /// failure.
-    Error(EnvironmentError),
-}
-/// Represents the result of an EVM transaction.
-///
-/// Contains the outcome of a transaction (e.g., success, revert, halt) and the
-/// block number at which the transaction was executed.
-#[derive(Debug, Clone)]
-pub(crate) struct RevmResult {
-    pub(crate) outcome: TransactionOutcome,
-    pub(crate) block_number: U64,
-}
-
 /// Responsible for broadcasting Ethereum logs to subscribers.
 ///
 /// Maintains a list of senders to which logs are sent whenever they are
@@ -524,9 +443,7 @@ impl EventBroadcaster {
     /// downstream to any and all receivers
     fn broadcast(&self, logs: Vec<Log>) -> Result<(), EnvironmentError> {
         for sender in &self.0 {
-            sender
-                .send(logs.clone())
-                .map_err(|e| EnvironmentError::Communication(format!("{:?}", e)))?;
+            sender.send(logs.clone())?;
         }
         Ok(())
     }
@@ -539,11 +456,13 @@ impl EventBroadcaster {
 /// * `Ok(U64)` - The converted U64.
 /// Used for block number which is a U64.
 #[inline]
-fn convert_uint_to_u64(input: U256) -> Result<U64, &'static str> {
+fn convert_uint_to_u64(input: U256) -> Result<U64, EnvironmentError> {
     let as_str = input.to_string();
     match as_str.parse::<u64>() {
         Ok(val) => Ok(val.into()),
-        Err(_) => Err("U256 value is too large to fit into u64"),
+        Err(_) => Err(EnvironmentError::Conversion(
+            "U256 value is too large to fit into u64".to_string(),
+        )),
     }
 }
 

--- a/arbiter-core/src/middleware.rs
+++ b/arbiter-core/src/middleware.rs
@@ -45,9 +45,7 @@ use revm::primitives::{CreateScheme, ExecutionResult, Output, TransactTo, TxEnv,
 use serde::{de::DeserializeOwned, Serialize};
 use thiserror::Error;
 
-use crate::environment::{
-    Environment, EventBroadcaster, ResultReceiver, ResultSender, TransactionOutcome, TxSender,
-};
+use crate::environment::{Environment, EventBroadcaster, ResultReceiver, ResultSender, TxSender};
 
 /// A middleware structure that integrates with `revm`.
 ///

--- a/arbiter-core/src/middleware.rs
+++ b/arbiter-core/src/middleware.rs
@@ -104,6 +104,10 @@ pub struct RevmMiddleware {
 /// [GitHub](https://github.com/primitivefinance/arbiter/).
 #[derive(Error, Debug)]
 pub enum RevmMiddlewareError {
+    /// An error occurred while attempting to interact with the environment.
+    #[error("an error came from the environment! due to: {0}")]
+    Environment(#[from] crate::environment::EnvironmentError),
+
     /// An error occurred while attempting to send a transaction.
     #[error("failed to send transaction! due to: {0}")]
     Send(String),
@@ -111,7 +115,7 @@ pub enum RevmMiddlewareError {
     /// There was an issue receiving an [`ExecutionResult`], possibly from
     /// another service or module.
     #[error("failed to receive `ExecutionResult`! due to: {0}")]
-    Receive(String),
+    Receive(#[from] crossbeam_channel::RecvError),
 
     /// There was a failure trying to obtain a lock on the [`EventBroadcaster`],
     /// possibly due to concurrency issues.
@@ -302,52 +306,33 @@ impl Middleware for RevmMiddleware {
             ))
             .map_err(|e| RevmMiddlewareError::Send(e.to_string()))?;
 
-        let revm_result = self
-            .provider()
-            .as_ref()
-            .result_receiver
-            .recv()
-            .map_err(|e| RevmMiddlewareError::Receive(e.to_string()))?;
+        let (execution_result, block_number) =
+            self.provider().as_ref().result_receiver.recv()??;
 
-        match revm_result.outcome {
-            TransactionOutcome::Success(execution_result) => {
-                let Success {
-                    _reason: _,
-                    _gas_used: _,
-                    _gas_refunded: _,
-                    logs,
-                    output,
-                } = unpack_execution_result(execution_result)?;
+        let Success {
+            _reason: _,
+            _gas_used: _,
+            _gas_refunded: _,
+            logs,
+            output,
+        } = unpack_execution_result(execution_result)?;
 
-                match output {
-                    Output::Create(_, address) => {
-                        let address = address.ok_or(RevmMiddlewareError::MissingData(
-                            "Address missing in transaction!".to_string(),
-                        ))?;
-                        let mut pending_tx =
-                            PendingTransaction::new(ethers::types::H256::zero(), self.provider());
-                        pending_tx.state =
-                            PendingTxState::RevmDeployOutput(recast_address(address));
-                        return Ok(pending_tx);
-                    }
-                    Output::Call(_) => {
-                        let mut pending_tx =
-                            PendingTransaction::new(ethers::types::H256::zero(), self.provider());
-
-                        pending_tx.state =
-                            PendingTxState::RevmTransactOutput(logs, revm_result.block_number);
-                        return Ok(pending_tx);
-                    }
-                }
+        match output {
+            Output::Create(_, address) => {
+                let address = address.ok_or(RevmMiddlewareError::MissingData(
+                    "Address missing in transaction!".to_string(),
+                ))?;
+                let mut pending_tx =
+                    PendingTransaction::new(ethers::types::H256::zero(), self.provider());
+                pending_tx.state = PendingTxState::RevmDeployOutput(recast_address(address));
+                return Ok(pending_tx);
             }
-            TransactionOutcome::Error(err) => {
-                return Err(RevmMiddlewareError::Receive(
-                    format!(
-                        "Error recieving response from the environement with environment error: {}",
-                        err
-                    )
-                    .to_string(),
-                ));
+            Output::Call(_) => {
+                let mut pending_tx =
+                    PendingTransaction::new(ethers::types::H256::zero(), self.provider());
+
+                pending_tx.state = PendingTxState::RevmTransactOutput(logs, block_number);
+                return Ok(pending_tx);
             }
         }
     }
@@ -410,33 +395,16 @@ impl Middleware for RevmMiddleware {
                 self.provider().as_ref().result_sender.clone(),
             ))
             .map_err(|e| RevmMiddlewareError::Send(e.to_string()))?;
-        let revm_result = self
-            .provider()
-            .as_ref()
-            .result_receiver
-            .recv()
-            .map_err(|e| RevmMiddlewareError::Receive(e.to_string()))?;
+        let (execution_result, _block_number) =
+            self.provider().as_ref().result_receiver.recv()??;
 
-        match revm_result.outcome {
-            TransactionOutcome::Success(execution_result) => {
-                let output = unpack_execution_result(execution_result)?.output;
-                match output {
-                    Output::Create(bytes, ..) => {
-                        return Ok(Bytes::from(bytes.to_vec()));
-                    }
-                    Output::Call(bytes) => {
-                        return Ok(Bytes::from(bytes.to_vec()));
-                    }
-                }
+        let output = unpack_execution_result(execution_result)?.output;
+        match output {
+            Output::Create(bytes, ..) => {
+                return Ok(Bytes::from(bytes.to_vec()));
             }
-            TransactionOutcome::Error(err) => {
-                return Err(RevmMiddlewareError::Receive(
-                    format!(
-                        "Error recieving response from the environement with environment error: {}",
-                        err
-                    )
-                    .to_string(),
-                ));
+            Output::Call(bytes) => {
+                return Ok(Bytes::from(bytes.to_vec()));
             }
         }
     }


### PR DESCRIPTION
**Give an overview of the tasks completed**
- Cleaned up the `EnvironmentError`s and their handling as well. 
- Removed some unnecessary structs by repackaging into Rust's `Result` enum.
- Took those changes and made necessary changes to `middleware.rs` to handle this more succinctly.

**Link to issue(s) that this PR closes**
Closes #477 