### PR TITLE
feat: block type enum

### DIFF
--- a/arbiter-core/benches/bench.rs
+++ b/arbiter-core/benches/bench.rs
@@ -10,7 +10,7 @@ use arbiter_core::{
         arbiter_math::ArbiterMath,
         arbiter_token::{self, ArbiterToken},
     },
-    environment::EnvironmentParameters,
+    environment::{BlockType, EnvironmentParameters},
     manager::Manager,
     middleware::RevmMiddleware,
 };
@@ -160,8 +160,7 @@ async fn arbiter_startup() -> Result<(Arc<RevmMiddleware>, Manager)> {
     let mut manager = Manager::new();
     let params = EnvironmentParameters {
         label: ENV_LABEL.to_string(),
-        block_rate: 10.0,
-        seed: 0,
+        block_type: BlockType::UserControlled,
     };
     manager.add_environment(params)?;
 

--- a/arbiter-core/src/bindings/block_info.rs
+++ b/arbiter-core/src/bindings/block_info.rs
@@ -7,7 +7,7 @@ pub use block_info::*;
     clippy::upper_case_acronyms,
     clippy::type_complexity,
     dead_code,
-    non_camel_case_types,
+    non_camel_case_types
 )]
 pub mod block_info {
     #[allow(deprecated)]
@@ -17,47 +17,35 @@ pub mod block_info {
             functions: ::core::convert::From::from([
                 (
                     ::std::borrow::ToOwned::to_owned("getBlockNumber"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("getBlockNumber"),
-                            inputs: ::std::vec![],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("getBlockNumber"),
+                        inputs: ::std::vec![],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint256"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("getBlockTimestamp"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("getBlockTimestamp"),
-                            inputs: ::std::vec![],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("getBlockTimestamp"),
+                        inputs: ::std::vec![],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint256"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
             ]),
             events: ::std::collections::BTreeMap::new(),
@@ -66,22 +54,19 @@ pub mod block_info {
             fallback: false,
         }
     }
-    ///The parsed JSON ABI of the contract.
-    pub static BLOCKINFO_ABI: ::ethers::contract::Lazy<::ethers::core::abi::Abi> = ::ethers::contract::Lazy::new(
-        __abi,
-    );
+    /// The parsed JSON ABI of the contract.
+    pub static BLOCKINFO_ABI: ::ethers::contract::Lazy<::ethers::core::abi::Abi> =
+        ::ethers::contract::Lazy::new(__abi);
     #[rustfmt::skip]
     const __BYTECODE: &[u8] = b"`\x80\x80`@R4a\0\x19W`@Qa\x01\xA5\x90\x81a\0g\x829\xF3[bF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD\xFE`\x80`@R`\x046\x10\x15a\0qW[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01Rtnor receive functions`X\x1B`d\x82\x01R`\x84\x90\xFD[`\x005`\xE0\x1C\x80cB\xCB\xB1\\\x14a\0\xA9Wcyk\x89\xB9\x03a\0\x0EW4a\0\xA4Wa\0\x9A6a\x01\x11V[` `@QB\x81R\xF3[a\0\xC1V[4a\0\xC1Wa\0\xB76a\x01\x11V[` `@QC\x81R\xF3[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD[`\0\x90`\x03\x19\x01\x12a\x01\x1FWV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x90\xFD\xFE\xA2dipfsX\"\x12 \xF7\xAD\x12 \x0E\xBD/\x87\xEF\x8DoY6\xE2\xD1\xEF1m\x1FLsJ\xC2\x85\x1E\xDAn\x9Bj\xDF\xC3hdsolcC\0\x08\x13\x003";
     /// The bytecode of the contract.
-    pub static BLOCKINFO_BYTECODE: ::ethers::core::types::Bytes = ::ethers::core::types::Bytes::from_static(
-        __BYTECODE,
-    );
+    pub static BLOCKINFO_BYTECODE: ::ethers::core::types::Bytes =
+        ::ethers::core::types::Bytes::from_static(__BYTECODE);
     #[rustfmt::skip]
     const __DEPLOYED_BYTECODE: &[u8] = b"`\x80`@R`\x046\x10\x15a\0qW[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01Rtnor receive functions`X\x1B`d\x82\x01R`\x84\x90\xFD[`\x005`\xE0\x1C\x80cB\xCB\xB1\\\x14a\0\xA9Wcyk\x89\xB9\x03a\0\x0EW4a\0\xA4Wa\0\x9A6a\x01\x11V[` `@QB\x81R\xF3[a\0\xC1V[4a\0\xC1Wa\0\xB76a\x01\x11V[` `@QC\x81R\xF3[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD[`\0\x90`\x03\x19\x01\x12a\x01\x1FWV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x90\xFD\xFE\xA2dipfsX\"\x12 \xF7\xAD\x12 \x0E\xBD/\x87\xEF\x8DoY6\xE2\xD1\xEF1m\x1FLsJ\xC2\x85\x1E\xDAn\x9Bj\xDF\xC3hdsolcC\0\x08\x13\x003";
     /// The deployed bytecode of the contract.
-    pub static BLOCKINFO_DEPLOYED_BYTECODE: ::ethers::core::types::Bytes = ::ethers::core::types::Bytes::from_static(
-        __DEPLOYED_BYTECODE,
-    );
+    pub static BLOCKINFO_DEPLOYED_BYTECODE: ::ethers::core::types::Bytes =
+        ::ethers::core::types::Bytes::from_static(__DEPLOYED_BYTECODE);
     pub struct BlockInfo<M>(::ethers::contract::Contract<M>);
     impl<M> ::core::clone::Clone for BlockInfo<M> {
         fn clone(&self) -> Self {
@@ -101,38 +86,44 @@ pub mod block_info {
     }
     impl<M> ::core::fmt::Debug for BlockInfo<M> {
         fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-            f.debug_tuple(::core::stringify!(BlockInfo)).field(&self.address()).finish()
+            f.debug_tuple(::core::stringify!(BlockInfo))
+                .field(&self.address())
+                .finish()
         }
     }
     impl<M: ::ethers::providers::Middleware> BlockInfo<M> {
-        /// Creates a new contract instance with the specified `ethers` client at
-        /// `address`. The contract derefs to a `ethers::Contract` object.
+        /// Creates a new contract instance with the specified `ethers` client
+        /// at `address`. The contract derefs to a `ethers::Contract`
+        /// object.
         pub fn new<T: Into<::ethers::core::types::Address>>(
             address: T,
             client: ::std::sync::Arc<M>,
         ) -> Self {
-            Self(
-                ::ethers::contract::Contract::new(
-                    address.into(),
-                    BLOCKINFO_ABI.clone(),
-                    client,
-                ),
-            )
+            Self(::ethers::contract::Contract::new(
+                address.into(),
+                BLOCKINFO_ABI.clone(),
+                client,
+            ))
         }
-        /// Constructs the general purpose `Deployer` instance based on the provided constructor arguments and sends it.
-        /// Returns a new instance of a deployer that returns an instance of this contract after sending the transaction
+        /// Constructs the general purpose `Deployer` instance based on the
+        /// provided constructor arguments and sends it. Returns a new
+        /// instance of a deployer that returns an instance of this contract
+        /// after sending the transaction
         ///
         /// Notes:
-        /// - If there are no constructor arguments, you should pass `()` as the argument.
+        /// - If there are no constructor arguments, you should pass `()` as the
+        ///   argument.
         /// - The default poll duration is 7 seconds.
         /// - The default number of confirmations is 1 block.
         ///
         ///
         /// # Example
         ///
-        /// Generate contract bindings with `abigen!` and deploy a new contract instance.
+        /// Generate contract bindings with `abigen!` and deploy a new contract
+        /// instance.
         ///
-        /// *Note*: this requires a `bytecode` and `abi` object in the `greeter.json` artifact.
+        /// *Note*: this requires a `bytecode` and `abi` object in the
+        /// `greeter.json` artifact.
         ///
         /// ```ignore
         /// # async fn deploy<M: ethers::providers::Middleware>(client: ::std::sync::Arc<M>) {
@@ -158,7 +149,7 @@ pub mod block_info {
             let deployer = ::ethers::contract::ContractDeployer::new(deployer);
             Ok(deployer)
         }
-        ///Calls the contract's `getBlockNumber` (0x42cbb15c) function
+        /// Calls the contract's `getBlockNumber` (0x42cbb15c) function
         pub fn get_block_number(
             &self,
         ) -> ::ethers::contract::builders::ContractCall<M, ::ethers::core::types::U256> {
@@ -166,7 +157,7 @@ pub mod block_info {
                 .method_hash([66, 203, 177, 92], ())
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `getBlockTimestamp` (0x796b89b9) function
+        /// Calls the contract's `getBlockTimestamp` (0x796b89b9) function
         pub fn get_block_timestamp(
             &self,
         ) -> ::ethers::contract::builders::ContractCall<M, ::ethers::core::types::U256> {
@@ -175,13 +166,13 @@ pub mod block_info {
                 .expect("method not found (this should never happen)")
         }
     }
-    impl<M: ::ethers::providers::Middleware> From<::ethers::contract::Contract<M>>
-    for BlockInfo<M> {
+    impl<M: ::ethers::providers::Middleware> From<::ethers::contract::Contract<M>> for BlockInfo<M> {
         fn from(contract: ::ethers::contract::Contract<M>) -> Self {
             Self::new(contract.address(), contract.client())
         }
     }
-    ///Container type for all input parameters for the `getBlockNumber` function with signature `getBlockNumber()` and selector `0x42cbb15c`
+    /// Container type for all input parameters for the `getBlockNumber`
+    /// function with signature `getBlockNumber()` and selector `0x42cbb15c`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -190,11 +181,12 @@ pub mod block_info {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "getBlockNumber", abi = "getBlockNumber()")]
     pub struct GetBlockNumberCall;
-    ///Container type for all input parameters for the `getBlockTimestamp` function with signature `getBlockTimestamp()` and selector `0x796b89b9`
+    /// Container type for all input parameters for the `getBlockTimestamp`
+    /// function with signature `getBlockTimestamp()` and selector `0x796b89b9`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -203,11 +195,11 @@ pub mod block_info {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "getBlockTimestamp", abi = "getBlockTimestamp()")]
     pub struct GetBlockTimestampCall;
-    ///Container type for all of the contract's call
+    /// Container type for all of the contract's call
     #[derive(Clone, ::ethers::contract::EthAbiType, Debug, PartialEq, Eq, Hash)]
     pub enum BlockInfoCalls {
         GetBlockNumber(GetBlockNumberCall),
@@ -218,14 +210,14 @@ pub mod block_info {
             data: impl AsRef<[u8]>,
         ) -> ::core::result::Result<Self, ::ethers::core::abi::AbiError> {
             let data = data.as_ref();
-            if let Ok(decoded)
-                = <GetBlockNumberCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) =
+                <GetBlockNumberCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::GetBlockNumber(decoded));
             }
-            if let Ok(decoded)
-                = <GetBlockTimestampCall as ::ethers::core::abi::AbiDecode>::decode(
-                    data,
-                ) {
+            if let Ok(decoded) =
+                <GetBlockTimestampCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::GetBlockTimestamp(decoded));
             }
             Err(::ethers::core::abi::Error::InvalidData.into())
@@ -234,12 +226,8 @@ pub mod block_info {
     impl ::ethers::core::abi::AbiEncode for BlockInfoCalls {
         fn encode(self) -> Vec<u8> {
             match self {
-                Self::GetBlockNumber(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::GetBlockTimestamp(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                Self::GetBlockNumber(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::GetBlockTimestamp(element) => ::ethers::core::abi::AbiEncode::encode(element),
             }
         }
     }
@@ -261,7 +249,8 @@ pub mod block_info {
             Self::GetBlockTimestamp(value)
         }
     }
-    ///Container type for all return fields from the `getBlockNumber` function with signature `getBlockNumber()` and selector `0x42cbb15c`
+    /// Container type for all return fields from the `getBlockNumber` function
+    /// with signature `getBlockNumber()` and selector `0x42cbb15c`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -270,10 +259,11 @@ pub mod block_info {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct GetBlockNumberReturn(pub ::ethers::core::types::U256);
-    ///Container type for all return fields from the `getBlockTimestamp` function with signature `getBlockTimestamp()` and selector `0x796b89b9`
+    /// Container type for all return fields from the `getBlockTimestamp`
+    /// function with signature `getBlockTimestamp()` and selector `0x796b89b9`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -282,7 +272,7 @@ pub mod block_info {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct GetBlockTimestampReturn(pub ::ethers::core::types::U256);
 }

--- a/arbiter-core/src/bindings/block_info.rs
+++ b/arbiter-core/src/bindings/block_info.rs
@@ -1,0 +1,288 @@
+pub use block_info::*;
+/// This module was auto-generated with ethers-rs Abigen.
+/// More information at: <https://github.com/gakonst/ethers-rs>
+#[allow(
+    clippy::enum_variant_names,
+    clippy::too_many_arguments,
+    clippy::upper_case_acronyms,
+    clippy::type_complexity,
+    dead_code,
+    non_camel_case_types,
+)]
+pub mod block_info {
+    #[allow(deprecated)]
+    fn __abi() -> ::ethers::core::abi::Abi {
+        ::ethers::core::abi::ethabi::Contract {
+            constructor: ::core::option::Option::None,
+            functions: ::core::convert::From::from([
+                (
+                    ::std::borrow::ToOwned::to_owned("getBlockNumber"),
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("getBlockNumber"),
+                            inputs: ::std::vec![],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                        },
+                    ],
+                ),
+                (
+                    ::std::borrow::ToOwned::to_owned("getBlockTimestamp"),
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("getBlockTimestamp"),
+                            inputs: ::std::vec![],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                        },
+                    ],
+                ),
+            ]),
+            events: ::std::collections::BTreeMap::new(),
+            errors: ::std::collections::BTreeMap::new(),
+            receive: false,
+            fallback: false,
+        }
+    }
+    ///The parsed JSON ABI of the contract.
+    pub static BLOCKINFO_ABI: ::ethers::contract::Lazy<::ethers::core::abi::Abi> = ::ethers::contract::Lazy::new(
+        __abi,
+    );
+    #[rustfmt::skip]
+    const __BYTECODE: &[u8] = b"`\x80\x80`@R4a\0\x19W`@Qa\x01\xA5\x90\x81a\0g\x829\xF3[bF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD\xFE`\x80`@R`\x046\x10\x15a\0qW[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01Rtnor receive functions`X\x1B`d\x82\x01R`\x84\x90\xFD[`\x005`\xE0\x1C\x80cB\xCB\xB1\\\x14a\0\xA9Wcyk\x89\xB9\x03a\0\x0EW4a\0\xA4Wa\0\x9A6a\x01\x11V[` `@QB\x81R\xF3[a\0\xC1V[4a\0\xC1Wa\0\xB76a\x01\x11V[` `@QC\x81R\xF3[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD[`\0\x90`\x03\x19\x01\x12a\x01\x1FWV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x90\xFD\xFE\xA2dipfsX\"\x12 \xF7\xAD\x12 \x0E\xBD/\x87\xEF\x8DoY6\xE2\xD1\xEF1m\x1FLsJ\xC2\x85\x1E\xDAn\x9Bj\xDF\xC3hdsolcC\0\x08\x13\x003";
+    /// The bytecode of the contract.
+    pub static BLOCKINFO_BYTECODE: ::ethers::core::types::Bytes = ::ethers::core::types::Bytes::from_static(
+        __BYTECODE,
+    );
+    #[rustfmt::skip]
+    const __DEPLOYED_BYTECODE: &[u8] = b"`\x80`@R`\x046\x10\x15a\0qW[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01Rtnor receive functions`X\x1B`d\x82\x01R`\x84\x90\xFD[`\x005`\xE0\x1C\x80cB\xCB\xB1\\\x14a\0\xA9Wcyk\x89\xB9\x03a\0\x0EW4a\0\xA4Wa\0\x9A6a\x01\x11V[` `@QB\x81R\xF3[a\0\xC1V[4a\0\xC1Wa\0\xB76a\x01\x11V[` `@QC\x81R\xF3[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD[`\0\x90`\x03\x19\x01\x12a\x01\x1FWV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x90\xFD\xFE\xA2dipfsX\"\x12 \xF7\xAD\x12 \x0E\xBD/\x87\xEF\x8DoY6\xE2\xD1\xEF1m\x1FLsJ\xC2\x85\x1E\xDAn\x9Bj\xDF\xC3hdsolcC\0\x08\x13\x003";
+    /// The deployed bytecode of the contract.
+    pub static BLOCKINFO_DEPLOYED_BYTECODE: ::ethers::core::types::Bytes = ::ethers::core::types::Bytes::from_static(
+        __DEPLOYED_BYTECODE,
+    );
+    pub struct BlockInfo<M>(::ethers::contract::Contract<M>);
+    impl<M> ::core::clone::Clone for BlockInfo<M> {
+        fn clone(&self) -> Self {
+            Self(::core::clone::Clone::clone(&self.0))
+        }
+    }
+    impl<M> ::core::ops::Deref for BlockInfo<M> {
+        type Target = ::ethers::contract::Contract<M>;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+    impl<M> ::core::ops::DerefMut for BlockInfo<M> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
+    impl<M> ::core::fmt::Debug for BlockInfo<M> {
+        fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+            f.debug_tuple(::core::stringify!(BlockInfo)).field(&self.address()).finish()
+        }
+    }
+    impl<M: ::ethers::providers::Middleware> BlockInfo<M> {
+        /// Creates a new contract instance with the specified `ethers` client at
+        /// `address`. The contract derefs to a `ethers::Contract` object.
+        pub fn new<T: Into<::ethers::core::types::Address>>(
+            address: T,
+            client: ::std::sync::Arc<M>,
+        ) -> Self {
+            Self(
+                ::ethers::contract::Contract::new(
+                    address.into(),
+                    BLOCKINFO_ABI.clone(),
+                    client,
+                ),
+            )
+        }
+        /// Constructs the general purpose `Deployer` instance based on the provided constructor arguments and sends it.
+        /// Returns a new instance of a deployer that returns an instance of this contract after sending the transaction
+        ///
+        /// Notes:
+        /// - If there are no constructor arguments, you should pass `()` as the argument.
+        /// - The default poll duration is 7 seconds.
+        /// - The default number of confirmations is 1 block.
+        ///
+        ///
+        /// # Example
+        ///
+        /// Generate contract bindings with `abigen!` and deploy a new contract instance.
+        ///
+        /// *Note*: this requires a `bytecode` and `abi` object in the `greeter.json` artifact.
+        ///
+        /// ```ignore
+        /// # async fn deploy<M: ethers::providers::Middleware>(client: ::std::sync::Arc<M>) {
+        ///     abigen!(Greeter, "../greeter.json");
+        ///
+        ///    let greeter_contract = Greeter::deploy(client, "Hello world!".to_string()).unwrap().send().await.unwrap();
+        ///    let msg = greeter_contract.greet().call().await.unwrap();
+        /// # }
+        /// ```
+        pub fn deploy<T: ::ethers::core::abi::Tokenize>(
+            client: ::std::sync::Arc<M>,
+            constructor_args: T,
+        ) -> ::core::result::Result<
+            ::ethers::contract::builders::ContractDeployer<M, Self>,
+            ::ethers::contract::ContractError<M>,
+        > {
+            let factory = ::ethers::contract::ContractFactory::new(
+                BLOCKINFO_ABI.clone(),
+                BLOCKINFO_BYTECODE.clone().into(),
+                client,
+            );
+            let deployer = factory.deploy(constructor_args)?;
+            let deployer = ::ethers::contract::ContractDeployer::new(deployer);
+            Ok(deployer)
+        }
+        ///Calls the contract's `getBlockNumber` (0x42cbb15c) function
+        pub fn get_block_number(
+            &self,
+        ) -> ::ethers::contract::builders::ContractCall<M, ::ethers::core::types::U256> {
+            self.0
+                .method_hash([66, 203, 177, 92], ())
+                .expect("method not found (this should never happen)")
+        }
+        ///Calls the contract's `getBlockTimestamp` (0x796b89b9) function
+        pub fn get_block_timestamp(
+            &self,
+        ) -> ::ethers::contract::builders::ContractCall<M, ::ethers::core::types::U256> {
+            self.0
+                .method_hash([121, 107, 137, 185], ())
+                .expect("method not found (this should never happen)")
+        }
+    }
+    impl<M: ::ethers::providers::Middleware> From<::ethers::contract::Contract<M>>
+    for BlockInfo<M> {
+        fn from(contract: ::ethers::contract::Contract<M>) -> Self {
+            Self::new(contract.address(), contract.client())
+        }
+    }
+    ///Container type for all input parameters for the `getBlockNumber` function with signature `getBlockNumber()` and selector `0x42cbb15c`
+    #[derive(
+        Clone,
+        ::ethers::contract::EthCall,
+        ::ethers::contract::EthDisplay,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    #[ethcall(name = "getBlockNumber", abi = "getBlockNumber()")]
+    pub struct GetBlockNumberCall;
+    ///Container type for all input parameters for the `getBlockTimestamp` function with signature `getBlockTimestamp()` and selector `0x796b89b9`
+    #[derive(
+        Clone,
+        ::ethers::contract::EthCall,
+        ::ethers::contract::EthDisplay,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    #[ethcall(name = "getBlockTimestamp", abi = "getBlockTimestamp()")]
+    pub struct GetBlockTimestampCall;
+    ///Container type for all of the contract's call
+    #[derive(Clone, ::ethers::contract::EthAbiType, Debug, PartialEq, Eq, Hash)]
+    pub enum BlockInfoCalls {
+        GetBlockNumber(GetBlockNumberCall),
+        GetBlockTimestamp(GetBlockTimestampCall),
+    }
+    impl ::ethers::core::abi::AbiDecode for BlockInfoCalls {
+        fn decode(
+            data: impl AsRef<[u8]>,
+        ) -> ::core::result::Result<Self, ::ethers::core::abi::AbiError> {
+            let data = data.as_ref();
+            if let Ok(decoded)
+                = <GetBlockNumberCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+                return Ok(Self::GetBlockNumber(decoded));
+            }
+            if let Ok(decoded)
+                = <GetBlockTimestampCall as ::ethers::core::abi::AbiDecode>::decode(
+                    data,
+                ) {
+                return Ok(Self::GetBlockTimestamp(decoded));
+            }
+            Err(::ethers::core::abi::Error::InvalidData.into())
+        }
+    }
+    impl ::ethers::core::abi::AbiEncode for BlockInfoCalls {
+        fn encode(self) -> Vec<u8> {
+            match self {
+                Self::GetBlockNumber(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
+                Self::GetBlockTimestamp(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
+            }
+        }
+    }
+    impl ::core::fmt::Display for BlockInfoCalls {
+        fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+            match self {
+                Self::GetBlockNumber(element) => ::core::fmt::Display::fmt(element, f),
+                Self::GetBlockTimestamp(element) => ::core::fmt::Display::fmt(element, f),
+            }
+        }
+    }
+    impl ::core::convert::From<GetBlockNumberCall> for BlockInfoCalls {
+        fn from(value: GetBlockNumberCall) -> Self {
+            Self::GetBlockNumber(value)
+        }
+    }
+    impl ::core::convert::From<GetBlockTimestampCall> for BlockInfoCalls {
+        fn from(value: GetBlockTimestampCall) -> Self {
+            Self::GetBlockTimestamp(value)
+        }
+    }
+    ///Container type for all return fields from the `getBlockNumber` function with signature `getBlockNumber()` and selector `0x42cbb15c`
+    #[derive(
+        Clone,
+        ::ethers::contract::EthAbiType,
+        ::ethers::contract::EthAbiCodec,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    pub struct GetBlockNumberReturn(pub ::ethers::core::types::U256);
+    ///Container type for all return fields from the `getBlockTimestamp` function with signature `getBlockTimestamp()` and selector `0x796b89b9`
+    #[derive(
+        Clone,
+        ::ethers::contract::EthAbiType,
+        ::ethers::contract::EthAbiCodec,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    pub struct GetBlockTimestampReturn(pub ::ethers::core::types::U256);
+}

--- a/arbiter-core/src/bindings/mod.rs
+++ b/arbiter-core/src/bindings/mod.rs
@@ -3,4 +3,6 @@
 
 pub mod arbiter_math;
 pub mod arbiter_token;
+#[cfg(test)]
+pub mod block_info;
 pub mod liquid_exchange;

--- a/arbiter-core/src/environment.rs
+++ b/arbiter-core/src/environment.rs
@@ -345,9 +345,11 @@ impl Environment {
                                     outcome_sender,
                                 } => {
                                     if block_type != BlockType::UserControlled {
-                                        outcome_sender.send(Err(
-                                            EnvironmentError::NotUserControlledBlockType,
-                                        ));
+                                        outcome_sender
+                                            .send(Err(EnvironmentError::NotUserControlledBlockType))
+                                            .map_err(|e| {
+                                                EnvironmentError::Communication(e.to_string())
+                                            })?;
                                     }
                                     // Update the block number and timestamp
                                     evm.env.block.number = block_number;

--- a/arbiter-core/src/environment.rs
+++ b/arbiter-core/src/environment.rs
@@ -300,7 +300,6 @@ impl Environment {
             let mut transactions_per_block = seeded_poisson
                 .clone()
                 .map(|mut distribution| distribution.sample());
-
             let mut counter: usize = 0;
 
             // Loop over the reception of calls/transactions sent through the socket
@@ -345,8 +344,10 @@ impl Environment {
                                 evm.env.block.number += U256::from(1);
 
                                 // This unwrap cannot fail.
-                                transactions_per_block =
-                                    Some(seeded_poisson.clone().unwrap().sample());
+                                let mut seeded_poisson = seeded_poisson.clone().unwrap();
+
+                                evm.env.block.timestamp += U256::from(seeded_poisson.time_step);
+                                transactions_per_block = Some(seeded_poisson.sample());
                             }
 
                             // Set the tx_env and prepare to process it

--- a/arbiter-core/src/environment.rs
+++ b/arbiter-core/src/environment.rs
@@ -50,11 +50,11 @@ pub(crate) type ToTransact = bool;
 
 /// Alias for the sender of the channel for transmitting [`RevmResult`] emitted
 /// from transactions.
-pub(crate) type ResultSender = Sender<RevmResult>;
+pub(crate) type ResultSender = Sender<Result<(ExecutionResult, U64), EnvironmentError>>;
 
 /// Alias for the receiver of the channel for transmitting [`RevmResult`]
 /// emitted from transactions.
-pub(crate) type ResultReceiver = Receiver<RevmResult>;
+pub(crate) type ResultReceiver = Receiver<Result<(ExecutionResult, U64), EnvironmentError>>;
 
 /// Alias for the sender of the channel for transmitting transactions.
 pub(crate) type TxSender = Sender<(ToTransact, TxEnv, ResultSender)>;
@@ -206,7 +206,7 @@ pub enum EnvironmentError {
     /// [`EnvironmentError::Pause`] is thrown when the [`Environment`]
     /// fails to pause. This should likely never occur, but if it does,
     /// please report this error!
-    #[error("error pausing! the source error is: {0}")]
+    #[error("error pausing! the source error is: {0:?}")]
     Pause(String),
 
     /// [`EnvironmentError::Communication`] is thrown when a channel for
@@ -217,6 +217,9 @@ pub enum EnvironmentError {
     #[error("error communicating! the source error is: {0}")]
     Communication(String),
 
+    #[error("error broadcasting! the source error is: {0}")]
+    Broadcast(#[from] crossbeam_channel::SendError<Vec<Log>>),
+
     /// [`EnvironmentError::Conversion`] is thrown when a type fails to
     /// convert into another (typically a type used in `revm` versus a type used
     /// in [`ethers-rs`](https://github.com/gakonst/ethers-rs)).
@@ -225,6 +228,9 @@ pub enum EnvironmentError {
     /// this will be (hopefully) unnecessary!
     #[error("conversion error! the source error is: {0}")]
     Conversion(String),
+
+    #[error("transaction was received while the environment was paused. this transaction was not processed.")]
+    TransactionReceivedWhilePaused,
 }
 
 impl Environment {
@@ -300,30 +306,20 @@ impl Environment {
                         let (lock, cvar) = &*pausevar;
                         let mut guard = lock
                             .lock()
-                            .map_err(|e| EnvironmentError::Pause(format!("{:?}", e)))?;
+                            .map_err(|e| EnvironmentError::Pause(e.to_string()))?;
 
-                        // this logic here ensures we catch any edge case last transactions and send
-                        // the appropriate error so that we dont hang in
-                        // limbo forever
+                        // This logic here ensures we catch any last transactions and send
+                        // the appropriate error so that we dont hang on the `tx_receiver`
                         while let Ok((_, _, sender)) = tx_receiver.try_recv() {
-                            let error_outcome = TransactionOutcome::Error(EnvironmentError::Pause(
-                                "Environment is paused".into(),
-                            ));
-                            let revm_result = RevmResult {
-                                outcome: error_outcome,
-                                block_number: convert_uint_to_u64(evm.env.block.number).map_err(
-                                    |e| EnvironmentError::Conversion(format!("{:?}", e)),
-                                )?,
-                            };
                             sender
-                                .send(revm_result)
-                                .map_err(|e| EnvironmentError::Communication(format!("{:?}", e)))?;
+                                .send(Err(EnvironmentError::TransactionReceivedWhilePaused))
+                                .map_err(|e| EnvironmentError::Communication(e.to_string()))?;
                         }
 
                         while state.load(std::sync::atomic::Ordering::SeqCst) == State::Paused {
                             guard = cvar
                                 .wait(guard)
-                                .map_err(|e| EnvironmentError::Pause(format!("{:?}", e)))?;
+                                .map_err(|e| EnvironmentError::Pause(e.to_string()))?;
                         }
                     }
 
@@ -346,66 +342,24 @@ impl Environment {
                             // If the transaction is a state-changing transaction, `to_transact ==
                             // true` and the state will be written to the database via a
                             // `transact_commit()` Otherwise it must be
-                            // a read-only call, so we will not update the database
-                            // Calls will not have events to emit
-                            if to_transact {
-                                let execution_result = match evm.transact_commit() {
-                                    // Check for an error in execution ([`EVMError<Infallible>`]),
-                                    // but pass to the middleware to determine if the result is
-                                    // [`ExecutionResult::Success`], [`ExecutionResult::Revert`], or
-                                    // [`ExecutionResult::Halt`].
-                                    Ok(val) => val,
-                                    Err(e) => {
-                                        state.store(
-                                            State::Paused,
-                                            std::sync::atomic::Ordering::SeqCst,
-                                        );
-                                        error!("Pausing the environment labeled {} due to an execution error: {:#?}", label, e);
-                                        return Err(EnvironmentError::Execution(e));
-                                    }
-                                };
-                                let event_broadcaster = event_broadcaster.lock().map_err(|e| {
-                                    EnvironmentError::Communication(format!("{:?}", e))
-                                })?;
+                            // a read-only call, so we will not update the database.
+                            // Calls will not have events to emit.
+                            let execution_result = if to_transact {
+                                let execution_result =
+                                    evm.transact_commit().map_err(EnvironmentError::Execution)?;
+                                let event_broadcaster = event_broadcaster
+                                    .lock()
+                                    .map_err(|e| EnvironmentError::Communication(e.to_string()))?;
                                 event_broadcaster.broadcast(execution_result.logs())?;
-                                let revm_result = RevmResult {
-                                    outcome: TransactionOutcome::Success(execution_result),
-                                    block_number: convert_uint_to_u64(evm.env.block.number)
-                                        .map_err(|e| {
-                                            EnvironmentError::Conversion(format!("{:?}", e))
-                                        })?,
-                                };
-                                sender.send(revm_result).map_err(|e| {
-                                    EnvironmentError::Communication(format!("{:?}", e))
-                                })?;
                                 counter += 1;
+                                execution_result
                             } else {
-                                let result = match evm.transact() {
-                                    // Check for an error in execution ([`EVMError<Infallible>`]),
-                                    // but pass to the middleware to determine if the result is
-                                    // [`ExecutionResult::Success`], [`ExecutionResult::Revert`], or
-                                    // [`ExecutionResult::Halt`].
-                                    Ok(result_and_state) => result_and_state.result,
-                                    Err(e) => {
-                                        state.store(
-                                            State::Paused,
-                                            std::sync::atomic::Ordering::SeqCst,
-                                        );
-                                        error!("Pausing the environment labeled {} due to an execution error: {:#?}", label, e);
-                                        return Err(EnvironmentError::Execution(e));
-                                    }
-                                };
-                                let result_and_block = RevmResult {
-                                    outcome: TransactionOutcome::Success(result),
-                                    block_number: convert_uint_to_u64(evm.env.block.number)
-                                        .map_err(|e| {
-                                            EnvironmentError::Conversion(format!("{:?}", e))
-                                        })?,
-                                };
-                                sender.send(result_and_block).map_err(|e| {
-                                    EnvironmentError::Communication(format!("{:?}", e))
-                                })?;
-                            }
+                                evm.transact().map_err(EnvironmentError::Execution)?.result
+                            };
+                            let block_number = convert_uint_to_u64(evm.env.block.number)?;
+                            sender
+                                .send(Ok((execution_result, block_number)))
+                                .map_err(|e| EnvironmentError::Communication(e.to_string()))?;
                         }
                     }
                     State::Initialization => {
@@ -466,41 +420,6 @@ pub(crate) struct Socket {
     pub(crate) event_broadcaster: Arc<Mutex<EventBroadcaster>>,
 }
 
-/// Represents the possible outcomes of an EVM transaction.
-///
-/// This enum is used to encapsulate both successful transaction results and
-/// potential errors.
-/// - `Success`: Indicates that the transaction was executed successfully and
-///   contains the result of the execution. The wrapped `ExecutionResult`
-///   provides detailed information about the transaction's execution, such as
-///   returned values or changes made to the state.
-/// - `Error`: Indicates that the transaction failed due to some error
-///   condition. The wrapped `EnvironmentError` provides specifics about the
-///   error, allowing callers to take appropriate action or relay more
-///   informative error messages.
-#[derive(Debug, Clone)]
-pub(crate) enum TransactionOutcome {
-    /// Represents a successfully executed transaction.
-    ///
-    /// Contains the result of the transaction's execution.
-    Success(ExecutionResult),
-
-    /// Represents a failed transaction due to some error.
-    ///
-    /// Contains information about the error that caused the transaction
-    /// failure.
-    Error(EnvironmentError),
-}
-/// Represents the result of an EVM transaction.
-///
-/// Contains the outcome of a transaction (e.g., success, revert, halt) and the
-/// block number at which the transaction was executed.
-#[derive(Debug, Clone)]
-pub(crate) struct RevmResult {
-    pub(crate) outcome: TransactionOutcome,
-    pub(crate) block_number: U64,
-}
-
 /// Responsible for broadcasting Ethereum logs to subscribers.
 ///
 /// Maintains a list of senders to which logs are sent whenever they are
@@ -524,9 +443,7 @@ impl EventBroadcaster {
     /// downstream to any and all receivers
     fn broadcast(&self, logs: Vec<Log>) -> Result<(), EnvironmentError> {
         for sender in &self.0 {
-            sender
-                .send(logs.clone())
-                .map_err(|e| EnvironmentError::Communication(format!("{:?}", e)))?;
+            sender.send(logs.clone())?;
         }
         Ok(())
     }
@@ -539,11 +456,13 @@ impl EventBroadcaster {
 /// * `Ok(U64)` - The converted U64.
 /// Used for block number which is a U64.
 #[inline]
-fn convert_uint_to_u64(input: U256) -> Result<U64, &'static str> {
+fn convert_uint_to_u64(input: U256) -> Result<U64, EnvironmentError> {
     let as_str = input.to_string();
     match as_str.parse::<u64>() {
         Ok(val) => Ok(val.into()),
-        Err(_) => Err("U256 value is too large to fit into u64"),
+        Err(_) => Err(EnvironmentError::Conversion(
+            "U256 value is too large to fit into u64".to_string(),
+        )),
     }
 }
 

--- a/arbiter-core/src/manager.rs
+++ b/arbiter-core/src/manager.rs
@@ -107,13 +107,19 @@ impl Manager {
     /// # Examples
     ///
     /// ```rust
-    /// use arbiter_core::{environment::EnvironmentParameters, manager::Manager};
+    /// use arbiter_core::{
+    ///     environment::{BlockType, EnvironmentParameters},
+    ///     manager::Manager,
+    /// };
     ///
     /// let mut manager = Manager::new();
     /// let params = EnvironmentParameters {
     ///     label: "example_env".to_string(),
-    ///     block_rate: 1.0,
-    ///     seed: 1,
+    ///     block_type: BlockType::RandomlySampled {
+    ///         block_rate: 1.0,
+    ///         block_time: 12,
+    ///         seed: 1,
+    ///     },
     /// };
     /// manager.add_environment(params).unwrap();
     /// ```
@@ -155,13 +161,19 @@ impl Manager {
     /// # Examples
     ///
     /// ```rust
-    /// use arbiter_core::{environment::EnvironmentParameters, manager::Manager};
+    /// use arbiter_core::{
+    ///     environment::{BlockType, EnvironmentParameters},
+    ///     manager::Manager,
+    /// };
     ///
     /// let mut manager = Manager::new();
     /// let params = EnvironmentParameters {
     ///     label: "example_env".to_string(),
-    ///     block_rate: 1.0,
-    ///     seed: 1,
+    ///     block_type: BlockType::RandomlySampled {
+    ///         block_rate: 1.0,
+    ///         block_time: 12,
+    ///         seed: 1,
+    ///     },
     /// };
     /// manager.add_environment(params).unwrap();
     ///
@@ -231,13 +243,19 @@ impl Manager {
     /// # Examples
     ///
     /// ```rust
-    /// use arbiter_core::{environment::EnvironmentParameters, manager::Manager};
+    /// use arbiter_core::{
+    ///     environment::{BlockType, EnvironmentParameters},
+    ///     manager::Manager,
+    /// };
     ///
     /// let mut manager = Manager::new();
     /// let params = EnvironmentParameters {
     ///     label: "example_env".to_string(),
-    ///     block_rate: 1.0,
-    ///     seed: 1,
+    ///     block_type: BlockType::RandomlySampled {
+    ///         block_rate: 1.0,
+    ///         block_time: 12,
+    ///         seed: 1,
+    ///     },
     /// };
     /// manager.add_environment(params).unwrap();
     /// manager.start_environment("example_env").unwrap();
@@ -303,13 +321,19 @@ impl Manager {
     /// # Examples
     ///
     /// ```rust
-    /// use arbiter_core::{environment::EnvironmentParameters, manager::Manager};
+    /// use arbiter_core::{
+    ///     environment::{BlockType, EnvironmentParameters},
+    ///     manager::Manager,
+    /// };
     ///
     /// let mut manager = Manager::new();
     /// let params = EnvironmentParameters {
     ///     label: "example_env".to_string(),
-    ///     block_rate: 1.0,
-    ///     seed: 1,
+    ///     block_type: BlockType::RandomlySampled {
+    ///         block_rate: 1.0,
+    ///         block_time: 12,
+    ///         seed: 1,
+    ///     },
     /// };
     /// manager.add_environment(params).unwrap();
     /// manager.start_environment("example_env").unwrap();

--- a/arbiter-core/src/math.rs
+++ b/arbiter-core/src/math.rs
@@ -13,7 +13,7 @@
 //! ```
 //! # use arbiter_core::math::{SeededPoisson, float_to_wad, wad_to_float};
 //! // Using SeededPoisson
-//! let mut poisson = SeededPoisson::new(10.0, 12345);
+//! let mut poisson = SeededPoisson::new(10.0, 12, 12345);
 //! let random_value = poisson.sample();
 //! // Converting floating-point numbers to WAD representation and back
 //! let wad_val = float_to_wad(10.5);
@@ -51,6 +51,7 @@ pub struct SeededPoisson {
     /// Poisson distribution.
     pub distribution: Poisson,
 
+    /// Time step for the Poisson distribution.
     pub time_step: u32,
 
     /// Random number generator.

--- a/arbiter-core/src/math.rs
+++ b/arbiter-core/src/math.rs
@@ -50,6 +50,9 @@ pub use RustQuant::stochastics::*;
 pub struct SeededPoisson {
     /// Poisson distribution.
     pub distribution: Poisson,
+
+    pub time_step: u32,
+
     /// Random number generator.
     rng: StdRng,
 }
@@ -72,12 +75,16 @@ impl SeededPoisson {
     ///
     /// ```
     /// # use arbiter_core::math::SeededPoisson;
-    /// let poisson = SeededPoisson::new(10.0, 12345);
+    /// let poisson = SeededPoisson::new(10.0, 12, 12345);
     /// ```
-    pub fn new(rate_parameter: f64, seed: u64) -> Self {
+    pub fn new(rate_parameter: f64, time_step: u32, seed: u64) -> Self {
         let distribution = Poisson::new(rate_parameter).unwrap();
         let rng = StdRng::seed_from_u64(seed);
-        Self { distribution, rng }
+        Self {
+            distribution,
+            time_step,
+            rng,
+        }
     }
 
     /// Samples a single value from the Poisson distribution using the seeded
@@ -91,7 +98,7 @@ impl SeededPoisson {
     ///
     /// ```
     /// # use arbiter_core::math::SeededPoisson;
-    /// let mut poisson = SeededPoisson::new(10.0, 12345);
+    /// let mut poisson = SeededPoisson::new(10.0, 12, 12345);
     /// let random_value = poisson.sample();
     /// ```
     pub fn sample(&mut self) -> usize {
@@ -106,9 +113,9 @@ mod tests {
 
     #[test]
     fn seeded_poisson() {
-        let mut test_dist_1 = SeededPoisson::new(10.0, 321);
-        let mut test_dist_2 = SeededPoisson::new(10000.0, 123);
-        let mut test_dist_3 = SeededPoisson::new(10000.0, 123);
+        let mut test_dist_1 = SeededPoisson::new(10.0, 10, 321);
+        let mut test_dist_2 = SeededPoisson::new(10000.0, 11, 123);
+        let mut test_dist_3 = SeededPoisson::new(10000.0, 12, 123);
 
         let result_1 = test_dist_1.sample();
         let result_2 = test_dist_1.sample();

--- a/arbiter-core/src/middleware.rs
+++ b/arbiter-core/src/middleware.rs
@@ -45,9 +45,7 @@ use revm::primitives::{CreateScheme, ExecutionResult, Output, TransactTo, TxEnv,
 use serde::{de::DeserializeOwned, Serialize};
 use thiserror::Error;
 
-use crate::environment::{
-    Environment, EventBroadcaster, ResultReceiver, ResultSender, TransactionOutcome, TxSender,
-};
+use crate::environment::{Environment, EventBroadcaster, ResultReceiver, ResultSender, TxSender};
 
 /// A middleware structure that integrates with `revm`.
 ///

--- a/arbiter-core/src/middleware.rs
+++ b/arbiter-core/src/middleware.rs
@@ -104,6 +104,10 @@ pub struct RevmMiddleware {
 /// [GitHub](https://github.com/primitivefinance/arbiter/).
 #[derive(Error, Debug)]
 pub enum RevmMiddlewareError {
+    /// An error occurred while attempting to interact with the environment.
+    #[error("an error came from the environment! due to: {0}")]
+    Environment(#[from] crate::environment::EnvironmentError),
+
     /// An error occurred while attempting to send a transaction.
     #[error("failed to send transaction! due to: {0}")]
     Send(String),
@@ -111,7 +115,7 @@ pub enum RevmMiddlewareError {
     /// There was an issue receiving an [`ExecutionResult`], possibly from
     /// another service or module.
     #[error("failed to receive `ExecutionResult`! due to: {0}")]
-    Receive(String),
+    Receive(#[from] crossbeam_channel::RecvError),
 
     /// There was a failure trying to obtain a lock on the [`EventBroadcaster`],
     /// possibly due to concurrency issues.
@@ -302,52 +306,33 @@ impl Middleware for RevmMiddleware {
             ))
             .map_err(|e| RevmMiddlewareError::Send(e.to_string()))?;
 
-        let revm_result = self
-            .provider()
-            .as_ref()
-            .result_receiver
-            .recv()
-            .map_err(|e| RevmMiddlewareError::Receive(e.to_string()))?;
+        let (execution_result, block_number) =
+            self.provider().as_ref().result_receiver.recv()??;
 
-        match revm_result.outcome {
-            TransactionOutcome::Success(execution_result) => {
-                let Success {
-                    _reason: _,
-                    _gas_used: _,
-                    _gas_refunded: _,
-                    logs,
-                    output,
-                } = unpack_execution_result(execution_result)?;
+        let Success {
+            _reason: _,
+            _gas_used: _,
+            _gas_refunded: _,
+            logs,
+            output,
+        } = unpack_execution_result(execution_result)?;
 
-                match output {
-                    Output::Create(_, address) => {
-                        let address = address.ok_or(RevmMiddlewareError::MissingData(
-                            "Address missing in transaction!".to_string(),
-                        ))?;
-                        let mut pending_tx =
-                            PendingTransaction::new(ethers::types::H256::zero(), self.provider());
-                        pending_tx.state =
-                            PendingTxState::RevmDeployOutput(recast_address(address));
-                        return Ok(pending_tx);
-                    }
-                    Output::Call(_) => {
-                        let mut pending_tx =
-                            PendingTransaction::new(ethers::types::H256::zero(), self.provider());
-
-                        pending_tx.state =
-                            PendingTxState::RevmTransactOutput(logs, revm_result.block_number);
-                        return Ok(pending_tx);
-                    }
-                }
+        match output {
+            Output::Create(_, address) => {
+                let address = address.ok_or(RevmMiddlewareError::MissingData(
+                    "Address missing in transaction!".to_string(),
+                ))?;
+                let mut pending_tx =
+                    PendingTransaction::new(ethers::types::H256::zero(), self.provider());
+                pending_tx.state = PendingTxState::RevmDeployOutput(recast_address(address));
+                return Ok(pending_tx);
             }
-            TransactionOutcome::Error(err) => {
-                return Err(RevmMiddlewareError::Receive(
-                    format!(
-                        "Error recieving response from the environement with environment error: {}",
-                        err
-                    )
-                    .to_string(),
-                ));
+            Output::Call(_) => {
+                let mut pending_tx =
+                    PendingTransaction::new(ethers::types::H256::zero(), self.provider());
+
+                pending_tx.state = PendingTxState::RevmTransactOutput(logs, block_number);
+                return Ok(pending_tx);
             }
         }
     }
@@ -410,33 +395,16 @@ impl Middleware for RevmMiddleware {
                 self.provider().as_ref().result_sender.clone(),
             ))
             .map_err(|e| RevmMiddlewareError::Send(e.to_string()))?;
-        let revm_result = self
-            .provider()
-            .as_ref()
-            .result_receiver
-            .recv()
-            .map_err(|e| RevmMiddlewareError::Receive(e.to_string()))?;
+        let (execution_result, _block_number) =
+            self.provider().as_ref().result_receiver.recv()??;
 
-        match revm_result.outcome {
-            TransactionOutcome::Success(execution_result) => {
-                let output = unpack_execution_result(execution_result)?.output;
-                match output {
-                    Output::Create(bytes, ..) => {
-                        return Ok(Bytes::from(bytes.to_vec()));
-                    }
-                    Output::Call(bytes) => {
-                        return Ok(Bytes::from(bytes.to_vec()));
-                    }
-                }
+        let output = unpack_execution_result(execution_result)?.output;
+        match output {
+            Output::Create(bytes, ..) => {
+                return Ok(Bytes::from(bytes.to_vec()));
             }
-            TransactionOutcome::Error(err) => {
-                return Err(RevmMiddlewareError::Receive(
-                    format!(
-                        "Error recieving response from the environement with environment error: {}",
-                        err
-                    )
-                    .to_string(),
-                ));
+            Output::Call(bytes) => {
+                return Ok(Bytes::from(bytes.to_vec()));
             }
         }
     }

--- a/arbiter-core/src/middleware.rs
+++ b/arbiter-core/src/middleware.rs
@@ -39,7 +39,9 @@ use ethers::{
     },
 };
 use rand::rngs;
-use revm::primitives::{CreateScheme, ExecutionResult, Output, TransactTo, TxEnv, B160, U256};
+use revm::primitives::{
+    ruint::UintTryFrom, CreateScheme, ExecutionResult, Output, TransactTo, TxEnv, B160, U256,
+};
 use serde::{de::DeserializeOwned, Serialize};
 use thiserror::Error;
 
@@ -235,16 +237,18 @@ impl RevmMiddleware {
 
     pub fn update_block(
         &self,
-        block_number: U256,
-        block_timestamp: U256,
+        block_number: impl Into<ethers::types::U256>,
+        block_timestamp: impl Into<ethers::types::U256>,
     ) -> Result<(), RevmMiddlewareError> {
+        let block_number: ethers::types::U256 = block_number.into();
+        let block_timestamp: ethers::types::U256 = block_timestamp.into();
         let provider = self.provider.as_ref();
         provider.instruction_sender.send(Instruction::BlockUpdate {
-            block_number,
-            block_timestamp,
+            block_number: block_number.into(),
+            block_timestamp: block_timestamp.into(),
             outcome_sender: provider.outcome_sender.clone(),
         });
-        provider.outcome_receiver.recv()?;
+        provider.outcome_receiver.recv()??;
         Ok(())
     }
 }

--- a/arbiter-core/src/middleware.rs
+++ b/arbiter-core/src/middleware.rs
@@ -11,8 +11,6 @@
 
 #![warn(missing_docs, unsafe_code)]
 
-// TODO: Check the publicness of all structs and functions.
-
 use std::{
     collections::HashMap,
     fmt::Debug,
@@ -66,15 +64,20 @@ use crate::environment::{Environment, EventBroadcaster, ResultReceiver, ResultSe
 /// use std::sync::Arc;
 ///
 /// use arbiter_core::{
-///     environment::EnvironmentParameters, manager::Manager, middleware::RevmMiddleware,
+///     environment::{BlockType, EnvironmentParameters},
+///     manager::Manager,
+///     middleware::RevmMiddleware,
 /// };
 ///
 /// // Create a manager and add an environment
 /// let mut manager = Manager::new();
 /// let params = EnvironmentParameters {
 ///     label: "example_env".to_string(),
-///     block_rate: 1.0,
-///     seed: 1,
+///     block_type: BlockType::RandomlySampled {
+///         block_rate: 1.0,
+///         block_time: 12,
+///         seed: 1,
+///     },
 /// };
 /// manager.add_environment(params).unwrap();
 ///
@@ -177,14 +180,19 @@ impl RevmMiddleware {
     /// # Examples
     /// ```
     /// use arbiter_core::{
-    ///     environment::EnvironmentParameters, manager::Manager, middleware::RevmMiddleware,
+    ///     environment::{BlockType, EnvironmentParameters},
+    ///     manager::Manager,
+    ///     middleware::RevmMiddleware,
     /// };
     ///
     /// let mut manager = Manager::new();
     /// let params = EnvironmentParameters {
     ///     label: "example_env".to_string(),
-    ///     block_rate: 1.0,
-    ///     seed: 1,
+    ///     block_type: BlockType::RandomlySampled {
+    ///         block_rate: 1.0,
+    ///         block_time: 12,
+    ///         seed: 1,
+    ///     },
     /// };
     /// manager.add_environment(params).unwrap();
     /// let environment = manager.environments.get("example_env").unwrap();

--- a/arbiter-core/src/tests/contracts.rs
+++ b/arbiter-core/src/tests/contracts.rs
@@ -1,49 +1,18 @@
 // TODO: Hit all the contract bindings.
 
 use super::*;
-use crate::bindings::liquid_exchange::LiquidExchange;
-
-pub const ARBITER_TOKEN_X_NAME: &str = "Arbiter Token X";
-pub const ARBITER_TOKEN_X_SYMBOL: &str = "ARBX";
-pub const ARBITER_TOKEN_X_DECIMALS: u8 = 18;
-
-pub const ARBITER_TOKEN_Y_NAME: &str = "Arbiter Token Y";
-pub const ARBITER_TOKEN_Y_SYMBOL: &str = "ARBY";
-pub const ARBITER_TOKEN_Y_DECIMALS: u8 = 18;
-
-pub const LIQUID_EXCHANGE_PRICE: f64 = 420.69;
-
-fn startup() -> Result<(Manager, Arc<RevmMiddleware>)> {
-    let mut manager = Manager::new();
-    let params = EnvironmentParameters {
-        label: TEST_ENV_LABEL.to_string(),
-        block_rate: 1.0,
-        seed: 1,
-    };
-    manager.add_environment(params).unwrap();
-    let environment = manager.environments.get(TEST_ENV_LABEL).unwrap();
-    let client = Arc::new(RevmMiddleware::new(
-        environment,
-        Some(TEST_SIGNER_SEED_AND_LABEL.to_string()),
-    ));
-    manager.start_environment(TEST_ENV_LABEL)?;
-    Ok((manager, client))
-}
-
-async fn deploy_arbiter_math(client: Arc<RevmMiddleware>) -> Result<ArbiterMath<RevmMiddleware>> {
-    Ok(ArbiterMath::deploy(client, ())?.send().await?)
-}
 
 #[tokio::test]
-async fn arbiter_math() -> Result<()> {
-    let (_manager, client) = startup()?;
-    let arbiter_math = deploy_arbiter_math(client).await?;
+async fn arbiter_math() {
+    let (_manager, client) = startup().unwrap();
+    let arbiter_math = deploy_arbiter_math(client).await.unwrap();
 
     // Test the cdf function
     let cdf_output = arbiter_math
         .cdf(ethers::types::I256::from(1))
         .call()
-        .await?;
+        .await
+        .unwrap();
     println!("cdf(1) = {}", cdf_output);
     assert_eq!(cdf_output, ethers::types::I256::from(500000000000000000u64));
 
@@ -51,7 +20,8 @@ async fn arbiter_math() -> Result<()> {
     let pdf_output = arbiter_math
         .pdf(ethers::types::I256::from(1))
         .call()
-        .await?;
+        .await
+        .unwrap();
     println!("pdf(1) = {}", pdf_output);
     assert_eq!(pdf_output, ethers::types::I256::from(398942280401432678u64));
 
@@ -59,7 +29,8 @@ async fn arbiter_math() -> Result<()> {
     let ppf_output = arbiter_math
         .ppf(ethers::types::I256::from(1))
         .call()
-        .await?;
+        .await
+        .unwrap();
     println!("ppf(1) = {}", ppf_output);
     assert_eq!(
         ppf_output,
@@ -73,7 +44,8 @@ async fn arbiter_math() -> Result<()> {
             ethers::types::U256::from(2),
         )
         .call()
-        .await?;
+        .await
+        .unwrap();
     println!("mulWadDown(1, 2) = {}", mulwaddown_output);
     assert_eq!(mulwaddown_output, ethers::types::U256::from(2));
 
@@ -84,7 +56,8 @@ async fn arbiter_math() -> Result<()> {
             ethers::types::U256::from(2),
         )
         .call()
-        .await?;
+        .await
+        .unwrap();
     println!("mulWadUp(1, 2) = {}", mulwadup_output);
     assert_eq!(mulwadup_output, ethers::types::U256::from(2));
 
@@ -95,7 +68,8 @@ async fn arbiter_math() -> Result<()> {
             ethers::types::U256::from(2),
         )
         .call()
-        .await?;
+        .await
+        .unwrap();
     println!("divWadDown(1, 2) = {}", divwaddown_output);
     assert_eq!(
         divwaddown_output,
@@ -109,7 +83,8 @@ async fn arbiter_math() -> Result<()> {
             ethers::types::U256::from(2),
         )
         .call()
-        .await?;
+        .await
+        .unwrap();
     println!("divWadUp(1, 2) = {}", divwadup_output);
     assert_eq!(
         divwadup_output,
@@ -120,7 +95,8 @@ async fn arbiter_math() -> Result<()> {
     let lnwad_output = arbiter_math
         .log(ethers::types::I256::from(1_000_000_000_000_000_000_u128))
         .call()
-        .await?;
+        .await
+        .unwrap();
     println!("ln(1) = {}", lnwad_output);
     assert_eq!(lnwad_output, ethers::types::I256::from(0));
 
@@ -128,44 +104,18 @@ async fn arbiter_math() -> Result<()> {
     let sqrt_output = arbiter_math
         .sqrt(ethers::types::U256::from(1_000_000_000_000_000_000_u128))
         .call()
-        .await?;
+        .await
+        .unwrap();
     println!("sqrt(1) = {}", sqrt_output);
     assert_eq!(sqrt_output, ethers::types::U256::from(1_000_000_000));
-    Ok(())
-}
-
-async fn deploy_arbx(client: Arc<RevmMiddleware>) -> Result<ArbiterToken<RevmMiddleware>> {
-    Ok(ArbiterToken::deploy(
-        client,
-        (
-            ARBITER_TOKEN_X_NAME.to_string(),
-            ARBITER_TOKEN_X_SYMBOL.to_string(),
-            ARBITER_TOKEN_X_DECIMALS,
-        ),
-    )?
-    .send()
-    .await?)
-}
-
-async fn deploy_arby(client: Arc<RevmMiddleware>) -> Result<ArbiterToken<RevmMiddleware>> {
-    Ok(ArbiterToken::deploy(
-        client,
-        (
-            ARBITER_TOKEN_Y_NAME.to_string(),
-            ARBITER_TOKEN_Y_SYMBOL.to_string(),
-            ARBITER_TOKEN_Y_DECIMALS,
-        ),
-    )?
-    .send()
-    .await?)
 }
 
 // TODO: It would be good to change this to `token_functions` and test all
 // relevant ERC20 functions (e.g., transfer, approve, etc.).
 #[tokio::test]
-async fn token_mint_and_balance() -> Result<()> {
-    let (_manager, client) = startup()?;
-    let arbx = deploy_arbx(client.clone()).await?;
+async fn token_mint_and_balance() {
+    let (_manager, client) = startup().unwrap();
+    let arbx = deploy_arbx(client.clone()).await.unwrap();
 
     // Mint some tokens to the client.
     arbx.mint(
@@ -173,41 +123,26 @@ async fn token_mint_and_balance() -> Result<()> {
         ethers::types::U256::from(TEST_MINT_AMOUNT),
     )
     .send()
-    .await?
-    .await?;
+    .await
+    .unwrap()
+    .await
+    .unwrap();
 
     // Fetch the balance of the client.
     let balance = arbx
         .balance_of(client.default_sender().unwrap())
         .call()
-        .await?;
+        .await
+        .unwrap();
 
     // Check that the balance is correct.
     assert_eq!(balance, ethers::types::U256::from(TEST_MINT_AMOUNT));
-
-    Ok(())
-}
-
-async fn deploy_liquid_exchange(
-    client: Arc<RevmMiddleware>,
-) -> Result<(
-    ArbiterToken<RevmMiddleware>,
-    ArbiterToken<RevmMiddleware>,
-    LiquidExchange<RevmMiddleware>,
-)> {
-    let arbx = deploy_arbx(client.clone()).await?;
-    let arby = deploy_arby(client.clone()).await?;
-    let price = float_to_wad(LIQUID_EXCHANGE_PRICE);
-    let liquid_exchange = LiquidExchange::deploy(client, (arbx.address(), arby.address(), price))?
-        .send()
-        .await?;
-    Ok((arbx, arby, liquid_exchange))
 }
 
 #[tokio::test]
-async fn liquid_exchange_swap() -> Result<()> {
-    let (_manager, client) = startup()?;
-    let (arbx, arby, liquid_exchange) = deploy_liquid_exchange(client.clone()).await?;
+async fn liquid_exchange_swap() {
+    let (_manager, client) = startup().unwrap();
+    let (arbx, arby, liquid_exchange) = deploy_liquid_exchange(client.clone()).await.unwrap();
 
     // Mint tokens to the client then check balances.
     arbx.mint(
@@ -215,71 +150,89 @@ async fn liquid_exchange_swap() -> Result<()> {
         ethers::types::U256::from(TEST_MINT_AMOUNT),
     )
     .send()
-    .await?
-    .await?;
+    .await
+    .unwrap()
+    .await
+    .unwrap();
     arby.mint(
         client.default_sender().unwrap(),
         ethers::types::U256::from(TEST_MINT_AMOUNT),
     )
     .send()
-    .await?
-    .await?;
+    .await
+    .unwrap()
+    .await
+    .unwrap();
     let arbx_balance = arbx
         .balance_of(client.default_sender().unwrap())
         .call()
-        .await?;
+        .await
+        .unwrap();
     let arby_balance = arby
         .balance_of(client.default_sender().unwrap())
         .call()
-        .await?;
+        .await
+        .unwrap();
     println!("arbx_balance prior to swap = {}", arbx_balance);
     println!("arby_balance prior to swap = {}", arby_balance);
     assert_eq!(arbx_balance, ethers::types::U256::from(TEST_MINT_AMOUNT));
     assert_eq!(arby_balance, ethers::types::U256::from(TEST_MINT_AMOUNT));
 
     // Get the price at the liquid exchange
-    let price = liquid_exchange.price().call().await?;
+    let price = liquid_exchange.price().call().await.unwrap();
     println!("price in 18 decimal WAD: {}", price);
 
     // Mint tokens to the liquid exchange.
     let exchange_mint_amount = ethers::types::U256::MAX / 2;
     arbx.mint(liquid_exchange.address(), exchange_mint_amount)
         .send()
-        .await?
-        .await?;
+        .await
+        .unwrap()
+        .await
+        .unwrap();
     arby.mint(liquid_exchange.address(), exchange_mint_amount)
         .send()
-        .await?
-        .await?;
+        .await
+        .unwrap()
+        .await
+        .unwrap();
 
     // Approve the liquid exchange to spend the client's tokens.
     arbx.approve(liquid_exchange.address(), ethers::types::U256::MAX)
         .send()
-        .await?
-        .await?;
+        .await
+        .unwrap()
+        .await
+        .unwrap();
     arby.approve(liquid_exchange.address(), ethers::types::U256::MAX)
         .send()
-        .await?
-        .await?;
+        .await
+        .unwrap()
+        .await
+        .unwrap();
 
     // Swap some X for Y on the liquid exchange.
     let swap_amount_x = ethers::types::U256::from(TEST_MINT_AMOUNT) / 2;
     liquid_exchange
         .swap(arbx.address(), swap_amount_x)
         .send()
-        .await?
-        .await?
+        .await
+        .unwrap()
+        .await
+        .unwrap()
         .unwrap();
 
     // Check the client's balances are correct.
     let arbx_balance_after_swap_x = arbx
         .balance_of(client.default_sender().unwrap())
         .call()
-        .await?;
+        .await
+        .unwrap();
     let arby_balance_after_swap_x = arby
         .balance_of(client.default_sender().unwrap())
         .call()
-        .await?;
+        .await
+        .unwrap();
     println!("arbx_balance after swap = {}", arbx_balance_after_swap_x);
     println!("arby_balance after swap = {}", arby_balance_after_swap_x);
     assert_eq!(
@@ -297,18 +250,22 @@ async fn liquid_exchange_swap() -> Result<()> {
     liquid_exchange
         .swap(arby.address(), swap_amount_y)
         .send()
-        .await?
-        .await?;
+        .await
+        .unwrap()
+        .await
+        .unwrap();
 
     // Check the client's balances are correct.
     let arbx_balance_after_swap_y = arbx
         .balance_of(client.default_sender().unwrap())
         .call()
-        .await?;
+        .await
+        .unwrap();
     let arby_balance_after_swap_y = arby
         .balance_of(client.default_sender().unwrap())
         .call()
-        .await?;
+        .await
+        .unwrap();
     println!("arbx_balance after swap = {}", arbx_balance_after_swap_y);
     println!("arby_balance after swap = {}", arby_balance_after_swap_y);
 
@@ -322,29 +279,31 @@ async fn liquid_exchange_swap() -> Result<()> {
         arby_balance_after_swap_y,
         ethers::types::U256::from(TEST_MINT_AMOUNT)
     );
-
-    Ok(())
 }
 
 #[tokio::test]
-async fn price_simulation_oracle() -> Result<()> {
-    let (_manager, client) = startup()?;
-    let (.., liquid_exchange) = deploy_liquid_exchange(client.clone()).await?;
+async fn price_simulation_oracle() {
+    let (_manager, client) = startup().unwrap();
+    let (.., liquid_exchange) = deploy_liquid_exchange(client.clone()).await.unwrap();
 
     let price_path = vec![
         1000.0, 2000.0, 3000.0, 4000.0, 5000.0, 6000.0, 7000.0, 8000.0,
     ];
 
     // Get the initial price of the liquid exchange.
-    let initial_price = liquid_exchange.price().call().await?;
+    let initial_price = liquid_exchange.price().call().await.unwrap();
     assert_eq!(initial_price, float_to_wad(LIQUID_EXCHANGE_PRICE));
 
     for price in price_path {
         let wad_price = float_to_wad(price);
-        liquid_exchange.set_price(wad_price).send().await?.await?;
-        let new_price = liquid_exchange.price().call().await?;
+        liquid_exchange
+            .set_price(wad_price)
+            .send()
+            .await
+            .unwrap()
+            .await
+            .unwrap();
+        let new_price = liquid_exchange.price().call().await.unwrap();
         assert_eq!(new_price, wad_price);
     }
-
-    Ok(())
 }

--- a/arbiter-core/src/tests/contracts.rs
+++ b/arbiter-core/src/tests/contracts.rs
@@ -4,7 +4,7 @@ use super::*;
 
 #[tokio::test]
 async fn arbiter_math() {
-    let (_manager, client) = startup().unwrap();
+    let (_manager, client) = startup_randomly_sampled().unwrap();
     let arbiter_math = deploy_arbiter_math(client).await.unwrap();
 
     // Test the cdf function
@@ -114,7 +114,7 @@ async fn arbiter_math() {
 // relevant ERC20 functions (e.g., transfer, approve, etc.).
 #[tokio::test]
 async fn token_mint_and_balance() {
-    let (_manager, client) = startup().unwrap();
+    let (_manager, client) = startup_randomly_sampled().unwrap();
     let arbx = deploy_arbx(client.clone()).await.unwrap();
 
     // Mint some tokens to the client.
@@ -141,7 +141,7 @@ async fn token_mint_and_balance() {
 
 #[tokio::test]
 async fn liquid_exchange_swap() {
-    let (_manager, client) = startup().unwrap();
+    let (_manager, client) = startup_randomly_sampled().unwrap();
     let (arbx, arby, liquid_exchange) = deploy_liquid_exchange(client.clone()).await.unwrap();
 
     // Mint tokens to the client then check balances.
@@ -283,7 +283,7 @@ async fn liquid_exchange_swap() {
 
 #[tokio::test]
 async fn price_simulation_oracle() {
-    let (_manager, client) = startup().unwrap();
+    let (_manager, client) = startup_randomly_sampled().unwrap();
     let (.., liquid_exchange) = deploy_liquid_exchange(client.clone()).await.unwrap();
 
     let price_path = vec![

--- a/arbiter-core/src/tests/interaction.rs
+++ b/arbiter-core/src/tests/interaction.rs
@@ -3,44 +3,44 @@ use std::{
     task::{Context, Poll},
 };
 
-use anyhow::Ok;
 use assert_matches::assert_matches;
-use futures::stream::Stream;
+use futures::{Stream, StreamExt};
 
 use super::*;
 use crate::bindings::arbiter_math::ArbiterMath;
 
 #[tokio::test]
-async fn deploy() -> Result<()> {
-    let (arbiter_token, _environment, _) = deploy_and_start().await?;
+async fn deploy() {
+    let (_manager, client) = startup().unwrap();
+    let arbiter_token = deploy_arbx(client).await.unwrap();
     println!("{:?}", arbiter_token);
     assert_eq!(
         arbiter_token.address(),
         Address::from_str("0x067ea9e44c76a2620f10b39a1b51d5124a299192").unwrap()
     );
-    Ok(())
 }
 
 #[tokio::test]
-async fn call() -> Result<()> {
-    let (arbiter_token, _, _client) = deploy_and_start().await?;
+async fn call() {
+    let (_manager, client) = startup().unwrap();
+    let arbiter_token = deploy_arbx(client).await.unwrap();
     let admin = arbiter_token.admin();
-    let output = admin.call().await?;
+    let output = admin.call().await.unwrap();
     assert_eq!(
         output,
-        Address::from_str("0x2efdc9eecfee3a776209fcb8e9a83a6b221d74f5")?
+        Address::from_str("0x2efdc9eecfee3a776209fcb8e9a83a6b221d74f5").unwrap()
     );
-    Ok(())
 }
 
 #[tokio::test]
-async fn transact() -> Result<()> {
-    let (arbiter_token, _, _) = deploy_and_start().await?;
+async fn transact() {
+    let (_manager, client) = startup().unwrap();
+    let arbiter_token = deploy_arbx(client).await.unwrap();
     let mint = arbiter_token.mint(
         Address::from_str(TEST_MINT_TO).unwrap(),
         ethers::types::U256::from(TEST_MINT_AMOUNT),
     );
-    let receipt = mint.send().await?.await?.unwrap();
+    let receipt = mint.send().await.unwrap().await.unwrap().unwrap();
     assert_eq!(receipt.logs[0].address, arbiter_token.address());
     let topics = vec![
         ethers::core::types::H256::from_str(
@@ -57,35 +57,37 @@ async fn transact() -> Result<()> {
         .unwrap(),
     ];
     assert_eq!(receipt.logs[0].topics, topics);
-    let bytes = hex::decode("0000000000000000000000000000000000000000000000000000000000000045")?;
+    let bytes =
+        hex::decode("0000000000000000000000000000000000000000000000000000000000000045").unwrap();
     assert_eq!(
         receipt.logs[0].data,
         ethers::core::types::Bytes::from(bytes)
     );
     println!("logs are: {:#?}", receipt.logs);
-    Ok(())
 }
 
 #[tokio::test]
-async fn filter_id() -> Result<()> {
-    let (arbiter_token, _environment, client) = deploy_and_start().await.unwrap();
-    let filter_watcher_1 = client.watch(&Filter::default()).await?;
+async fn filter_id() {
+    let (_manager, client) = startup().unwrap();
+    let arbiter_token = deploy_arbx(client.clone()).await.unwrap();
+    let filter_watcher_1 = client.watch(&Filter::default()).await.unwrap();
     let filter_watcher_2 = client
         .watch(&Filter::new().address(arbiter_token.address()))
-        .await?;
+        .await
+        .unwrap();
     assert_ne!(filter_watcher_1.id, filter_watcher_2.id);
-    Ok(())
 }
 
 #[tokio::test]
-async fn filter_watcher() -> Result<()> {
-    let (arbiter_token, _environment, client) = deploy_and_start().await.unwrap();
-    let mut filter_watcher = client.watch(&Filter::default()).await?;
+async fn filter_watcher() {
+    let (_manager, client) = startup().unwrap();
+    let arbiter_token = deploy_arbx(client.clone()).await.unwrap();
+    let mut filter_watcher = client.watch(&Filter::default()).await.unwrap();
     let approval = arbiter_token.approve(
         client.default_sender().unwrap(),
         ethers::types::U256::from(TEST_APPROVAL_AMOUNT),
     );
-    approval.send().await?.await?;
+    approval.send().await.unwrap().await.unwrap();
     let event = filter_watcher.next().await.unwrap();
     assert_eq!(event.address, arbiter_token.address());
     // Check that the only populated topic from the approval_filter is correct
@@ -118,24 +120,25 @@ async fn filter_watcher() -> Result<()> {
         approval_filter_output.amount,
         ethers::types::U256::from(TEST_APPROVAL_AMOUNT)
     );
-    Ok(())
 }
 
 #[tokio::test]
-async fn filter_address() -> Result<()> {
-    let (arbiter_token, _environment, client) = deploy_and_start().await.unwrap();
+async fn filter_address() {
+    let (_manager, client) = startup().unwrap();
+    let arbiter_token = deploy_arbx(client.clone()).await.unwrap();
 
-    let mut default_watcher = client.watch(&Filter::default()).await?;
+    let mut default_watcher = client.watch(&Filter::default()).await.unwrap();
     let mut address_watcher = client
         .watch(&Filter::new().address(arbiter_token.address()))
-        .await?;
+        .await
+        .unwrap();
 
     // Check that both watchers get this event
     let approval = arbiter_token.approve(
         client.default_sender().unwrap(),
         ethers::types::U256::from(TEST_APPROVAL_AMOUNT),
     );
-    approval.send().await?.await?;
+    approval.send().await.unwrap().await.unwrap();
     let default_watcher_event = default_watcher.next().await.unwrap();
     let address_watcher_event = address_watcher.next().await.unwrap();
     assert!(!default_watcher_event.data.is_empty());
@@ -152,9 +155,11 @@ async fn filter_address() -> Result<()> {
             format!("new_{}", TEST_ARG_SYMBOL),
             TEST_ARG_DECIMALS,
         ),
-    )?
+    )
+    .unwrap()
     .send()
-    .await?;
+    .await
+    .unwrap();
 
     // Sanity check that tokens have different addresses
     assert_ne!(arbiter_token.address(), arbiter_token2.address());
@@ -163,7 +168,7 @@ async fn filter_address() -> Result<()> {
         client.default_sender().unwrap(),
         ethers::types::U256::from(TEST_APPROVAL_AMOUNT),
     );
-    approval.send().await?.await?;
+    approval.send().await.unwrap().await.unwrap();
 
     // get the next event with the default_watcher
     let event_two = default_watcher.next().await.unwrap();
@@ -178,23 +183,25 @@ async fn filter_address() -> Result<()> {
         Poll::Pending => println!("No event ready yet, as expected."),
     }
     assert_matches!(poll_result, Poll::Pending);
-    Ok(())
 }
 
 #[tokio::test]
-async fn filter_topics() -> Result<()> {
-    let (arbiter_token, _environment, client) = deploy_and_start().await.unwrap();
-    let mut default_watcher = client.watch(&Filter::default()).await?;
+async fn filter_topics() {
+    let (_manager, client) = startup().unwrap();
+    let arbiter_token = deploy_arbx(client.clone()).await.unwrap();
+
+    let mut default_watcher = client.watch(&Filter::default()).await.unwrap();
     let mut approval_watcher = client
         .watch(&arbiter_token.approval_filter().filter)
-        .await?;
+        .await
+        .unwrap();
 
     // Check that both watchers get this event
     let approval = arbiter_token.approve(
         client.default_sender().unwrap(),
         ethers::types::U256::from(TEST_APPROVAL_AMOUNT),
     );
-    approval.send().await?.await?;
+    approval.send().await.unwrap().await.unwrap();
     let default_watcher_event = default_watcher.next().await.unwrap();
     let approval_watcher_event = approval_watcher.next().await.unwrap();
     assert!(!default_watcher_event.data.is_empty());
@@ -203,10 +210,10 @@ async fn filter_topics() -> Result<()> {
 
     // Check that only the default watcher gets this event
     let mint = arbiter_token.mint(
-        ethers::types::H160::from_str(TEST_MINT_TO)?,
+        ethers::types::H160::from_str(TEST_MINT_TO).unwrap(),
         ethers::types::U256::from(TEST_MINT_AMOUNT),
     );
-    mint.send().await?.await?;
+    mint.send().await.unwrap().await.unwrap();
     let default_watcher_event = default_watcher.next().await.unwrap();
     assert!(!default_watcher_event.data.is_empty());
 
@@ -219,7 +226,6 @@ async fn filter_topics() -> Result<()> {
         Poll::Pending => println!("No event ready yet, as expected."),
     }
     assert_matches!(poll_result, Poll::Pending);
-    Ok(())
 }
 
 // This test has two parts
@@ -227,12 +233,23 @@ async fn filter_topics() -> Result<()> {
 // number of transactions per block. 2 check the block number is incremented
 // after the expected number of transactions is reached.
 #[tokio::test]
-async fn transaction_loop() -> Result<()> {
+async fn transaction_loop() {
+    let (manager, client) = startup().unwrap();
     // tx_0 is the transaction that creates the token contract
-    let (arbiter_token, env, client) = deploy_and_start().await?;
+    let arbiter_token = deploy_arbx(client.clone()).await.unwrap();
 
-    let mut dist = env.seeded_poisson.clone();
-    let expected_tx_per_block = dist.sample();
+    // get the environment so we can look at its distribution
+    let environment = manager.environments.get(TEST_ENV_LABEL).unwrap();
+
+    let mut distribution = match environment.parameters.block_type {
+        BlockType::RandomlySampled {
+            block_rate,
+            block_time,
+            seed,
+        } => SeededPoisson::new(block_rate, block_time, seed),
+        _ => panic!("Expected RandomlySampled block type"),
+    };
+    let expected_tx_per_block = distribution.sample();
     println!("expected_tx_per_block: {}", expected_tx_per_block);
 
     for index in 1..expected_tx_per_block + 1 {
@@ -257,25 +274,11 @@ async fn transaction_loop() -> Result<()> {
             assert_eq!(block_number, U64::from(1));
         }
     }
-    Ok(())
 }
 
 #[tokio::test]
 async fn pause_prevents_processing_transactions() {
-    let mut manager = Manager::new();
-    let params = EnvironmentParameters {
-        label: TEST_ENV_LABEL.to_string(),
-        block_rate: 1.0,
-        seed: 1,
-    };
-    manager.add_environment(params).unwrap();
-    let client = Arc::new(RevmMiddleware::new(
-        manager.environments.get(TEST_ENV_LABEL).unwrap(),
-        Some(TEST_SIGNER_SEED_AND_LABEL.to_string()),
-    ));
-
-    // Start environment
-    manager.start_environment(TEST_ENV_LABEL).unwrap();
+    let (mut manager, client) = startup().unwrap();
 
     // Send a tx and check it works (it should)
     let arbiter_math_1 = ArbiterMath::deploy(client.clone(), ())

--- a/arbiter-core/src/tests/management.rs
+++ b/arbiter-core/src/tests/management.rs
@@ -28,7 +28,7 @@ fn add_environment() {
 
 #[test_log::test]
 fn run_environment() {
-    let (manager, _client) = startup().unwrap();
+    let (manager, _client) = startup_randomly_sampled().unwrap();
     assert_eq!(
         manager
             .environments
@@ -42,7 +42,7 @@ fn run_environment() {
 
 #[test_log::test]
 fn pause_environment() {
-    let (mut manager, _client) = startup().unwrap();
+    let (mut manager, _client) = startup_randomly_sampled().unwrap();
 
     manager.pause_environment(TEST_ENV_LABEL).unwrap();
     std::thread::sleep(std::time::Duration::from_millis(100));
@@ -70,7 +70,7 @@ fn pause_environment() {
 
 #[test_log::test]
 fn stop_environment() {
-    let (mut manager, _client) = startup().unwrap();
+    let (mut manager, _client) = startup_randomly_sampled().unwrap();
 
     manager.stop_environment(TEST_ENV_LABEL).unwrap();
     assert_eq!(
@@ -86,7 +86,7 @@ fn stop_environment() {
 
 #[tokio::test]
 async fn stop_environment_after_transactions() {
-    let (mut manager, client) = startup().unwrap();
+    let (mut manager, client) = startup_randomly_sampled().unwrap();
     ArbiterMath::deploy(client, ())
         .unwrap()
         .send()

--- a/arbiter-core/src/tests/management.rs
+++ b/arbiter-core/src/tests/management.rs
@@ -5,8 +5,11 @@ fn add_environment() {
     let mut manager = Manager::new();
     let params = EnvironmentParameters {
         label: TEST_ENV_LABEL.to_string(),
-        block_rate: 1.0,
-        seed: 1,
+        block_type: BlockType::RandomlySampled {
+            block_rate: TEST_BLOCK_RATE,
+            block_time: TEST_BLOCK_TIME,
+            seed: TEST_ENV_SEED,
+        },
     };
     manager.add_environment(params).unwrap();
     assert!(manager
@@ -25,14 +28,7 @@ fn add_environment() {
 
 #[test_log::test]
 fn run_environment() {
-    let mut manager = Manager::new();
-    let params = EnvironmentParameters {
-        label: TEST_ENV_LABEL.to_string(),
-        block_rate: 1.0,
-        seed: 1,
-    };
-    manager.add_environment(params).unwrap();
-    manager.start_environment(TEST_ENV_LABEL).unwrap();
+    let (manager, _client) = startup().unwrap();
     assert_eq!(
         manager
             .environments
@@ -46,14 +42,8 @@ fn run_environment() {
 
 #[test_log::test]
 fn pause_environment() {
-    let mut manager = Manager::new();
-    let params = EnvironmentParameters {
-        label: TEST_ENV_LABEL.to_string(),
-        block_rate: 1.0,
-        seed: 1,
-    };
-    manager.add_environment(params).unwrap();
-    manager.start_environment(TEST_ENV_LABEL).unwrap();
+    let (mut manager, _client) = startup().unwrap();
+
     manager.pause_environment(TEST_ENV_LABEL).unwrap();
     std::thread::sleep(std::time::Duration::from_millis(100));
     assert_eq!(
@@ -80,14 +70,8 @@ fn pause_environment() {
 
 #[test_log::test]
 fn stop_environment() {
-    let mut manager = Manager::new();
-    let params = EnvironmentParameters {
-        label: TEST_ENV_LABEL.to_string(),
-        block_rate: 1.0,
-        seed: 1,
-    };
-    manager.add_environment(params).unwrap();
-    manager.start_environment(TEST_ENV_LABEL).unwrap();
+    let (mut manager, _client) = startup().unwrap();
+
     manager.stop_environment(TEST_ENV_LABEL).unwrap();
     assert_eq!(
         manager
@@ -101,23 +85,13 @@ fn stop_environment() {
 }
 
 #[tokio::test]
-async fn stop_environment_after_transactions() -> Result<()> {
-    let mut manager = Manager::new();
-    let params = EnvironmentParameters {
-        label: TEST_ENV_LABEL.to_string(),
-        block_rate: 1.0,
-        seed: 1,
-    };
-    manager.add_environment(params).unwrap();
-    manager.start_environment(TEST_ENV_LABEL).unwrap();
-
-    // Send some transactions (e.g., deploy `ArbiterMath` which is easy and has no
-    // args)
-    let client = Arc::new(RevmMiddleware::new(
-        manager.environments.get(TEST_ENV_LABEL).unwrap(),
-        Some(TEST_SIGNER_SEED_AND_LABEL.to_string()),
-    ));
-    ArbiterMath::deploy(client, ())?.send().await?;
+async fn stop_environment_after_transactions() {
+    let (mut manager, client) = startup().unwrap();
+    ArbiterMath::deploy(client, ())
+        .unwrap()
+        .send()
+        .await
+        .unwrap();
 
     manager.stop_environment(TEST_ENV_LABEL).unwrap();
     assert_eq!(
@@ -129,5 +103,4 @@ async fn stop_environment_after_transactions() -> Result<()> {
             .load(std::sync::atomic::Ordering::Relaxed),
         State::Stopped
     );
-    Ok(())
 }

--- a/arbiter-core/src/tests/mod.rs
+++ b/arbiter-core/src/tests/mod.rs
@@ -47,7 +47,7 @@ pub const ARBITER_TOKEN_Y_DECIMALS: u8 = 18;
 
 pub const LIQUID_EXCHANGE_PRICE: f64 = 420.69;
 
-fn startup() -> Result<(Manager, Arc<RevmMiddleware>)> {
+fn startup_randomly_sampled() -> Result<(Manager, Arc<RevmMiddleware>)> {
     let mut manager = Manager::new();
     let params = EnvironmentParameters {
         label: TEST_ENV_LABEL.to_string(),
@@ -56,6 +56,22 @@ fn startup() -> Result<(Manager, Arc<RevmMiddleware>)> {
             block_time: TEST_BLOCK_TIME,
             seed: TEST_ENV_SEED,
         },
+    };
+    manager.add_environment(params).unwrap();
+    let environment = manager.environments.get(TEST_ENV_LABEL).unwrap();
+    let client = Arc::new(RevmMiddleware::new(
+        environment,
+        Some(TEST_SIGNER_SEED_AND_LABEL.to_string()),
+    ));
+    manager.start_environment(TEST_ENV_LABEL)?;
+    Ok((manager, client))
+}
+
+fn startup_user_controlled() -> Result<(Manager, Arc<RevmMiddleware>)> {
+    let mut manager = Manager::new();
+    let params = EnvironmentParameters {
+        label: TEST_ENV_LABEL.to_string(),
+        block_type: BlockType::UserControlled,
     };
     manager.add_environment(params).unwrap();
     let environment = manager.environments.get(TEST_ENV_LABEL).unwrap();

--- a/arbiter-core/src/tests/signer.rs
+++ b/arbiter-core/src/tests/signer.rs
@@ -4,7 +4,7 @@ use super::*;
 
 #[test]
 fn simulation_signer() -> Result<()> {
-    let (_manager, client) = startup()?;
+    let (_manager, client) = startup_randomly_sampled()?;
     assert_eq!(
         client.default_sender().unwrap(),
         Address::from_str("0x2efdc9eecfee3a776209fcb8e9a83a6b221d74f5").unwrap()

--- a/arbiter-core/src/tests/signer.rs
+++ b/arbiter-core/src/tests/signer.rs
@@ -3,29 +3,20 @@ use std::sync::Arc;
 use super::*;
 
 #[test]
-fn simulation_signer() {
-    let params = EnvironmentParameters {
-        label: TEST_ENV_LABEL.to_string(),
-        block_rate: 1.0,
-        seed: 1,
-    };
-    let environment = &mut Environment::new(params);
-    let client = Arc::new(RevmMiddleware::new(
-        environment,
-        Some(TEST_SIGNER_SEED_AND_LABEL.to_string()),
-    ));
+fn simulation_signer() -> Result<()> {
+    let (_manager, client) = startup()?;
     assert_eq!(
         client.default_sender().unwrap(),
         Address::from_str("0x2efdc9eecfee3a776209fcb8e9a83a6b221d74f5").unwrap()
     );
+    Ok(())
 }
 
 #[test]
 fn multiple_signer_addresses() {
     let params = EnvironmentParameters {
         label: TEST_ENV_LABEL.to_string(),
-        block_rate: 1.0,
-        seed: 1,
+        block_type: BlockType::UserControlled,
     };
     let environment = &mut Environment::new(params);
     let client_1 = Arc::new(RevmMiddleware::new(environment, Some("0".to_string())));
@@ -37,8 +28,7 @@ fn multiple_signer_addresses() {
 fn signer_collision() {
     let params = EnvironmentParameters {
         label: TEST_ENV_LABEL.to_string(),
-        block_rate: 1.0,
-        seed: 1,
+        block_type: BlockType::UserControlled,
     };
     let environment = &mut Environment::new(params);
     let client_1 = Arc::new(RevmMiddleware::new(environment, Some("0".to_string())));

--- a/contracts/BlockInfo.sol
+++ b/contracts/BlockInfo.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.8.0;
+
+contract BlockInfo {
+    function getBlockNumber() public view returns (uint256) {
+        return block.number;
+    }
+
+    function getBlockTimestamp() public view returns (uint256) {
+        return block.timestamp;
+    }
+}


### PR DESCRIPTION
**Give an overview of the tasks completed**
Provides an upgraded API for handling block updates with added user control, i.e.:
- [x] Provide some `update_block` function for the environment.

Provides an ability to procedurally update block timestamps when using `BlockType::RandomlySampled`. Furthermore, gives the ability to update block timestamps via the `update_block` function as well.

Furthermore, there is a refactor of the comms used in `RevmMiddleware` to `Environment` which feels much cleaner to me.

**Link to issue(s) that this PR closes**
Closes #418 and closes #464

**NOTE THAT THIS SHOULD COME AFTER #478 AS IT IS FORKED FROM THAT HEAD**