### PR TITLE
Feat/reciepts

### DIFF
--- a/arbiter-core/Cargo.toml
+++ b/arbiter-core/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2021"
 # Ethereum and EVM
 ethers = "2.0.8"
 revm = "3.3.0"
+reth-rlp = { git = "https://github.com/paradigmxyz/reth.git", package = "reth-rlp" }
+rlp = "0.5.2"
 
 # Serialization
 bytes = "1.4.0"

--- a/arbiter-core/Cargo.toml
+++ b/arbiter-core/Cargo.toml
@@ -9,8 +9,6 @@ edition = "2021"
 # Ethereum and EVM
 ethers = "2.0.8"
 revm = "3.3.0"
-reth-rlp = { git = "https://github.com/paradigmxyz/reth.git", package = "reth-rlp" }
-rlp = "0.5.2"
 
 # Serialization
 bytes = "1.4.0"

--- a/arbiter-core/src/environment.rs
+++ b/arbiter-core/src/environment.rs
@@ -302,7 +302,8 @@ impl Environment {
             let mut transactions_per_block = seeded_poisson
                 .clone()
                 .map(|mut distribution| distribution.sample());
-            let mut counter: usize = 0;
+            let mut transaction_index: usize = 0;
+            let mut cumulative_gas_per_block: U256 = U256::ZERO;
 
             // Loop over the reception of calls/transactions sent through the socket
             loop {
@@ -390,8 +391,10 @@ impl Environment {
                                     // if need be and draw a new sample from the `SeededPoisson`
                                     // distribution. Only do so if there is a distribution in the
                                     // first place.
-                                    if transactions_per_block.is_some_and(|x| x == counter) {
-                                        counter = 0;
+                                    if transactions_per_block
+                                        .is_some_and(|x| x == transaction_index)
+                                    {
+                                        transaction_index = 0;
                                         evm.env.block.number += U256::from(1);
 
                                         // This unwrap cannot fail.
@@ -409,20 +412,30 @@ impl Environment {
                                     let execution_result = evm
                                         .transact_commit()
                                         .map_err(EnvironmentError::Execution)?;
+
+                                    // increment culmulative gas per block
+                                    cumulative_gas_per_block +=
+                                        U256::from(execution_result.clone().gas_used());
+
                                     let event_broadcaster =
                                         event_broadcaster.lock().map_err(|e| {
                                             EnvironmentError::Communication(e.to_string())
                                         })?;
+                                    let receipt_data = ReceiptData {
+                                        block_number,
+                                        transaction_index: transaction_index.into(),
+                                        cumulative_gas_per_block,
+                                    };
                                     event_broadcaster.broadcast(execution_result.logs())?;
                                     outcome_sender
                                         .send(Ok(Outcome::TransactionCompleted(
                                             execution_result,
-                                            block_number,
+                                            receipt_data,
                                         )))
                                         .map_err(|e| {
                                             EnvironmentError::Communication(e.to_string())
                                         })?;
-                                    counter += 1;
+                                    transaction_index += 1;
                                 }
                             }
                         }
@@ -476,6 +489,20 @@ pub enum Instruction {
     },
 }
 
+/// [`RecieptData`] is a structure that holds the block number, transaction
+/// index, and cumulative gas used per block for a transaction.
+pub struct ReceiptData {
+    /// `block_number` is the number of the block in which the transaction was
+    /// included.
+    pub(crate) block_number: U64,
+    /// `transaction_index` is the index position of the transaction in the
+    /// block.
+    pub(crate) transaction_index: U64,
+    /// [`cumulative_gas_per_block`] is the total amount of gas used in the
+    /// block up until and including the transaction.
+    pub(crate) cumulative_gas_per_block: U256,
+}
+
 /// [`Outcome`]s that can be sent back to the the client via the
 /// [`Socket`].
 /// These outcomes can be from `Call`, `Transaction`, or `BlockUpdate`
@@ -495,7 +522,7 @@ pub enum Outcome {
     /// The outcome of a `Transaction` instruction that is first unpacked to see
     /// if the result is successful, then it can be used to build a
     /// `TransactionReceipt` in the `Middleware`.
-    TransactionCompleted(ExecutionResult, U64),
+    TransactionCompleted(ExecutionResult, ReceiptData),
 }
 /// Provides channels for communication between the EVM and external entities.
 ///

--- a/arbiter-core/src/environment.rs
+++ b/arbiter-core/src/environment.rs
@@ -360,8 +360,16 @@ impl Environment {
                                     evm.env.block.timestamp = block_timestamp;
                                     transaction_index = 0;
                                     cumulative_gas_per_block = U256::ZERO;
+
+                                    let receipt_data = ReceiptData {
+                                        block_number: convert_uint_to_u64(evm.env.block.number)
+                                            .unwrap(),
+                                        transaction_index: U64::from(0), /* replace with actual
+                                                                          * value */
+                                        cumulative_gas_per_block: U256::from(0),
+                                    };
                                     outcome_sender
-                                        .send(Ok(Outcome::BlockUpdateCompleted))
+                                        .send(Ok(Outcome::BlockUpdateCompleted(receipt_data)))
                                         .map_err(|e| {
                                             EnvironmentError::Communication(e.to_string())
                                         })?;
@@ -513,7 +521,7 @@ pub enum Outcome {
     /// The outcome of a `BlockUpdate` instruction that is used to provide a
     /// non-error output of updating the block number and timestamp of the
     /// [`EVM`] to the client.
-    BlockUpdateCompleted,
+    BlockUpdateCompleted(ReceiptData),
 
     /// The outcome of a `Call` instruction that is used to provide the output
     /// of some [`EVM`] computation to the client.

--- a/arbiter-core/src/environment.rs
+++ b/arbiter-core/src/environment.rs
@@ -358,6 +358,8 @@ impl Environment {
                                     // Update the block number and timestamp
                                     evm.env.block.number = block_number;
                                     evm.env.block.timestamp = block_timestamp;
+                                    transaction_index = 0;
+                                    cumulative_gas_per_block = U256::ZERO;
                                     outcome_sender
                                         .send(Ok(Outcome::BlockUpdateCompleted))
                                         .map_err(|e| {

--- a/arbiter-core/src/middleware.rs
+++ b/arbiter-core/src/middleware.rs
@@ -21,6 +21,7 @@ use std::{
 };
 
 use ethers::{
+    abi::ethereum_types::BloomInput,
     prelude::{
         k256::{
             ecdsa::SigningKey,
@@ -34,17 +35,16 @@ use ethers::{
     },
     signers::{Signer, Wallet},
     types::{
-        transaction::eip2718::TypedTransaction, Address, BlockId, Bytes, Filter, FilteredParams,
-        Log, Transaction, TransactionReceipt, U64, Bloom, OtherFields,
-    }, utils::keccak256, abi::ethereum_types::BloomInput,
+        transaction::eip2718::TypedTransaction, Address, BlockId, Bloom, Bytes, Filter,
+        FilteredParams, Log, Transaction, TransactionReceipt, U64,
+    },
 };
 use futures_timer::Delay;
 use rand::{rngs::StdRng, SeedableRng};
 use revm::primitives::{CreateScheme, ExecutionResult, Output, TransactTo, TxEnv, B160, U256};
 use serde::{de::DeserializeOwned, Serialize};
 use thiserror::Error;
-use reth_rlp::Encodable;
-// use rlp;
+
 use crate::environment::{
     Environment, EventBroadcaster, Instruction, InstructionSender, Outcome, OutcomeReceiver,
     OutcomeSender,
@@ -357,10 +357,10 @@ impl Middleware for RevmMiddleware {
             } = unpack_execution_result(execution_result)?;
 
             let to: Option<ethers::types::H160> = match tx_env.transact_to {
-                    TransactTo::Call(address) => Some(address.into()),
-                    TransactTo::Create(_) => None,
-                };
-            
+                TransactTo::Call(address) => Some(address.into()),
+                TransactTo::Create(_) => None,
+            };
+
             // Note that this is technically not the correct construction on the tx hash
             // but untill we increment the nonce correctly this will do
             let sender = self.wallet.address();
@@ -369,7 +369,6 @@ impl Middleware for RevmMiddleware {
             hasher.update(sender.as_bytes());
             hasher.update(data.as_ref());
             let hash = hasher.finalize();
-
 
             let mut block_hasher = Sha256::new();
             block_hasher.update(block_number.to_string().as_bytes());

--- a/arbiter-core/src/middleware.rs
+++ b/arbiter-core/src/middleware.rs
@@ -348,7 +348,7 @@ impl Middleware for RevmMiddleware {
         if let Outcome::TransactionCompleted(execution_result, block_number) = outcome {
             let Success {
                 _reason: _,
-                _gas_used: _,
+                _gas_used: gas_used,
                 _gas_refunded: _,
                 logs,
                 output,
@@ -362,6 +362,8 @@ impl Middleware for RevmMiddleware {
                         block_number: Some(block_number),
                         contract_address: Some(recast_address(address.unwrap())),
                         logs,
+                        from: self.provider.default_sender().unwrap(),
+                        gas_used: Some(gas_used.into()),
                         ..Default::default()
                     };
 
@@ -388,6 +390,9 @@ impl Middleware for RevmMiddleware {
                         block_hash: None,
                         block_number: Some(block_number),
                         logs,
+                        from: self.provider.default_sender().unwrap(),
+                        gas_used: Some(gas_used.into()),
+                        // need to add the effective gas price
                         ..Default::default()
                     };
 
@@ -641,7 +646,7 @@ impl JsonRpcClient for Connection {
                 let logs_deserializeowned: R = serde_json::from_str(&logs_str)?;
                 return Ok(logs_deserializeowned);
             }
-            var @ _ => {
+            var => {
                 unimplemented!("We don't cover this case yet: {}", var);
             }
         }

--- a/arbiter-core/src/tests/interaction.rs
+++ b/arbiter-core/src/tests/interaction.rs
@@ -4,6 +4,10 @@ use std::{
 };
 
 use assert_matches::assert_matches;
+use ethers::{
+    prelude::k256::sha2::{Digest, Sha256},
+    types::U256,
+};
 use futures::{Stream, StreamExt};
 
 use super::*;
@@ -333,4 +337,51 @@ async fn update_block() {
     assert_eq!(block_number, new_block_number.into());
     let block_timestamp = block_info.get_block_timestamp().call().await.unwrap();
     assert_eq!(block_timestamp, new_block_timestamp.into());
+}
+
+#[tokio::test]
+async fn receipt_data() {
+    let (_manager, client) = startup_user_controlled().unwrap();
+    let arbiter_token = deploy_arbx(client.clone()).await.unwrap();
+    let receipt = arbiter_token
+        .mint(client.default_sender().unwrap(), 1000u64.into())
+        .send()
+        .await
+        .unwrap()
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert!(receipt.block_number.is_some());
+    let mut block_hasher = Sha256::new();
+    block_hasher.update(receipt.block_number.unwrap().to_string().as_bytes());
+    let block_hash = block_hasher.finalize();
+    let block_hash = Some(ethers::types::H256::from_slice(&block_hash));
+    assert_eq!(receipt.block_hash, block_hash);
+    assert_eq!(receipt.status, Some(1.into()));
+
+    assert!(receipt.contract_address.is_none());
+    assert_eq!(receipt.to, Some(arbiter_token.address()));
+
+    assert!(receipt.gas_used.is_some());
+    assert_eq!(receipt.logs.len(), 1);
+    assert_eq!(receipt.logs[0].topics.len(), 3);
+    assert_eq!(receipt.transaction_index, 1.into());
+    assert_eq!(receipt.from, client.default_sender().unwrap());
+
+    let mut cumulative_gas = U256::from(0);
+    assert!(receipt.cumulative_gas_used >= cumulative_gas);
+    cumulative_gas += receipt.cumulative_gas_used;
+
+    let receipt_1 = arbiter_token
+        .mint(client.default_sender().unwrap(), 1000u64.into())
+        .send()
+        .await
+        .unwrap()
+        .await
+        .unwrap()
+        .unwrap();
+
+    // ensure gas in increasing
+    assert!(cumulative_gas <= receipt_1.cumulative_gas_used);
 }


### PR DESCRIPTION
**Give an overview of the tasks completed**
This PR populates the transaction receipts with full information. 

**Link to issue(s) that this PR closes**
closes #479 

This PR will also get the tests to pass in the v0.5.0 feature branch.

I noticed two things while working on this. Particularly when working on the transaction hash. 
- The tx hash of course depends on rlp encodings of a collection of fields in the tx, there are some nice abstractions for this that i was looking at in this [reth crate](https://github.com/paradigmxyz/reth/blob/main/crates/rlp/src/encode.rs) that i think we should use in the future. However right now it is not implemented for revm and ethers types (pending alloy migrations) and i think the current implementation is sufficient. 
- The encoding does depend on the nonce which we aren't incrementing or bookkeeping for the clients. I think the way to go would be to implement the [nonce manager](https://github.com/gakonst/ethers-rs/blob/master/ethers-middleware/src/nonce_manager.rs) here

