### PR TITLE
codespell

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -49,5 +49,5 @@ jobs:
         with:
           check_hidden: true
           check_filenames: true
-          skip: Cargo.lock,target
+          skip: .git,Cargo.lock,target
           ignore_words_list: crate,Crate

--- a/arbiter-core/src/environment.rs
+++ b/arbiter-core/src/environment.rs
@@ -612,7 +612,7 @@ impl Environment {
 
                                     // Check whether we need to increment the block number given the
                                     // amount of transactions
-                                    // that have occured on the current block and increment
+                                    // that have occurred on the current block and increment
                                     // if need be and draw a new sample from the `SeededPoisson`
                                     // distribution. Only do so if there is a distribution in the
                                     // first place.

--- a/arbiter-core/src/math.rs
+++ b/arbiter-core/src/math.rs
@@ -44,7 +44,7 @@ pub use RustQuant::stochastics::*;
 /// the amount of transactions that go through a block. For instance, the larger
 /// the `rate_paramater`, the more transactions we expect (on average) to fit
 /// into a block. A large `rate_parameter` would represent a high-volume network
-/// where lots of transactions are occuring. This could be during periods of
+/// where lots of transactions are occurring. This could be during periods of
 /// times of high market (DEX) volatility or during new NFT launches.
 #[derive(Debug, Clone)]
 pub struct SeededPoisson {


### PR DESCRIPTION
fixes code-spell detections by
- Correcting spelling in documentation and 
- Tell the code-spell to skip .git files
