### PR TITLE
feat(contracts): contract serde derives

### DIFF
--- a/arbiter-core/Cargo.toml
+++ b/arbiter-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arbiter-core"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Waylon Jepsen <waylonjepsen1@gmail.com>", "Colin Roberts <colin@autoparallel.xyz>"]
 description = "Allowing smart contract developers to do simulation driven development via an EVM emulator"

--- a/arbiter-core/src/bindings/arbiter_math.rs
+++ b/arbiter-core/src/bindings/arbiter_math.rs
@@ -7,7 +7,7 @@ pub use arbiter_math::*;
     clippy::upper_case_acronyms,
     clippy::type_complexity,
     dead_code,
-    non_camel_case_types
+    non_camel_case_types,
 )]
 pub mod arbiter_math {
     #[allow(deprecated)]
@@ -17,346 +17,447 @@ pub mod arbiter_math {
             functions: ::core::convert::From::from([
                 (
                     ::std::borrow::ToOwned::to_owned("cdf"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("cdf"),
-                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::borrow::ToOwned::to_owned("input"),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("int256"),
-                            ),
-                        },],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::borrow::ToOwned::to_owned("output"),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("int256"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("cdf"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("input"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("int256"),
+                                    ),
+                                },
+                            ],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("output"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("int256"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("divWadDown"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("divWadDown"),
-                        inputs: ::std::vec![
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("x"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint256"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("y"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint256"),
-                                ),
-                            },
-                        ],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::borrow::ToOwned::to_owned("z"),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("uint256"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("divWadDown"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("x"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("y"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("z"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("divWadUp"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("divWadUp"),
-                        inputs: ::std::vec![
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("x"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint256"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("y"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint256"),
-                                ),
-                            },
-                        ],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::borrow::ToOwned::to_owned("z"),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("uint256"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("divWadUp"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("x"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("y"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("z"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("invariant"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("invariant"),
-                        inputs: ::std::vec![
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("R_y"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint256"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("R_x"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint256"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("stk"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint256"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("vol"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint256"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("tau"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint256"),
-                                ),
-                            },
-                        ],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::borrow::ToOwned::to_owned("k"),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("int256"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("invariant"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("R_y"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("R_x"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("stk"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("vol"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("tau"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("k"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("int256"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("log"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("log"),
-                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::borrow::ToOwned::to_owned("x"),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("int256"),
-                            ),
-                        },],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::borrow::ToOwned::to_owned("z"),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("int256"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("log"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("x"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("int256"),
+                                    ),
+                                },
+                            ],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("z"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("int256"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("mulWadDown"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("mulWadDown"),
-                        inputs: ::std::vec![
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("x"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint256"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("y"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint256"),
-                                ),
-                            },
-                        ],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::borrow::ToOwned::to_owned("z"),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("uint256"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("mulWadDown"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("x"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("y"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("z"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("mulWadUp"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("mulWadUp"),
-                        inputs: ::std::vec![
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("x"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint256"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("y"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint256"),
-                                ),
-                            },
-                        ],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::borrow::ToOwned::to_owned("z"),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("uint256"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("mulWadUp"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("x"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("y"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("z"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("pdf"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("pdf"),
-                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::borrow::ToOwned::to_owned("input"),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("int256"),
-                            ),
-                        },],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::borrow::ToOwned::to_owned("output"),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("int256"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("pdf"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("input"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("int256"),
+                                    ),
+                                },
+                            ],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("output"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("int256"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("ppf"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("ppf"),
-                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::borrow::ToOwned::to_owned("input"),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("int256"),
-                            ),
-                        },],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::borrow::ToOwned::to_owned("output"),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("int256"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("ppf"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("input"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("int256"),
+                                    ),
+                                },
+                            ],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("output"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("int256"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("sqrt"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("sqrt"),
-                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::borrow::ToOwned::to_owned("x"),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("uint256"),
-                            ),
-                        },],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::borrow::ToOwned::to_owned("z"),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("uint256"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("sqrt"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("x"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("z"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
+                        },
+                    ],
                 ),
             ]),
             events: ::std::collections::BTreeMap::new(),
             errors: ::core::convert::From::from([
                 (
                     ::std::borrow::ToOwned::to_owned("Infinity"),
-                    ::std::vec![::ethers::core::abi::ethabi::AbiError {
-                        name: ::std::borrow::ToOwned::to_owned("Infinity"),
-                        inputs: ::std::vec![],
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::AbiError {
+                            name: ::std::borrow::ToOwned::to_owned("Infinity"),
+                            inputs: ::std::vec![],
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("Min"),
-                    ::std::vec![::ethers::core::abi::ethabi::AbiError {
-                        name: ::std::borrow::ToOwned::to_owned("Min"),
-                        inputs: ::std::vec![],
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::AbiError {
+                            name: ::std::borrow::ToOwned::to_owned("Min"),
+                            inputs: ::std::vec![],
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("NegativeInfinity"),
-                    ::std::vec![::ethers::core::abi::ethabi::AbiError {
-                        name: ::std::borrow::ToOwned::to_owned("NegativeInfinity"),
-                        inputs: ::std::vec![],
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::AbiError {
+                            name: ::std::borrow::ToOwned::to_owned("NegativeInfinity"),
+                            inputs: ::std::vec![],
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("OOB"),
-                    ::std::vec![::ethers::core::abi::ethabi::AbiError {
-                        name: ::std::borrow::ToOwned::to_owned("OOB"),
-                        inputs: ::std::vec![],
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::AbiError {
+                            name: ::std::borrow::ToOwned::to_owned("OOB"),
+                            inputs: ::std::vec![],
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("OutOfBounds"),
-                    ::std::vec![::ethers::core::abi::ethabi::AbiError {
-                        name: ::std::borrow::ToOwned::to_owned("OutOfBounds"),
-                        inputs: ::std::vec![],
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::AbiError {
+                            name: ::std::borrow::ToOwned::to_owned("OutOfBounds"),
+                            inputs: ::std::vec![],
+                        },
+                    ],
                 ),
             ]),
             receive: false,
             fallback: false,
         }
     }
-    /// The parsed JSON ABI of the contract.
-    pub static ARBITERMATH_ABI: ::ethers::contract::Lazy<::ethers::core::abi::Abi> =
-        ::ethers::contract::Lazy::new(__abi);
+    ///The parsed JSON ABI of the contract.
+    pub static ARBITERMATH_ABI: ::ethers::contract::Lazy<::ethers::core::abi::Abi> = ::ethers::contract::Lazy::new(
+        __abi,
+    );
     #[rustfmt::skip]
-    const __BYTECODE: &[u8] = b"`\x80`@R4\x80\x15a\0]W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01\x90\x81Ra7\xB7`\xF1\x1B`d\x83\x01R`\x84\x82\xFD[Pa\x11\xAF\x80a\0m`\09`\0\xF3\xFE`\x80`@R4\x80\x15a\0]W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01\x90\x81Ra7\xB7`\xF1\x1B`d\x83\x01R`\x84\x82\xFD[P`\x046\x10a\0\xEBW`\x005`\xE0\x1C\x80c\xAE\x97h\xA8\x11a\0\xB3W\x80c\xAE\x97h\xA8\x14a\x01\xC1W\x80c\xBD%-\x06\x14a\x01\xD4W\x80c\xD0\xB7\x1B\x1E\x14a\x01\xE7W\x80c\xD2L\xE6\xE5\x14a\x01\xFAW\x80c\xE5$\xF8I\x14a\x02\rWa\0\xEBV[\x80c-[l\xB9\x14a\x01PW\x80c/Yw:\x14a\x01uW\x80c6yr:\x14a\x01\x88W\x80c7\xC6\xA4J\x14a\x01\x9BW\x80cgsB\xCE\x14a\x01\xAEW[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01\x90\x81Rtnor receive functions`X\x1B`d\x83\x01R`\x84\x82\xFD[a\x01ca\x01^6`\x04a\x0F\xF6V[a\x02 V[`@Q\x90\x81R` \x01`@Q\x80\x91\x03\x90\xF3[a\x01ca\x01\x836`\x04a\x10\x12V[a\x021V[a\x01ca\x01\x966`\x04a\x0F\xF6V[a\x02JV[a\x01ca\x01\xA96`\x04a\x10PV[a\x02UV[a\x01ca\x01\xBC6`\x04a\x0F\xF6V[a\x02hV[a\x01ca\x01\xCF6`\x04a\x10PV[a\x02sV[a\x01ca\x01\xE26`\x04a\x10PV[a\x02\x7FV[a\x01ca\x01\xF56`\x04a\x0F\xF6V[a\x02\x8BV[a\x01ca\x02\x086`\x04a\x0F\xF6V[a\x02\x96V[a\x01ca\x02\x1B6`\x04a\x10PV[a\x02\xA1V[`\0a\x02+\x82a\x02\xADV[\x92\x91PPV[`\0a\x02@\x86\x86\x86\x86\x86a\x04\x8DV[\x96\x95PPPPPPV[`\0a\x02+\x82a\x04\xAAV[`\0a\x02a\x83\x83a\x05PV[\x93\x92PPPV[`\0a\x02+\x82a\x05eV[`\0a\x02a\x83\x83a\x06\tV[`\0a\x02a\x83\x83a\x06\x1EV[`\0a\x02+\x82a\x063V[`\0a\x02+\x82a\x06\x9CV[`\0a\x02a\x83\x83a\x06\xF8V[`\0\x80\x82\x13a\x02\xEFW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\t`$\x82\x01Rh\x15S\x91\x11Q\x92S\x91Q`\xBA\x1B`D\x82\x01R`d\x01[`@Q\x80\x91\x03\x90\xFD[`\0``a\x02\xFC\x84a\x07\rV[\x03`\x9F\x81\x81\x03\x94\x90\x94\x1B\x90\x93\x1ClFWr\xB2\xBB\xBB_\x82K\x15 z0\x81\x01\x81\x02``\x90\x81\x1Dm\x03\x88\xEA\xA2t\x12\xD5\xAC\xA0&\x81]cn\x01\x82\x02\x81\x1Dm\r\xF9\x9A\xC5\x02\x03\x1B\xF9S\xEF\xF4r\xFD\xCC\x01\x82\x02\x81\x1Dm\x13\xCD\xFF\xB2\x9DQ\xD9\x93\"\xBD\xFF_\"\x11\x01\x82\x02\x81\x1Dm\n\x0Ft #\xDE\xF7\x83\xA3\x07\xA9\x86\x91.\x01\x82\x02\x81\x1Dm\x01\x92\r\x80C\xCA\x89\xB5#\x92S(NB\x01\x82\x02\x81\x1Dl\x0Bz\x86\xD77Th\xFA\xC6g\xA0\xA5'\x01l)P\x8EE\x85C\xD8\xAAM\xF2\xAB\xEEx\x83\x01\x83\x02\x82\x1Dm\x019`\x1A.\xFA\xBEq~`L\xBBH\x94\x01\x83\x02\x82\x1Dm\x02$\x7Fz{e\x942\x06I\xAA\x03\xAB\xA1\x01\x83\x02\x82\x1Dl\x8C?8\xE9Zk\x1F\xF2\xAB\x1C;46\x19\x01\x83\x02\x82\x1Dm\x028Gs\xBD\xF1\xACVv\xFA\xCC\xED`\x90\x19\x01\x83\x02\x90\x91\x1Dl\xB9\xA0%\xD8\x14\xB2\x9C!+\x8B\x1A\x07\xCD\x19\x01\x90\x91\x02x\n\tPp\x84\xCCi\x9B\xB0\xE7\x1E\xA8i\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x19\x01\x05q\x13@\xDA\xA0\xD5\xF7i\xDB\xA1\x91\\\xEFY\xF0\x81ZU\x06\x02}\x02g\xA3l\x0C\x95\xB3\x97Z\xB3\xEE[ :v\x14\xA3\xF7Ss\xF0G\xD8\x03\xAE{f\x87\xF2\xB3\x93\x90\x93\x02\x92\x90\x92\x01}W\x11^G\x01\x8Cqw\xEE\xBF|\xD3p\xA35j\x1Bxc\0\x8AZ\xE8\x02\x8Cr\xB8\x86B\x84\x01`\xAE\x1D\x92\x91PPV[`\0\x80a\x04\x9D\x86\x86\x86\x86\x86a\x07\xB5V[\x90\x96\x03\x96\x95PPPPPPV[`\0g\x06\xF0[Y\xD3\xB2\0\0\x82\x03a\x04\xC3WP`\0\x91\x90PV[g\r\xE0\xB6\xB3\xA7d\0\0\x82\x12a\x04\xEBW`@Qc\x07\xA0!'`\xE0\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[\x81`\0\x03a\x05\x0CW`@Qc\"\xEDY\x85`\xE2\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[`\0a\x05\x19\x83`\x02a\x10\x8BV[\x90P`\0a\x05&\x82a\x08\xD0V[\x90P`\0a\x05<g\x13\xA0K\xBD\xFD\xC9\xBE\x88\x83a\x0BLV[\x90Pa\x05G\x81a\x10\xBBV[\x95\x94PPPPPV[`\0a\x02a\x83g\r\xE0\xB6\xB3\xA7d\0\0\x84a\x0BaV[`\xB5\x81`\x01`\x88\x1B\x81\x10a\x05~W`@\x91\x90\x91\x1B\x90`\x80\x1C[i\x01\0\0\0\0\0\0\0\0\0\x81\x10a\x05\x9AW` \x91\x90\x91\x1B\x90`@\x1C[e\x01\0\0\0\0\0\x81\x10a\x05\xB2W`\x10\x91\x90\x91\x1B\x90` \x1C[c\x01\0\0\0\x81\x10a\x05\xC8W`\x08\x91\x90\x91\x1B\x90`\x10\x1C[b\x01\0\0\x01\x02`\x12\x1C\x80\x82\x04\x01`\x01\x90\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x90\x1C\x90\x81\x90\x04\x81\x11\x90\x03\x90V[`\0a\x02a\x83\x83g\r\xE0\xB6\xB3\xA7d\0\0a\x0B\x80V[`\0a\x02a\x83g\r\xE0\xB6\xB3\xA7d\0\0\x84a\x0B\x80V[`\0\x80g\x13\xA0K\xBD\xFD\xC9\xBE\x88a\x06Qg\r\xE0\xB6\xB3\xA7d\0\0\x85a\x10\x8BV[a\x06[\x91\x90a\x10\xD7V[\x90P`\0a\x06h\x82a\x10\xBBV[\x90P`\0a\x06u\x82a\x0B\xAEV[\x90Pg\x1B\xC1mgN\xC8\0\0a\x06\x92g\r\xE0\xB6\xB3\xA7d\0\0\x83a\x10\x8BV[a\x05G\x91\x90a\x10\xD7V[`\0\x80g\x1B\xC1mgN\xC8\0\0\x83a\x06\xB2\x81a\x10\xBBV[a\x06\xBC\x91\x90a\x10\x8BV[a\x06\xC6\x91\x90a\x10\xD7V[\x90Pa\x06\xD1\x81a\r\x92V[\x90Pg\"\xC9U\"\x95T\xC1\xB6a\x06\xEEg\r\xE0\xB6\xB3\xA7d\0\0\x83a\x10\x8BV[a\x02a\x91\x90a\x10\xD7V[`\0a\x02a\x83\x83g\r\xE0\xB6\xB3\xA7d\0\0a\x0BaV[`\0\x80\x82\x11a\x07JW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\t`$\x82\x01Rh\x15S\x91\x11Q\x92S\x91Q`\xBA\x1B`D\x82\x01R`d\x01a\x02\xE6V[P`\x01o\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11`\x07\x1B\x82\x81\x1Cg\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x10`\x06\x1B\x17\x82\x81\x1Cc\xFF\xFF\xFF\xFF\x10`\x05\x1B\x17\x82\x81\x1Ca\xFF\xFF\x10`\x04\x1B\x17\x82\x81\x1C`\xFF\x10`\x03\x90\x81\x1B\x90\x91\x17\x83\x81\x1C`\x0F\x10`\x02\x1B\x17\x83\x81\x1C\x90\x91\x10\x82\x1B\x17\x91\x82\x1C\x11\x17\x90V[`\0g\r\xE0\xB6\xB3\xA7d\0\0\x86\x11\x15a\x07\xE0W`@Qc\xAA\xF3\x95o`\xE0\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[g\r\xE0\xB6\xB3\xA7d\0\0\x86\x03a\x07\xF6WP\x80a\x05GV[\x85`\0\x03a\x08\x0FWa\x08\x08\x82\x86a\x11\x13V[\x90Pa\x05GV[\x82\x15a\x08\xAAW`\0a\x08%\x84c\x01\xE1\x85Xa\x05PV[\x90P`\0a\x082\x82a\x05eV[\x90Pa\x08Bc;\x9A\xCA\0\x82a\x11;V[\x90Pa\x08N\x86\x82a\x06\xF8V[\x90P`\0a\x08d\x89g\r\xE0\xB6\xB3\xA7d\0\0a\x11RV[\x90Pa\x08o\x81a\x04\xAAV[\x90P`\0a\x08}\x83\x83a\x11RV[\x90Pa\x08\x88\x81a\x063V[\x90P\x85a\x08\x95\x8A\x83a\x0BLV[a\x08\x9F\x91\x90a\x11\x13V[\x94PPPPPa\x05GV[\x81a\x08\xC6\x86a\x08\xC1\x89g\r\xE0\xB6\xB3\xA7d\0\0a\x11RV[a\x0BLV[a\x02@\x91\x90a\x11\x13V[`\0\x80\x82\x12\x80a\x08\xE7WPg\x1B\xC1mgN\xC8\0\0\x82\x13[\x15a\t\x05W`@Qc-\x04\x83\xC5`\xE2\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[\x81`\0\x03a\t&W`@Qc\x07\xA0!'`\xE0\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[\x81g\x1B\xC1mgN\xC8\0\0\x03a\tNW`@Qc\"\xEDY\x85`\xE2\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[\x80\x15a\tYW\x91\x90PV[`\0g\r\xE0\xB6\xB3\xA7d\0\0\x83\x12a\t\x81Wa\t|\x83g\x1B\xC1mgN\xC8\0\0a\x11RV[a\t\x83V[\x82[\x90P`\0a\t\x99\x82g\x1B\xC1mgN\xC8\0\0a\x0F;V[\x90P\x80`\0\x03a\t\xBCW`@Qc\x07\xA0!'`\xE0\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[`\0a\t\xC7\x82a\x02\xADV[\x90P`\0c;\x9A\xCA\0a\t\xF2a\t\xEDa\t\xE7g\x1B\xC1mgN\xC8\0\0a\x10\xBBV[\x85a\x0BLV[a\x05eV[a\t\xFC\x91\x90a\x10\x8BV[\x90P`\0\x80a\n\x13\x83g\x03\xC1f\\z\xAB \0a\x0BLV[a\n%\x90g \x05\xFEO&\x8E\xA0\0a\x11\x13V[\x90P`\0a\nP\x84a\n>\x86f\x9F2u$b\xA0\0a\x0BLV[a\x08\xC1\x90g\r\xC5R\x7Fd, \0a\x11\x13V[a\nb\x90g\r\xE0\xB6\xB3\xA7d\0\0a\x11\x13V[\x90Pa\n\x86g\t\xD0(\xCCo _\xFF\x19\x85a\n|\x85\x85a\x0F;V[a\x08\xC1\x91\x90a\x11RV[\x92PPP`\0[`\x02\x81\x10\x15a\x0B!W`\0\x86a\n\xA2\x84a\x0B\xAEV[a\n\xAC\x91\x90a\x11RV[\x90P`\0a\n\xBA\x84\x85a\x0BLV[a\n\xC3\x90a\x10\xBBV[\x90P`\0a\n\xD0\x82a\r\x92V[\x90P`\0a\n\xDE\x86\x85a\x0BLV[a\n\xF0g\x0F\xA8\xCE\xDF\xC2\xAD\xDD\xFA\x84a\x0BLV[a\n\xFA\x91\x90a\x11RV[\x90Pa\x0B\x06\x84\x82a\x0F;V[a\x0B\x10\x90\x87a\x11\x13V[\x95P\x84`\x01\x01\x94PPPPPa\n\x8DV[g\r\xE0\xB6\xB3\xA7d\0\0\x88\x12a\x0B>Wa\x0B9\x82a\x10\xBBV[a\x0B@V[\x81[\x98\x97PPPPPPPPV[`\0a\x02a\x83\x83g\r\xE0\xB6\xB3\xA7d\0\0a\x0FLV[\x82\x82\x02\x81\x15\x15\x84\x15\x85\x83\x04\x85\x14\x17\x16a\x0ByW`\0\x80\xFD[\x04\x92\x91PPV[\x82\x82\x02\x81\x15\x15\x84\x15\x85\x83\x04\x85\x14\x17\x16a\x0B\x98W`\0\x80\xFD[`\x01\x82`\x01\x83\x03\x04\x01\x81\x15\x15\x02\x90P\x93\x92PPPV[`\0\x81`\0\x03a\x0B\xC7WPg\r\xE0\xB6\xB3\xA7d\0\0\x91\x90PV[gV\x98\xEE\xF0fp\0\0\x82\x12a\x0B\xDEWP`\0\x91\x90PV[a\x0B\xEFgV\x98\xEE\xF0fp\0\0a\x10\xBBV[\x82\x13a\x0C\x04WPg\x1B\xC1mgN\xC8\0\0\x91\x90PV[`\0a\x0C\x0F\x83a\x0FkV[\x90P`\0a\x0CHg\r\xE0\xB6\xB3\xA7d\0\0a\x0C1\x84g\x1B\xC1mgN\xC8\0\0a\x05PV[a\x0CC\x90g\r\xE0\xB6\xB3\xA7d\0\0a\x11\x13V[a\x0F;V[\x90P`\0\x80\x82a\x0C\xA4\x81a\x0C\x91\x81a\x0C\x7F\x81a\x0Cl\x81g\x02_\x0F\xE1\x05\xA3\x14\0a\x0BLV[a\x08\xC1\x90g\x0Bh\xDF\x18\xE4q\xFB\xFF\x19a\x11\x13V[a\x08\xC1\x90g\x14\xA8EL\x19\xE1\xAC\0a\x11\x13V[a\x08\xC1\x90g\x0F\xC1\x0E\x01W\x82w\xFF\x19a\x11\x13V[a\x0C\xB6\x90g\x03\xDE\xBD\x08;\x8C|\0a\x11\x13V[\x91P\x83\x90Pa\r\x1E\x81a\r\x0C\x81a\x0C\xFA\x81a\x0C\xE8\x81a\x0C\xD5\x81\x8Ba\x0BLV[a\x08\xC1\x90g\x02\x95\xD4\0\xEA2W\xFF\x19a\x11\x13V[a\x08\xC1\x90g\x01W\xD8\xB2\xEC\xC7\x08\0a\x11\x13V[a\x08\xC1\x90g\x051\n\xA7\xD5!0\0a\x11\x13V[a\x08\xC1\x90g\r\xE0\xCC=\x15a\0\0a\x11\x13V[\x91P\x81g\x11\x90\0\xAB\x10\x0F\xFC\0a\r4\x87\x88a\x0BLV[a\r@\x90`\0\x19a\x10\x8BV[a\rJ\x91\x90a\x11RV[a\rT\x91\x90a\x11\x13V[\x92PP`\0a\rb\x83a\r\x92V[\x90P`\0a\rp\x85\x83a\x0BLV[\x90P`\0\x88\x12a\r\x80W\x80a\x0B@V[a\x0B@\x81g\x1B\xC1mgN\xC8\0\0a\x11RV[`\0h\x02H\xCE6\xA7\x0C\xB2k>\x19\x82\x13a\r\xADWP`\0\x91\x90PV[h\x07U\xBFy\x8BJ\x1B\xF1\xE5\x82\x12a\r\xF4W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x0C`$\x82\x01RkEXP_OVERFLOW`\xA0\x1B`D\x82\x01R`d\x01a\x02\xE6V[e\x03x-\xAC\xE9\xD9`N\x83\x90\x1B\x05\x91P`\0``k\xB1r\x17\xF7\xD1\xCFy\xAB\xC9\xE3\xB3\x98\x84\x82\x1B\x05`\x01`_\x1B\x01\x90\x1Dk\xB1r\x17\xF7\xD1\xCFy\xAB\xC9\xE3\xB3\x98\x81\x02\x90\x93\x03l$\x0C3\x0E\x9F\xB2\xD9\xCB\xAF\x0F\xD5\xAA\xFB\x19\x81\x01\x81\x02``\x90\x81\x1Dm\x02wYI\x91\xCF\xC8_n$a\x83|\xD9\x01\x82\x02\x81\x1Dm\x1AR\x12U\xE3OjPa\xB2^\xF1\xC9\xC3\x19\x01\x82\x02\x81\x1Dm\xB1\xBB\xB2\x01\xF4C\xCF\x96/\x1A\x1D=\xB4\xA5\x01\x82\x02\x81\x1Dn\x02\xC7#\x88\xD9\xF7OQ\xA93\x1F\xEDi?\x14\x19\x01\x82\x02\x81\x1Dn\x05\x18\x0B\xB1G\x99\xABG\xA8\xA8\xCB*R}W\x01m\x02\xD1g W{\xD1\x9B\xF6\x14\x17o\xE9\xEAl\x10\xFEh\xE7\xFD7\xD0\0{q?vP\x84\x01\x84\x02\x83\x1D\x90\x81\x01\x90\x84\x01m\x01\xD3\x96~\xD3\x0F\xC4\xF8\x9C\x02\xBA\xB5p\x81\x19\x01\x02\x90\x91\x1Dn\x05\x87\xF5\x03\xBBn\xA2\x9D%\xFC\xB7@\x19dP\x01\x90\x91\x02m6\rz\xEE\xA0\x93&>\xCCn\x0E\xCB)\x17`b\x1B\x01\x05t\x02\x9D\x9D\xC3\x85c\xC3.\\/m\xC1\x92\xEEp\xEFe\xF9\x97\x8A\xF3\x02`\xC3\x93\x90\x93\x03\x92\x90\x92\x1C\x92\x91PPV[`\0a\x02a\x83g\r\xE0\xB6\xB3\xA7d\0\0\x84[\x82\x82\x02\x81\x15\x15\x84\x15\x85\x83\x05\x85\x14\x17\x16a\x0FdW`\0\x80\xFD[\x05\x92\x91PPV[`\0`\x01`\xFF\x1B\x82\x03a\x0F\x91W`@QcM-u\xB1`\xE0\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[`\0\x82\x12\x15a\x0F\xA2WP\x19`\x01\x01\x90V[P\x90V[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x81\xFD[`\0` \x82\x84\x03\x12\x15a\x10\x0BWa\x10\x0Ba\x0F\xA6V[P5\x91\x90PV[`\0\x80`\0\x80`\0`\xA0\x86\x88\x03\x12\x15a\x10-Wa\x10-a\x0F\xA6V[PP\x835\x95` \x85\x015\x95P`@\x85\x015\x94``\x81\x015\x94P`\x80\x015\x92P\x90PV[`\0\x80`@\x83\x85\x03\x12\x15a\x10fWa\x10fa\x0F\xA6V[PP\x805\x92` \x90\x91\x015\x91PV[cNH{q`\xE0\x1B`\0R`\x11`\x04R`$`\0\xFD[\x80\x82\x02`\0\x82\x12`\x01`\xFF\x1B\x84\x14\x16\x15a\x10\xA7Wa\x10\xA7a\x10uV[\x81\x81\x05\x83\x14\x82\x15\x17a\x02+Wa\x02+a\x10uV[`\0`\x01`\xFF\x1B\x82\x01a\x10\xD0Wa\x10\xD0a\x10uV[P`\0\x03\x90V[`\0\x82a\x10\xF4WcNH{q`\xE0\x1B`\0R`\x12`\x04R`$`\0\xFD[`\x01`\xFF\x1B\x82\x14`\0\x19\x84\x14\x16\x15a\x11\x0EWa\x11\x0Ea\x10uV[P\x05\x90V[\x80\x82\x01\x82\x81\x12`\0\x83\x12\x80\x15\x82\x16\x82\x15\x82\x16\x17\x15a\x113Wa\x113a\x10uV[PP\x92\x91PPV[\x80\x82\x02\x81\x15\x82\x82\x04\x84\x14\x17a\x02+Wa\x02+a\x10uV[\x81\x81\x03`\0\x83\x12\x80\x15\x83\x83\x13\x16\x83\x83\x12\x82\x16\x17\x15a\x11rWa\x11ra\x10uV[P\x92\x91PPV\xFE\xA2dipfsX\"\x12 &\xC6Q\xA3\x8D>\xF3n\x80\xDF\x10s\xAC\xE4\x80\xA56\xC2\xCF<S\x07L\"\xA5\xE3\xDDEx\xF2}8dsolcC\0\x08\x13\x003";
+    const __BYTECODE: &[u8] = b"`\x80\x80`@R4a\0\x19W`@Qa\x10\xF9\x90\x81a\0g\x829\xF3[bF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD\xFE`\x80`@R`\x046\x10a\x03uW`\x005`\xE0\x1C\x80c-[l\xB9\x14a\0\xACW\x80c/Yw:\x14a\0\xA7W\x80c6yr:\x14a\0\xA2W\x80c7\xC6\xA4J\x14a\0\x9DW\x80cgsB\xCE\x14a\0\x98W\x80c\xAE\x97h\xA8\x14a\0\x93W\x80c\xBD%-\x06\x14a\0\x8EW\x80c\xD0\xB7\x1B\x1E\x14a\0\x89W\x80c\xD2L\xE6\xE5\x14a\0\x84Wc\xE5$\xF8I\x03a\x03uWa\x03TV[a\x02\xE9V[a\x02\xD1V[a\x02\x84V[a\x028V[a\x02\x1AV[a\x01\xD3V[a\x01\xBBV[a\x01\x83V[4a\0\xCCW` a\0\xC4a\0\xBF6a\x01lV[a\r\x7FV[`@Q\x90\x81R\xF3[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x90\xFD[` \x90`\x03\x19\x01\x12a\x01~W`\x045\x90V[a\x01\x1CV[4a\x01\xB6W`\xA06`\x03\x19\x01\x12a\x01~W` a\x01\xAA`\x845`d5`D5`$5a\tKV[`@Q\x90`\x045\x03\x81R\xF3[a\0\xCCV[4a\x01\xB6W` a\0\xC4a\x01\xCE6a\x01lV[a\x07wV[4a\x01\xB6W`@6`\x03\x19\x01\x12a\x01~W`\x045`$5\x90g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17\x82\x15\x15\x16\x15a\x02\x15W` \x91`@Q\x91\x04\x81R\xF3[`\0\x80\xFD[4a\x01\xB6W` 6`\x03\x19\x01\x12a\x01~W` a\0\xC4`\x045a\x0F\x93V[4a\x01\xB6W`@6`\x03\x19\x01\x12a\x01~W`\x045`$5\x90\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17`\x01\x16\x15a\x02\x15W` \x90`@Q\x90`\x01g\r\xE0\xB6\xB3\xA7d\0\0`\0\x19\x83\x01\x04\x01\x90\x15\x15\x02\x81R\xF3[4a\x01\xB6W`@6`\x03\x19\x01\x12a\x01~W`\x045`$5g\r\xE0\xB6\xB3\xA7d\0\0\x91\x82\x81\x02\x92\x81\x84\x04\x14\x90\x15\x17\x81\x15\x15\x16\x15a\x02\x15W` \x91`\x01`@Q\x92`\0\x19\x83\x01\x04\x01\x90\x15\x15\x02\x81R\xF3[4a\x01\xB6W` a\0\xC4a\x02\xE46a\x01lV[a\x04VV[4a\x01\xB6Wa\x02\xF76a\x01lV[a\x03\0\x81a\x04EV[\x80\x82\x02\x91`\0\x82\x12`\x01`\xFF\x1B\x82\x14\x16a\x03OW\x81\x83\x05\x14\x90\x15\x17\x15a\x03OWg\"\xC9U\"\x95T\xC1\xB6a\x03Fa\x03Ag\x1B\xC1mgN\xC8\0\0` \x94\x05a\x0B\xC3V[a\x03\xEEV[\x05`@Q\x90\x81R\xF3[a\x03\xD8V[4a\x01\xB6W`@6`\x03\x19\x01\x12a\x01~W` a\0\xC4`$5`\x045a\x0F V[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01Rtnor receive functions`X\x1B`d\x82\x01R`\x84\x90\xFD[cNH{q`\xE0\x1B`\0R`\x11`\x04R`$`\0\xFD[\x90g\r\xE0\xB6\xB3\xA7d\0\0\x91\x82\x81\x02\x92\x81\x84\x05\x14\x90\x15\x17\x15a\x03OWV[`\0\x81\x90\x03\x91\x90`\x01`\xFF\x1B\x81\x14`\x01\x16a\x03OW`\0\x19\x83\x05\x03a\x03OWV[\x90c;\x9A\xCA\0\x91\x82\x81\x02\x92\x81\x84\x05\x14\x90\x15\x17\x15a\x03OWV[`\x01`\xFF\x1B\x81\x14a\x03OW`\0\x03\x90V[a\x04\x85a\x03Aa\x04\x80g\x13\xA0K\xBD\xFD\xC9\xBE\x88a\x04zg\x1B\xC1mgN\xC8\0\0\x95a\x03\xEEV[\x05a\x04EV[a\x069V[\x05\x90V[\x90\x81g\r\xE0\xB6\xB3\xA7d\0\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\x0Bh\xDF\x18\xE4q\xFB\xFF\x19\x01\x91\x82\x12\x15`\x01\x16a\x03OWV[\x90\x81g\x14\xA8EL\x19\xE1\xAC\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\x0F\xC1\x0E\x01W\x82w\xFF\x19\x01\x91\x82\x12\x15`\x01\x16a\x03OWV[\x90\x81g\x03\xDE\xBD\x08;\x8C|\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\x02\x95\xD4\0\xEA2W\xFF\x19\x01\x91\x82\x12\x15`\x01\x16a\x03OWV[\x90\x81g\x01W\xD8\xB2\xEC\xC7\x08\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\x051\n\xA7\xD5!0\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\r\xE0\xCC=\x15a\0\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g \x05\xFEO&\x8E\xA0\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\r\xC5R\x7Fd, \0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90`\0\x82\x12\x80\x15\x16a\x03OWV[\x91\x90\x91`\0\x83\x82\x01\x93\x84\x12\x91\x12\x90\x80\x15\x82\x16\x91\x15\x16\x17a\x03OWV[\x90g\x11\x90\0\xAB\x10\x0F\xFB\xFF\x19\x82\x01\x91\x82\x13`\x01\x16a\x03OWV[\x90g\x1B\xC1mgN\xC8\0\0`\0\x83\x82\x03\x93\x12\x81\x84\x12\x81\x16\x91\x84\x13\x90\x15\x16\x17a\x03OWV[\x90g\r\xE0\xB6\xB3\xA7d\0\0`\0\x83\x82\x03\x93\x12\x81\x84\x12\x81\x16\x91\x84\x13\x90\x15\x16\x17a\x03OWV[\x81\x81\x03\x92\x91`\0\x13\x80\x15\x82\x85\x13\x16\x91\x84\x12\x16\x17a\x03OWV[\x80\x15a\x07jWgV\x98\xEE\xF0fp\0\0\x81\x12\x15a\x07dWgV\x98\xEE\xF0fo\xFF\xFF\x19\x81\x13\x15a\x07WWa\x07Ba\x06l\x82a\t\xEBV[a\x07\0a\x07=a\x06\x8Ba\x06\x86a\x06\x81\x85a\x0FAV[a\x04\x89V[a\x0B\x82V[\x92a\x078a\x073a\x07.a\x07'a\x07!a\x07\x1Ca\x07\x16a\x07\x11a\x07\x0Ba\x07\x06\x8Da\x07\0a\x06\xFBa\x06\xF5a\x06\xF0a\x06\xEAa\x06\xE5a\x06\xDFa\x06\xDAa\x06\xD4a\x06\xCF\x8Aa\n\x18V[a\x04\xA1V[\x89a\n\xBAV[a\x04\xBBV[\x87a\n\xBAV[a\x04\xD3V[\x85a\n\xBAV[a\x04\xEDV[\x83a\n\xBAV[a\x05\x05V[\x90a\n\xBAV[a\x05\x1FV[\x8Ca\n\xBAV[a\x057V[\x8Aa\n\xBAV[a\x05OV[\x88a\n\xBAV[\x93\x80a\n\xBAV[a\x04\x0BV[a\x05\xC1V[a\x05\xA5V[a\x0B\xC3V[\x90`\0\x13\x15a\x07TWa\x07T\x90a\x05\xDAV[\x90V[Pg\x1B\xC1mgN\xC8\0\0\x90V[P`\0\x90V[Pg\r\xE0\xB6\xB3\xA7d\0\0\x90V[g\x06\xF0[Y\xD3\xB2\0\0\x81\x14a\x07dWg\r\xE0\xB6\xB3\xA7d\0\0\x80\x82\x12\x15a\x08\xDCW\x81\x15a\x08\xFDW`\x01\x82\x81\x1B\x91`\x02\x93\x83\x05\x84\x03a\x03OW`\0\x83\x12\x80\x15a\t!W[a\t\x0FW\x82\x15a\x08\xDCWg\x1B\xC1mgN\xC8\0\0\x83\x14a\x08\xFDW\x82\x12\x91\x82\x15a\x08\xEEW\x92[a\x07\xE6\x84a\x0B\x02V[\x80\x15a\x08\xDCWa\x08Ma\x08\x17a\x08\x12a\x08\ra\x08\x08a\x08R\x95\x99\x97\x96\x99a\r\x7FV[a\nCV[a\x0F\x93V[a\x04,V[a\x08Ha\x08+a\x08&\x83a\x0B-V[a\x05gV[a\x08Ba\x06\x81a\x06\xEAa\x08=\x86a\x0BXV[a\x05\x7FV[\x90a\x0B\xA1V[a\x06 V[a\nkV[\x93`\0\x92[\x81\x84\x10a\x08\x89WPPPPa\x07T\x91a\x08v\x91`\0\x14a\x08{Wa\n\xDBV[a\x04EV[a\x08\x84\x90a\x04EV[a\n\xDBV[\x90\x91a\x08\xD2\x86a\x08\xCCa\x08\xA1\x85a\x08H\x86\x99\x9Ba\x069V[a\x08Ba\x08\xBCa\x08\xB7a\x07=a\x08v\x87\x80a\n\xBAV[a\n\x93V[a\x08\xC6\x83\x86a\n\xBAV[\x90a\x06 V[\x90a\x05\xA5V[\x95\x01\x92\x91\x90a\x08WV[`@Qc\x07\xA0!'`\xE0\x1B\x81R`\x04\x90\xFD[a\x08\xF7\x90a\x05\xDAV[\x92a\x07\xDDV[`@Qc\"\xEDY\x85`\xE2\x1B\x81R`\x04\x90\xFD[`@Qc-\x04\x83\xC5`\xE2\x1B\x81R`\x04\x90\xFD[Pg\x1B\xC1mgN\xC8\0\0\x83\x13a\x07\xB9V[\x90c;\x9A\xCA\0\x91\x82\x81\x02\x92\x81\x84\x04\x14\x90\x15\x17\x15a\x03OWV[\x91\x90\x92g\r\xE0\xB6\xB3\xA7d\0\0\x80\x84\x11a\t\xD9W\x83\x14a\t\xD0W\x82\x15a\t\xBFW\x80\x15a\t\xADWa\x02\xE4a\t\xA8\x93a\x08Ha\x01\xCEa\t\xA2a\x07T\x98\x96a\t\x9Ca\t\x97a\x08\ra\x07\0\x99a\x0FlV[a\t2V[\x90a\x0F V[\x92a\x05\xFDV[a\x05\x97V[PPa\x07T\x91a\x07\0a\t\xA8\x92a\x05\xFDV[PPP`\0\x81\x12\x80\x15\x16a\x03OW\x90V[PPPP`\0\x90V[`@Qc\xAA\xF3\x95o`\xE0\x1B\x81R`\x04\x90\xFD[`\x01`\xFF\x1B\x81\x14a\n\x06W`\0\x81\x12\x15a\x07TW\x19`\x01\x01\x90V[`@QcM-u\xB1`\xE0\x1B\x81R`\x04\x90\xFD[g\x02_\x0F\xE1\x05\xA3\x14\0\x90\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[g\x1B\xC1mgN\xC7\xFF\xFF\x19\x81\x81\x02\x91`\x01\x91\x83\x05\x14\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[g\t\xD0(\xCCo _\xFF\x19\x81\x81\x02\x91`\x01\x91\x83\x05\x14\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[g\x0F\xA8\xCE\xDF\xC2\xAD\xDD\xFA\x90\x80\x82\x02\x91\x82\x05\x14`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[g\x13\xA0K\xBD\xFD\xC9\xBE\x88\x90\x80\x82\x02\x91\x82\x05\x14`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\x1B\xC1mgN\xC8\0\0\x90\x05\x90V[g\x03\xC1f\\z\xAB \0\x90\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[f\x9F2u$b\xA0\0\x90\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[`\x01\x81\x15\x15\x16\x15a\x02\x15Wn\xC0\x97\xCE{\xC9\x07\x15\xB3K\x9F\x10\0\0\0\0\x05\x90V[g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17\x82\x15\x15\x16\x15a\x02\x15W\x05\x90V[h\x02H\xCE6\xA7\x0C\xB2k>\x19\x81\x13\x15a\x07dWh\x07U\xBFy\x8BJ\x1B\xF1\xE5\x81\x12\x15a\r\x13We\x03x-\xAC\xE9\xD9\x90`N\x1B\x05t\x02\x9D\x9D\xC3\x85c\xC3.\\/m\xC1\x92\xEEp\xEFe\xF9\x97\x8A\xF3k\xB1r\x17\xF7\xD1\xCFy\xAB\xC9\xE3\xB3\x98\x91``\x90`\x01`_\x1B\x84\x82\x84\x1B\x05\x01\x82\x1D\x93\x84\x02\x90\x03\x80l\x10\xFEh\xE7\xFD7\xD0\0{q?vP\x81\x01\x02\x82\x1D\x90n\x05\x87\xF5\x03\xBBn\xA2\x9D%\xFC\xB7@\x19dPn\x05\x18\x0B\xB1G\x99\xABG\xA8\xA8\xCB*R}W\x82n\x02\xC7#\x88\xD9\xF7OQ\xA93\x1F\xEDi?\x14\x19\x81m\xB1\xBB\xB2\x01\xF4C\xCF\x96/\x1A\x1D=\xB4\xA5\x81m\x1AR\x12U\xE3OjPa\xB2^\xF1\xC9\xC3\x19\x81m\x02wYI\x91\xCF\xC8_n$a\x83|\xD9\x81l$\x0C3\x0E\x9F\xB2\xD9\xCB\xAF\x0F\xD5\xAA\xFB\x19\x81\x01\x02\x8D\x1D\x01\x02\x8B\x1D\x01\x02\x89\x1D\x01\x02\x87\x1D\x01\x02\x85\x1D\x01\x93m6\rz\xEE\xA0\x93&>\xCCn\x0E\xCB)\x17`b\x1B\x93m\x02\xD1g W{\xD1\x9B\xF6\x14\x17o\xE9\xEA\x81\x01\x90\x84m\x01\xD3\x96~\xD3\x0F\xC4\xF8\x9C\x02\xBA\xB5p\x81\x19\x91\x01\x01\x02\x90\x1D\x01\x02\x01\x05\x02\x90`\xC3\x03\x1C\x90V[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x0C`$\x82\x01RkEXP_OVERFLOW`\xA0\x1B`D\x82\x01R`d\x90\xFD[\x15a\rNWV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\t`$\x82\x01Rh\x15S\x91\x11Q\x92S\x91Q`\xBA\x1B`D\x82\x01R`d\x90\xFD[}W\x11^G\x01\x8Cqw\xEE\xBF|\xD3p\xA35j\x1Bxc\0\x8AZ\xE8\x02\x8Cr\xB8\x86B\x84\x90a\r\xAB`\0\x82\x13a\rGV[q\x13@\xDA\xA0\xD5\xF7i\xDB\xA1\x91\\\xEFY\xF0\x81ZU\x06a\r\xC7\x82a\x10QV[``\x92\x83\x82`\x9F\x03\x01\x1B`\x9F\x1C\x90`_\x19\x01}\x02g\xA3l\x0C\x95\xB3\x97Z\xB3\xEE[ :v\x14\xA3\xF7Ss\xF0G\xD8\x03\xAE{f\x87\xF2\xB3\x02\x92l\x0Bz\x86\xD77Th\xFA\xC6g\xA0\xA5'\x82m\x01\x92\r\x80C\xCA\x89\xB5#\x92S(NB\x81m\n\x0Ft #\xDE\xF7\x83\xA3\x07\xA9\x86\x91.\x81m\x13\xCD\xFF\xB2\x9DQ\xD9\x93\"\xBD\xFF_\"\x11\x81m\r\xF9\x9A\xC5\x02\x03\x1B\xF9S\xEF\xF4r\xFD\xCC\x81m\x03\x88\xEA\xA2t\x12\xD5\xAC\xA0&\x81]cn\x81lFWr\xB2\xBB\xBB_\x82K\x15 z0\x81\x01\x02\x8C\x1D\x01\x02\x8A\x1D\x01\x02\x88\x1D\x01\x02\x86\x1D\x01\x02\x84\x1D\x01\x02\x82\x1D\x01\x91x\n\tPp\x84\xCCi\x9B\xB0\xE7\x1E\xA8i\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x19\x91l\xB9\xA0%\xD8\x14\xB2\x9C!+\x8B\x1A\x07\xCD\x19\x90\x82m\x028Gs\xBD\xF1\xACVv\xFA\xCC\xED`\x90\x19\x81l\x8C?8\xE9Zk\x1F\xF2\xAB\x1C;46\x19\x81m\x02$\x7Fz{e\x942\x06I\xAA\x03\xAB\xA1\x81m\x019`\x1A.\xFA\xBEq~`L\xBBH\x94\x81l)P\x8EE\x85C\xD8\xAAM\xF2\xAB\xEEx\x81\x01\x02\x89\x1D\x01\x02\x87\x1D\x01\x02\x85\x1D\x01\x02\x83\x1D\x01\x02\x90\x1D\x01\x02\x01\x05\x02\x01\x01`\xAE\x1D\x90V[\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x04\x90V[g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\x1B\xC1mgN\xC8\0\0\x90\x04\x90V[g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wc\x01\xE1\x85X\x90\x04\x90V[`\xB5\x81`\x01`\x88\x1B\x81\x10\x15a\x10:W[\x80i\x01\0\0\0\0\0\0\0\0\0b\x01\0\0\x92\x10\x15a\x10-W[e\x01\0\0\0\0\0\x81\x10\x15a\x10 W[c\x01\0\0\0\x81\x10\x15a\x10\x13W[\x01\x02`\x12\x1C`\x01\x90\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x90\x1C\x80\x80\x92\x04\x10\x90\x03\x90V[`\x10\x1C\x91`\x08\x1B\x91a\x0F\xD7V[` \x1C\x91`\x10\x1B\x91a\x0F\xCAV[`@\x1C\x91` \x1B\x91a\x0F\xBBV[Ph\xB5\0\0\0\0\0\0\0\0\x90P`\x80\x82\x90\x1Ca\x0F\xA3V[a\x10\\\x81\x15\x15a\rGV[\x80o\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x10`\x07\x1B\x81\x81\x1Cg\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x10`\x06\x1B\x17\x81\x81\x1Cc\xFF\xFF\xFF\xFF\x10`\x05\x1B\x17\x81\x81\x1Ca\xFF\xFF\x10`\x04\x1B\x17\x81\x81\x1C`\xFF\x10`\x03\x1B\x17\x81\x81\x1C`\x0F\x10`\x02\x1B\x17\x81\x81\x1C`\x03\x10`\x01\x1B\x17\x90\x81\x1C`\x01\x10\x17\x90V\xFE\xA2dipfsX\"\x12 .\xFEi\x03^\x07I%\xF9\x93I\xC8\xD7T\x99b,B\x04\xD2\xEC>\xAA\xFF\xEA\xF2\x0E\x08\"\xC7\xD8\xEEdsolcC\0\x08\x13\x003";
     /// The bytecode of the contract.
-    pub static ARBITERMATH_BYTECODE: ::ethers::core::types::Bytes =
-        ::ethers::core::types::Bytes::from_static(__BYTECODE);
+    pub static ARBITERMATH_BYTECODE: ::ethers::core::types::Bytes = ::ethers::core::types::Bytes::from_static(
+        __BYTECODE,
+    );
     #[rustfmt::skip]
-    const __DEPLOYED_BYTECODE: &[u8] = b"`\x80`@R4\x80\x15a\0]W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01\x90\x81Ra7\xB7`\xF1\x1B`d\x83\x01R`\x84\x82\xFD[P`\x046\x10a\0\xEBW`\x005`\xE0\x1C\x80c\xAE\x97h\xA8\x11a\0\xB3W\x80c\xAE\x97h\xA8\x14a\x01\xC1W\x80c\xBD%-\x06\x14a\x01\xD4W\x80c\xD0\xB7\x1B\x1E\x14a\x01\xE7W\x80c\xD2L\xE6\xE5\x14a\x01\xFAW\x80c\xE5$\xF8I\x14a\x02\rWa\0\xEBV[\x80c-[l\xB9\x14a\x01PW\x80c/Yw:\x14a\x01uW\x80c6yr:\x14a\x01\x88W\x80c7\xC6\xA4J\x14a\x01\x9BW\x80cgsB\xCE\x14a\x01\xAEW[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01\x90\x81Rtnor receive functions`X\x1B`d\x83\x01R`\x84\x82\xFD[a\x01ca\x01^6`\x04a\x0F\xF6V[a\x02 V[`@Q\x90\x81R` \x01`@Q\x80\x91\x03\x90\xF3[a\x01ca\x01\x836`\x04a\x10\x12V[a\x021V[a\x01ca\x01\x966`\x04a\x0F\xF6V[a\x02JV[a\x01ca\x01\xA96`\x04a\x10PV[a\x02UV[a\x01ca\x01\xBC6`\x04a\x0F\xF6V[a\x02hV[a\x01ca\x01\xCF6`\x04a\x10PV[a\x02sV[a\x01ca\x01\xE26`\x04a\x10PV[a\x02\x7FV[a\x01ca\x01\xF56`\x04a\x0F\xF6V[a\x02\x8BV[a\x01ca\x02\x086`\x04a\x0F\xF6V[a\x02\x96V[a\x01ca\x02\x1B6`\x04a\x10PV[a\x02\xA1V[`\0a\x02+\x82a\x02\xADV[\x92\x91PPV[`\0a\x02@\x86\x86\x86\x86\x86a\x04\x8DV[\x96\x95PPPPPPV[`\0a\x02+\x82a\x04\xAAV[`\0a\x02a\x83\x83a\x05PV[\x93\x92PPPV[`\0a\x02+\x82a\x05eV[`\0a\x02a\x83\x83a\x06\tV[`\0a\x02a\x83\x83a\x06\x1EV[`\0a\x02+\x82a\x063V[`\0a\x02+\x82a\x06\x9CV[`\0a\x02a\x83\x83a\x06\xF8V[`\0\x80\x82\x13a\x02\xEFW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\t`$\x82\x01Rh\x15S\x91\x11Q\x92S\x91Q`\xBA\x1B`D\x82\x01R`d\x01[`@Q\x80\x91\x03\x90\xFD[`\0``a\x02\xFC\x84a\x07\rV[\x03`\x9F\x81\x81\x03\x94\x90\x94\x1B\x90\x93\x1ClFWr\xB2\xBB\xBB_\x82K\x15 z0\x81\x01\x81\x02``\x90\x81\x1Dm\x03\x88\xEA\xA2t\x12\xD5\xAC\xA0&\x81]cn\x01\x82\x02\x81\x1Dm\r\xF9\x9A\xC5\x02\x03\x1B\xF9S\xEF\xF4r\xFD\xCC\x01\x82\x02\x81\x1Dm\x13\xCD\xFF\xB2\x9DQ\xD9\x93\"\xBD\xFF_\"\x11\x01\x82\x02\x81\x1Dm\n\x0Ft #\xDE\xF7\x83\xA3\x07\xA9\x86\x91.\x01\x82\x02\x81\x1Dm\x01\x92\r\x80C\xCA\x89\xB5#\x92S(NB\x01\x82\x02\x81\x1Dl\x0Bz\x86\xD77Th\xFA\xC6g\xA0\xA5'\x01l)P\x8EE\x85C\xD8\xAAM\xF2\xAB\xEEx\x83\x01\x83\x02\x82\x1Dm\x019`\x1A.\xFA\xBEq~`L\xBBH\x94\x01\x83\x02\x82\x1Dm\x02$\x7Fz{e\x942\x06I\xAA\x03\xAB\xA1\x01\x83\x02\x82\x1Dl\x8C?8\xE9Zk\x1F\xF2\xAB\x1C;46\x19\x01\x83\x02\x82\x1Dm\x028Gs\xBD\xF1\xACVv\xFA\xCC\xED`\x90\x19\x01\x83\x02\x90\x91\x1Dl\xB9\xA0%\xD8\x14\xB2\x9C!+\x8B\x1A\x07\xCD\x19\x01\x90\x91\x02x\n\tPp\x84\xCCi\x9B\xB0\xE7\x1E\xA8i\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x19\x01\x05q\x13@\xDA\xA0\xD5\xF7i\xDB\xA1\x91\\\xEFY\xF0\x81ZU\x06\x02}\x02g\xA3l\x0C\x95\xB3\x97Z\xB3\xEE[ :v\x14\xA3\xF7Ss\xF0G\xD8\x03\xAE{f\x87\xF2\xB3\x93\x90\x93\x02\x92\x90\x92\x01}W\x11^G\x01\x8Cqw\xEE\xBF|\xD3p\xA35j\x1Bxc\0\x8AZ\xE8\x02\x8Cr\xB8\x86B\x84\x01`\xAE\x1D\x92\x91PPV[`\0\x80a\x04\x9D\x86\x86\x86\x86\x86a\x07\xB5V[\x90\x96\x03\x96\x95PPPPPPV[`\0g\x06\xF0[Y\xD3\xB2\0\0\x82\x03a\x04\xC3WP`\0\x91\x90PV[g\r\xE0\xB6\xB3\xA7d\0\0\x82\x12a\x04\xEBW`@Qc\x07\xA0!'`\xE0\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[\x81`\0\x03a\x05\x0CW`@Qc\"\xEDY\x85`\xE2\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[`\0a\x05\x19\x83`\x02a\x10\x8BV[\x90P`\0a\x05&\x82a\x08\xD0V[\x90P`\0a\x05<g\x13\xA0K\xBD\xFD\xC9\xBE\x88\x83a\x0BLV[\x90Pa\x05G\x81a\x10\xBBV[\x95\x94PPPPPV[`\0a\x02a\x83g\r\xE0\xB6\xB3\xA7d\0\0\x84a\x0BaV[`\xB5\x81`\x01`\x88\x1B\x81\x10a\x05~W`@\x91\x90\x91\x1B\x90`\x80\x1C[i\x01\0\0\0\0\0\0\0\0\0\x81\x10a\x05\x9AW` \x91\x90\x91\x1B\x90`@\x1C[e\x01\0\0\0\0\0\x81\x10a\x05\xB2W`\x10\x91\x90\x91\x1B\x90` \x1C[c\x01\0\0\0\x81\x10a\x05\xC8W`\x08\x91\x90\x91\x1B\x90`\x10\x1C[b\x01\0\0\x01\x02`\x12\x1C\x80\x82\x04\x01`\x01\x90\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x90\x1C\x90\x81\x90\x04\x81\x11\x90\x03\x90V[`\0a\x02a\x83\x83g\r\xE0\xB6\xB3\xA7d\0\0a\x0B\x80V[`\0a\x02a\x83g\r\xE0\xB6\xB3\xA7d\0\0\x84a\x0B\x80V[`\0\x80g\x13\xA0K\xBD\xFD\xC9\xBE\x88a\x06Qg\r\xE0\xB6\xB3\xA7d\0\0\x85a\x10\x8BV[a\x06[\x91\x90a\x10\xD7V[\x90P`\0a\x06h\x82a\x10\xBBV[\x90P`\0a\x06u\x82a\x0B\xAEV[\x90Pg\x1B\xC1mgN\xC8\0\0a\x06\x92g\r\xE0\xB6\xB3\xA7d\0\0\x83a\x10\x8BV[a\x05G\x91\x90a\x10\xD7V[`\0\x80g\x1B\xC1mgN\xC8\0\0\x83a\x06\xB2\x81a\x10\xBBV[a\x06\xBC\x91\x90a\x10\x8BV[a\x06\xC6\x91\x90a\x10\xD7V[\x90Pa\x06\xD1\x81a\r\x92V[\x90Pg\"\xC9U\"\x95T\xC1\xB6a\x06\xEEg\r\xE0\xB6\xB3\xA7d\0\0\x83a\x10\x8BV[a\x02a\x91\x90a\x10\xD7V[`\0a\x02a\x83\x83g\r\xE0\xB6\xB3\xA7d\0\0a\x0BaV[`\0\x80\x82\x11a\x07JW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\t`$\x82\x01Rh\x15S\x91\x11Q\x92S\x91Q`\xBA\x1B`D\x82\x01R`d\x01a\x02\xE6V[P`\x01o\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11`\x07\x1B\x82\x81\x1Cg\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x10`\x06\x1B\x17\x82\x81\x1Cc\xFF\xFF\xFF\xFF\x10`\x05\x1B\x17\x82\x81\x1Ca\xFF\xFF\x10`\x04\x1B\x17\x82\x81\x1C`\xFF\x10`\x03\x90\x81\x1B\x90\x91\x17\x83\x81\x1C`\x0F\x10`\x02\x1B\x17\x83\x81\x1C\x90\x91\x10\x82\x1B\x17\x91\x82\x1C\x11\x17\x90V[`\0g\r\xE0\xB6\xB3\xA7d\0\0\x86\x11\x15a\x07\xE0W`@Qc\xAA\xF3\x95o`\xE0\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[g\r\xE0\xB6\xB3\xA7d\0\0\x86\x03a\x07\xF6WP\x80a\x05GV[\x85`\0\x03a\x08\x0FWa\x08\x08\x82\x86a\x11\x13V[\x90Pa\x05GV[\x82\x15a\x08\xAAW`\0a\x08%\x84c\x01\xE1\x85Xa\x05PV[\x90P`\0a\x082\x82a\x05eV[\x90Pa\x08Bc;\x9A\xCA\0\x82a\x11;V[\x90Pa\x08N\x86\x82a\x06\xF8V[\x90P`\0a\x08d\x89g\r\xE0\xB6\xB3\xA7d\0\0a\x11RV[\x90Pa\x08o\x81a\x04\xAAV[\x90P`\0a\x08}\x83\x83a\x11RV[\x90Pa\x08\x88\x81a\x063V[\x90P\x85a\x08\x95\x8A\x83a\x0BLV[a\x08\x9F\x91\x90a\x11\x13V[\x94PPPPPa\x05GV[\x81a\x08\xC6\x86a\x08\xC1\x89g\r\xE0\xB6\xB3\xA7d\0\0a\x11RV[a\x0BLV[a\x02@\x91\x90a\x11\x13V[`\0\x80\x82\x12\x80a\x08\xE7WPg\x1B\xC1mgN\xC8\0\0\x82\x13[\x15a\t\x05W`@Qc-\x04\x83\xC5`\xE2\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[\x81`\0\x03a\t&W`@Qc\x07\xA0!'`\xE0\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[\x81g\x1B\xC1mgN\xC8\0\0\x03a\tNW`@Qc\"\xEDY\x85`\xE2\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[\x80\x15a\tYW\x91\x90PV[`\0g\r\xE0\xB6\xB3\xA7d\0\0\x83\x12a\t\x81Wa\t|\x83g\x1B\xC1mgN\xC8\0\0a\x11RV[a\t\x83V[\x82[\x90P`\0a\t\x99\x82g\x1B\xC1mgN\xC8\0\0a\x0F;V[\x90P\x80`\0\x03a\t\xBCW`@Qc\x07\xA0!'`\xE0\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[`\0a\t\xC7\x82a\x02\xADV[\x90P`\0c;\x9A\xCA\0a\t\xF2a\t\xEDa\t\xE7g\x1B\xC1mgN\xC8\0\0a\x10\xBBV[\x85a\x0BLV[a\x05eV[a\t\xFC\x91\x90a\x10\x8BV[\x90P`\0\x80a\n\x13\x83g\x03\xC1f\\z\xAB \0a\x0BLV[a\n%\x90g \x05\xFEO&\x8E\xA0\0a\x11\x13V[\x90P`\0a\nP\x84a\n>\x86f\x9F2u$b\xA0\0a\x0BLV[a\x08\xC1\x90g\r\xC5R\x7Fd, \0a\x11\x13V[a\nb\x90g\r\xE0\xB6\xB3\xA7d\0\0a\x11\x13V[\x90Pa\n\x86g\t\xD0(\xCCo _\xFF\x19\x85a\n|\x85\x85a\x0F;V[a\x08\xC1\x91\x90a\x11RV[\x92PPP`\0[`\x02\x81\x10\x15a\x0B!W`\0\x86a\n\xA2\x84a\x0B\xAEV[a\n\xAC\x91\x90a\x11RV[\x90P`\0a\n\xBA\x84\x85a\x0BLV[a\n\xC3\x90a\x10\xBBV[\x90P`\0a\n\xD0\x82a\r\x92V[\x90P`\0a\n\xDE\x86\x85a\x0BLV[a\n\xF0g\x0F\xA8\xCE\xDF\xC2\xAD\xDD\xFA\x84a\x0BLV[a\n\xFA\x91\x90a\x11RV[\x90Pa\x0B\x06\x84\x82a\x0F;V[a\x0B\x10\x90\x87a\x11\x13V[\x95P\x84`\x01\x01\x94PPPPPa\n\x8DV[g\r\xE0\xB6\xB3\xA7d\0\0\x88\x12a\x0B>Wa\x0B9\x82a\x10\xBBV[a\x0B@V[\x81[\x98\x97PPPPPPPPV[`\0a\x02a\x83\x83g\r\xE0\xB6\xB3\xA7d\0\0a\x0FLV[\x82\x82\x02\x81\x15\x15\x84\x15\x85\x83\x04\x85\x14\x17\x16a\x0ByW`\0\x80\xFD[\x04\x92\x91PPV[\x82\x82\x02\x81\x15\x15\x84\x15\x85\x83\x04\x85\x14\x17\x16a\x0B\x98W`\0\x80\xFD[`\x01\x82`\x01\x83\x03\x04\x01\x81\x15\x15\x02\x90P\x93\x92PPPV[`\0\x81`\0\x03a\x0B\xC7WPg\r\xE0\xB6\xB3\xA7d\0\0\x91\x90PV[gV\x98\xEE\xF0fp\0\0\x82\x12a\x0B\xDEWP`\0\x91\x90PV[a\x0B\xEFgV\x98\xEE\xF0fp\0\0a\x10\xBBV[\x82\x13a\x0C\x04WPg\x1B\xC1mgN\xC8\0\0\x91\x90PV[`\0a\x0C\x0F\x83a\x0FkV[\x90P`\0a\x0CHg\r\xE0\xB6\xB3\xA7d\0\0a\x0C1\x84g\x1B\xC1mgN\xC8\0\0a\x05PV[a\x0CC\x90g\r\xE0\xB6\xB3\xA7d\0\0a\x11\x13V[a\x0F;V[\x90P`\0\x80\x82a\x0C\xA4\x81a\x0C\x91\x81a\x0C\x7F\x81a\x0Cl\x81g\x02_\x0F\xE1\x05\xA3\x14\0a\x0BLV[a\x08\xC1\x90g\x0Bh\xDF\x18\xE4q\xFB\xFF\x19a\x11\x13V[a\x08\xC1\x90g\x14\xA8EL\x19\xE1\xAC\0a\x11\x13V[a\x08\xC1\x90g\x0F\xC1\x0E\x01W\x82w\xFF\x19a\x11\x13V[a\x0C\xB6\x90g\x03\xDE\xBD\x08;\x8C|\0a\x11\x13V[\x91P\x83\x90Pa\r\x1E\x81a\r\x0C\x81a\x0C\xFA\x81a\x0C\xE8\x81a\x0C\xD5\x81\x8Ba\x0BLV[a\x08\xC1\x90g\x02\x95\xD4\0\xEA2W\xFF\x19a\x11\x13V[a\x08\xC1\x90g\x01W\xD8\xB2\xEC\xC7\x08\0a\x11\x13V[a\x08\xC1\x90g\x051\n\xA7\xD5!0\0a\x11\x13V[a\x08\xC1\x90g\r\xE0\xCC=\x15a\0\0a\x11\x13V[\x91P\x81g\x11\x90\0\xAB\x10\x0F\xFC\0a\r4\x87\x88a\x0BLV[a\r@\x90`\0\x19a\x10\x8BV[a\rJ\x91\x90a\x11RV[a\rT\x91\x90a\x11\x13V[\x92PP`\0a\rb\x83a\r\x92V[\x90P`\0a\rp\x85\x83a\x0BLV[\x90P`\0\x88\x12a\r\x80W\x80a\x0B@V[a\x0B@\x81g\x1B\xC1mgN\xC8\0\0a\x11RV[`\0h\x02H\xCE6\xA7\x0C\xB2k>\x19\x82\x13a\r\xADWP`\0\x91\x90PV[h\x07U\xBFy\x8BJ\x1B\xF1\xE5\x82\x12a\r\xF4W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x0C`$\x82\x01RkEXP_OVERFLOW`\xA0\x1B`D\x82\x01R`d\x01a\x02\xE6V[e\x03x-\xAC\xE9\xD9`N\x83\x90\x1B\x05\x91P`\0``k\xB1r\x17\xF7\xD1\xCFy\xAB\xC9\xE3\xB3\x98\x84\x82\x1B\x05`\x01`_\x1B\x01\x90\x1Dk\xB1r\x17\xF7\xD1\xCFy\xAB\xC9\xE3\xB3\x98\x81\x02\x90\x93\x03l$\x0C3\x0E\x9F\xB2\xD9\xCB\xAF\x0F\xD5\xAA\xFB\x19\x81\x01\x81\x02``\x90\x81\x1Dm\x02wYI\x91\xCF\xC8_n$a\x83|\xD9\x01\x82\x02\x81\x1Dm\x1AR\x12U\xE3OjPa\xB2^\xF1\xC9\xC3\x19\x01\x82\x02\x81\x1Dm\xB1\xBB\xB2\x01\xF4C\xCF\x96/\x1A\x1D=\xB4\xA5\x01\x82\x02\x81\x1Dn\x02\xC7#\x88\xD9\xF7OQ\xA93\x1F\xEDi?\x14\x19\x01\x82\x02\x81\x1Dn\x05\x18\x0B\xB1G\x99\xABG\xA8\xA8\xCB*R}W\x01m\x02\xD1g W{\xD1\x9B\xF6\x14\x17o\xE9\xEAl\x10\xFEh\xE7\xFD7\xD0\0{q?vP\x84\x01\x84\x02\x83\x1D\x90\x81\x01\x90\x84\x01m\x01\xD3\x96~\xD3\x0F\xC4\xF8\x9C\x02\xBA\xB5p\x81\x19\x01\x02\x90\x91\x1Dn\x05\x87\xF5\x03\xBBn\xA2\x9D%\xFC\xB7@\x19dP\x01\x90\x91\x02m6\rz\xEE\xA0\x93&>\xCCn\x0E\xCB)\x17`b\x1B\x01\x05t\x02\x9D\x9D\xC3\x85c\xC3.\\/m\xC1\x92\xEEp\xEFe\xF9\x97\x8A\xF3\x02`\xC3\x93\x90\x93\x03\x92\x90\x92\x1C\x92\x91PPV[`\0a\x02a\x83g\r\xE0\xB6\xB3\xA7d\0\0\x84[\x82\x82\x02\x81\x15\x15\x84\x15\x85\x83\x05\x85\x14\x17\x16a\x0FdW`\0\x80\xFD[\x05\x92\x91PPV[`\0`\x01`\xFF\x1B\x82\x03a\x0F\x91W`@QcM-u\xB1`\xE0\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[`\0\x82\x12\x15a\x0F\xA2WP\x19`\x01\x01\x90V[P\x90V[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x81\xFD[`\0` \x82\x84\x03\x12\x15a\x10\x0BWa\x10\x0Ba\x0F\xA6V[P5\x91\x90PV[`\0\x80`\0\x80`\0`\xA0\x86\x88\x03\x12\x15a\x10-Wa\x10-a\x0F\xA6V[PP\x835\x95` \x85\x015\x95P`@\x85\x015\x94``\x81\x015\x94P`\x80\x015\x92P\x90PV[`\0\x80`@\x83\x85\x03\x12\x15a\x10fWa\x10fa\x0F\xA6V[PP\x805\x92` \x90\x91\x015\x91PV[cNH{q`\xE0\x1B`\0R`\x11`\x04R`$`\0\xFD[\x80\x82\x02`\0\x82\x12`\x01`\xFF\x1B\x84\x14\x16\x15a\x10\xA7Wa\x10\xA7a\x10uV[\x81\x81\x05\x83\x14\x82\x15\x17a\x02+Wa\x02+a\x10uV[`\0`\x01`\xFF\x1B\x82\x01a\x10\xD0Wa\x10\xD0a\x10uV[P`\0\x03\x90V[`\0\x82a\x10\xF4WcNH{q`\xE0\x1B`\0R`\x12`\x04R`$`\0\xFD[`\x01`\xFF\x1B\x82\x14`\0\x19\x84\x14\x16\x15a\x11\x0EWa\x11\x0Ea\x10uV[P\x05\x90V[\x80\x82\x01\x82\x81\x12`\0\x83\x12\x80\x15\x82\x16\x82\x15\x82\x16\x17\x15a\x113Wa\x113a\x10uV[PP\x92\x91PPV[\x80\x82\x02\x81\x15\x82\x82\x04\x84\x14\x17a\x02+Wa\x02+a\x10uV[\x81\x81\x03`\0\x83\x12\x80\x15\x83\x83\x13\x16\x83\x83\x12\x82\x16\x17\x15a\x11rWa\x11ra\x10uV[P\x92\x91PPV\xFE\xA2dipfsX\"\x12 &\xC6Q\xA3\x8D>\xF3n\x80\xDF\x10s\xAC\xE4\x80\xA56\xC2\xCF<S\x07L\"\xA5\xE3\xDDEx\xF2}8dsolcC\0\x08\x13\x003";
+    const __DEPLOYED_BYTECODE: &[u8] = b"`\x80`@R`\x046\x10a\x03uW`\x005`\xE0\x1C\x80c-[l\xB9\x14a\0\xACW\x80c/Yw:\x14a\0\xA7W\x80c6yr:\x14a\0\xA2W\x80c7\xC6\xA4J\x14a\0\x9DW\x80cgsB\xCE\x14a\0\x98W\x80c\xAE\x97h\xA8\x14a\0\x93W\x80c\xBD%-\x06\x14a\0\x8EW\x80c\xD0\xB7\x1B\x1E\x14a\0\x89W\x80c\xD2L\xE6\xE5\x14a\0\x84Wc\xE5$\xF8I\x03a\x03uWa\x03TV[a\x02\xE9V[a\x02\xD1V[a\x02\x84V[a\x028V[a\x02\x1AV[a\x01\xD3V[a\x01\xBBV[a\x01\x83V[4a\0\xCCW` a\0\xC4a\0\xBF6a\x01lV[a\r\x7FV[`@Q\x90\x81R\xF3[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x90\xFD[` \x90`\x03\x19\x01\x12a\x01~W`\x045\x90V[a\x01\x1CV[4a\x01\xB6W`\xA06`\x03\x19\x01\x12a\x01~W` a\x01\xAA`\x845`d5`D5`$5a\tKV[`@Q\x90`\x045\x03\x81R\xF3[a\0\xCCV[4a\x01\xB6W` a\0\xC4a\x01\xCE6a\x01lV[a\x07wV[4a\x01\xB6W`@6`\x03\x19\x01\x12a\x01~W`\x045`$5\x90g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17\x82\x15\x15\x16\x15a\x02\x15W` \x91`@Q\x91\x04\x81R\xF3[`\0\x80\xFD[4a\x01\xB6W` 6`\x03\x19\x01\x12a\x01~W` a\0\xC4`\x045a\x0F\x93V[4a\x01\xB6W`@6`\x03\x19\x01\x12a\x01~W`\x045`$5\x90\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17`\x01\x16\x15a\x02\x15W` \x90`@Q\x90`\x01g\r\xE0\xB6\xB3\xA7d\0\0`\0\x19\x83\x01\x04\x01\x90\x15\x15\x02\x81R\xF3[4a\x01\xB6W`@6`\x03\x19\x01\x12a\x01~W`\x045`$5g\r\xE0\xB6\xB3\xA7d\0\0\x91\x82\x81\x02\x92\x81\x84\x04\x14\x90\x15\x17\x81\x15\x15\x16\x15a\x02\x15W` \x91`\x01`@Q\x92`\0\x19\x83\x01\x04\x01\x90\x15\x15\x02\x81R\xF3[4a\x01\xB6W` a\0\xC4a\x02\xE46a\x01lV[a\x04VV[4a\x01\xB6Wa\x02\xF76a\x01lV[a\x03\0\x81a\x04EV[\x80\x82\x02\x91`\0\x82\x12`\x01`\xFF\x1B\x82\x14\x16a\x03OW\x81\x83\x05\x14\x90\x15\x17\x15a\x03OWg\"\xC9U\"\x95T\xC1\xB6a\x03Fa\x03Ag\x1B\xC1mgN\xC8\0\0` \x94\x05a\x0B\xC3V[a\x03\xEEV[\x05`@Q\x90\x81R\xF3[a\x03\xD8V[4a\x01\xB6W`@6`\x03\x19\x01\x12a\x01~W` a\0\xC4`$5`\x045a\x0F V[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01Rtnor receive functions`X\x1B`d\x82\x01R`\x84\x90\xFD[cNH{q`\xE0\x1B`\0R`\x11`\x04R`$`\0\xFD[\x90g\r\xE0\xB6\xB3\xA7d\0\0\x91\x82\x81\x02\x92\x81\x84\x05\x14\x90\x15\x17\x15a\x03OWV[`\0\x81\x90\x03\x91\x90`\x01`\xFF\x1B\x81\x14`\x01\x16a\x03OW`\0\x19\x83\x05\x03a\x03OWV[\x90c;\x9A\xCA\0\x91\x82\x81\x02\x92\x81\x84\x05\x14\x90\x15\x17\x15a\x03OWV[`\x01`\xFF\x1B\x81\x14a\x03OW`\0\x03\x90V[a\x04\x85a\x03Aa\x04\x80g\x13\xA0K\xBD\xFD\xC9\xBE\x88a\x04zg\x1B\xC1mgN\xC8\0\0\x95a\x03\xEEV[\x05a\x04EV[a\x069V[\x05\x90V[\x90\x81g\r\xE0\xB6\xB3\xA7d\0\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\x0Bh\xDF\x18\xE4q\xFB\xFF\x19\x01\x91\x82\x12\x15`\x01\x16a\x03OWV[\x90\x81g\x14\xA8EL\x19\xE1\xAC\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\x0F\xC1\x0E\x01W\x82w\xFF\x19\x01\x91\x82\x12\x15`\x01\x16a\x03OWV[\x90\x81g\x03\xDE\xBD\x08;\x8C|\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\x02\x95\xD4\0\xEA2W\xFF\x19\x01\x91\x82\x12\x15`\x01\x16a\x03OWV[\x90\x81g\x01W\xD8\xB2\xEC\xC7\x08\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\x051\n\xA7\xD5!0\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\r\xE0\xCC=\x15a\0\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g \x05\xFEO&\x8E\xA0\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\r\xC5R\x7Fd, \0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90`\0\x82\x12\x80\x15\x16a\x03OWV[\x91\x90\x91`\0\x83\x82\x01\x93\x84\x12\x91\x12\x90\x80\x15\x82\x16\x91\x15\x16\x17a\x03OWV[\x90g\x11\x90\0\xAB\x10\x0F\xFB\xFF\x19\x82\x01\x91\x82\x13`\x01\x16a\x03OWV[\x90g\x1B\xC1mgN\xC8\0\0`\0\x83\x82\x03\x93\x12\x81\x84\x12\x81\x16\x91\x84\x13\x90\x15\x16\x17a\x03OWV[\x90g\r\xE0\xB6\xB3\xA7d\0\0`\0\x83\x82\x03\x93\x12\x81\x84\x12\x81\x16\x91\x84\x13\x90\x15\x16\x17a\x03OWV[\x81\x81\x03\x92\x91`\0\x13\x80\x15\x82\x85\x13\x16\x91\x84\x12\x16\x17a\x03OWV[\x80\x15a\x07jWgV\x98\xEE\xF0fp\0\0\x81\x12\x15a\x07dWgV\x98\xEE\xF0fo\xFF\xFF\x19\x81\x13\x15a\x07WWa\x07Ba\x06l\x82a\t\xEBV[a\x07\0a\x07=a\x06\x8Ba\x06\x86a\x06\x81\x85a\x0FAV[a\x04\x89V[a\x0B\x82V[\x92a\x078a\x073a\x07.a\x07'a\x07!a\x07\x1Ca\x07\x16a\x07\x11a\x07\x0Ba\x07\x06\x8Da\x07\0a\x06\xFBa\x06\xF5a\x06\xF0a\x06\xEAa\x06\xE5a\x06\xDFa\x06\xDAa\x06\xD4a\x06\xCF\x8Aa\n\x18V[a\x04\xA1V[\x89a\n\xBAV[a\x04\xBBV[\x87a\n\xBAV[a\x04\xD3V[\x85a\n\xBAV[a\x04\xEDV[\x83a\n\xBAV[a\x05\x05V[\x90a\n\xBAV[a\x05\x1FV[\x8Ca\n\xBAV[a\x057V[\x8Aa\n\xBAV[a\x05OV[\x88a\n\xBAV[\x93\x80a\n\xBAV[a\x04\x0BV[a\x05\xC1V[a\x05\xA5V[a\x0B\xC3V[\x90`\0\x13\x15a\x07TWa\x07T\x90a\x05\xDAV[\x90V[Pg\x1B\xC1mgN\xC8\0\0\x90V[P`\0\x90V[Pg\r\xE0\xB6\xB3\xA7d\0\0\x90V[g\x06\xF0[Y\xD3\xB2\0\0\x81\x14a\x07dWg\r\xE0\xB6\xB3\xA7d\0\0\x80\x82\x12\x15a\x08\xDCW\x81\x15a\x08\xFDW`\x01\x82\x81\x1B\x91`\x02\x93\x83\x05\x84\x03a\x03OW`\0\x83\x12\x80\x15a\t!W[a\t\x0FW\x82\x15a\x08\xDCWg\x1B\xC1mgN\xC8\0\0\x83\x14a\x08\xFDW\x82\x12\x91\x82\x15a\x08\xEEW\x92[a\x07\xE6\x84a\x0B\x02V[\x80\x15a\x08\xDCWa\x08Ma\x08\x17a\x08\x12a\x08\ra\x08\x08a\x08R\x95\x99\x97\x96\x99a\r\x7FV[a\nCV[a\x0F\x93V[a\x04,V[a\x08Ha\x08+a\x08&\x83a\x0B-V[a\x05gV[a\x08Ba\x06\x81a\x06\xEAa\x08=\x86a\x0BXV[a\x05\x7FV[\x90a\x0B\xA1V[a\x06 V[a\nkV[\x93`\0\x92[\x81\x84\x10a\x08\x89WPPPPa\x07T\x91a\x08v\x91`\0\x14a\x08{Wa\n\xDBV[a\x04EV[a\x08\x84\x90a\x04EV[a\n\xDBV[\x90\x91a\x08\xD2\x86a\x08\xCCa\x08\xA1\x85a\x08H\x86\x99\x9Ba\x069V[a\x08Ba\x08\xBCa\x08\xB7a\x07=a\x08v\x87\x80a\n\xBAV[a\n\x93V[a\x08\xC6\x83\x86a\n\xBAV[\x90a\x06 V[\x90a\x05\xA5V[\x95\x01\x92\x91\x90a\x08WV[`@Qc\x07\xA0!'`\xE0\x1B\x81R`\x04\x90\xFD[a\x08\xF7\x90a\x05\xDAV[\x92a\x07\xDDV[`@Qc\"\xEDY\x85`\xE2\x1B\x81R`\x04\x90\xFD[`@Qc-\x04\x83\xC5`\xE2\x1B\x81R`\x04\x90\xFD[Pg\x1B\xC1mgN\xC8\0\0\x83\x13a\x07\xB9V[\x90c;\x9A\xCA\0\x91\x82\x81\x02\x92\x81\x84\x04\x14\x90\x15\x17\x15a\x03OWV[\x91\x90\x92g\r\xE0\xB6\xB3\xA7d\0\0\x80\x84\x11a\t\xD9W\x83\x14a\t\xD0W\x82\x15a\t\xBFW\x80\x15a\t\xADWa\x02\xE4a\t\xA8\x93a\x08Ha\x01\xCEa\t\xA2a\x07T\x98\x96a\t\x9Ca\t\x97a\x08\ra\x07\0\x99a\x0FlV[a\t2V[\x90a\x0F V[\x92a\x05\xFDV[a\x05\x97V[PPa\x07T\x91a\x07\0a\t\xA8\x92a\x05\xFDV[PPP`\0\x81\x12\x80\x15\x16a\x03OW\x90V[PPPP`\0\x90V[`@Qc\xAA\xF3\x95o`\xE0\x1B\x81R`\x04\x90\xFD[`\x01`\xFF\x1B\x81\x14a\n\x06W`\0\x81\x12\x15a\x07TW\x19`\x01\x01\x90V[`@QcM-u\xB1`\xE0\x1B\x81R`\x04\x90\xFD[g\x02_\x0F\xE1\x05\xA3\x14\0\x90\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[g\x1B\xC1mgN\xC7\xFF\xFF\x19\x81\x81\x02\x91`\x01\x91\x83\x05\x14\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[g\t\xD0(\xCCo _\xFF\x19\x81\x81\x02\x91`\x01\x91\x83\x05\x14\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[g\x0F\xA8\xCE\xDF\xC2\xAD\xDD\xFA\x90\x80\x82\x02\x91\x82\x05\x14`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[g\x13\xA0K\xBD\xFD\xC9\xBE\x88\x90\x80\x82\x02\x91\x82\x05\x14`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\x1B\xC1mgN\xC8\0\0\x90\x05\x90V[g\x03\xC1f\\z\xAB \0\x90\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[f\x9F2u$b\xA0\0\x90\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[`\x01\x81\x15\x15\x16\x15a\x02\x15Wn\xC0\x97\xCE{\xC9\x07\x15\xB3K\x9F\x10\0\0\0\0\x05\x90V[g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17\x82\x15\x15\x16\x15a\x02\x15W\x05\x90V[h\x02H\xCE6\xA7\x0C\xB2k>\x19\x81\x13\x15a\x07dWh\x07U\xBFy\x8BJ\x1B\xF1\xE5\x81\x12\x15a\r\x13We\x03x-\xAC\xE9\xD9\x90`N\x1B\x05t\x02\x9D\x9D\xC3\x85c\xC3.\\/m\xC1\x92\xEEp\xEFe\xF9\x97\x8A\xF3k\xB1r\x17\xF7\xD1\xCFy\xAB\xC9\xE3\xB3\x98\x91``\x90`\x01`_\x1B\x84\x82\x84\x1B\x05\x01\x82\x1D\x93\x84\x02\x90\x03\x80l\x10\xFEh\xE7\xFD7\xD0\0{q?vP\x81\x01\x02\x82\x1D\x90n\x05\x87\xF5\x03\xBBn\xA2\x9D%\xFC\xB7@\x19dPn\x05\x18\x0B\xB1G\x99\xABG\xA8\xA8\xCB*R}W\x82n\x02\xC7#\x88\xD9\xF7OQ\xA93\x1F\xEDi?\x14\x19\x81m\xB1\xBB\xB2\x01\xF4C\xCF\x96/\x1A\x1D=\xB4\xA5\x81m\x1AR\x12U\xE3OjPa\xB2^\xF1\xC9\xC3\x19\x81m\x02wYI\x91\xCF\xC8_n$a\x83|\xD9\x81l$\x0C3\x0E\x9F\xB2\xD9\xCB\xAF\x0F\xD5\xAA\xFB\x19\x81\x01\x02\x8D\x1D\x01\x02\x8B\x1D\x01\x02\x89\x1D\x01\x02\x87\x1D\x01\x02\x85\x1D\x01\x93m6\rz\xEE\xA0\x93&>\xCCn\x0E\xCB)\x17`b\x1B\x93m\x02\xD1g W{\xD1\x9B\xF6\x14\x17o\xE9\xEA\x81\x01\x90\x84m\x01\xD3\x96~\xD3\x0F\xC4\xF8\x9C\x02\xBA\xB5p\x81\x19\x91\x01\x01\x02\x90\x1D\x01\x02\x01\x05\x02\x90`\xC3\x03\x1C\x90V[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x0C`$\x82\x01RkEXP_OVERFLOW`\xA0\x1B`D\x82\x01R`d\x90\xFD[\x15a\rNWV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\t`$\x82\x01Rh\x15S\x91\x11Q\x92S\x91Q`\xBA\x1B`D\x82\x01R`d\x90\xFD[}W\x11^G\x01\x8Cqw\xEE\xBF|\xD3p\xA35j\x1Bxc\0\x8AZ\xE8\x02\x8Cr\xB8\x86B\x84\x90a\r\xAB`\0\x82\x13a\rGV[q\x13@\xDA\xA0\xD5\xF7i\xDB\xA1\x91\\\xEFY\xF0\x81ZU\x06a\r\xC7\x82a\x10QV[``\x92\x83\x82`\x9F\x03\x01\x1B`\x9F\x1C\x90`_\x19\x01}\x02g\xA3l\x0C\x95\xB3\x97Z\xB3\xEE[ :v\x14\xA3\xF7Ss\xF0G\xD8\x03\xAE{f\x87\xF2\xB3\x02\x92l\x0Bz\x86\xD77Th\xFA\xC6g\xA0\xA5'\x82m\x01\x92\r\x80C\xCA\x89\xB5#\x92S(NB\x81m\n\x0Ft #\xDE\xF7\x83\xA3\x07\xA9\x86\x91.\x81m\x13\xCD\xFF\xB2\x9DQ\xD9\x93\"\xBD\xFF_\"\x11\x81m\r\xF9\x9A\xC5\x02\x03\x1B\xF9S\xEF\xF4r\xFD\xCC\x81m\x03\x88\xEA\xA2t\x12\xD5\xAC\xA0&\x81]cn\x81lFWr\xB2\xBB\xBB_\x82K\x15 z0\x81\x01\x02\x8C\x1D\x01\x02\x8A\x1D\x01\x02\x88\x1D\x01\x02\x86\x1D\x01\x02\x84\x1D\x01\x02\x82\x1D\x01\x91x\n\tPp\x84\xCCi\x9B\xB0\xE7\x1E\xA8i\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x19\x91l\xB9\xA0%\xD8\x14\xB2\x9C!+\x8B\x1A\x07\xCD\x19\x90\x82m\x028Gs\xBD\xF1\xACVv\xFA\xCC\xED`\x90\x19\x81l\x8C?8\xE9Zk\x1F\xF2\xAB\x1C;46\x19\x81m\x02$\x7Fz{e\x942\x06I\xAA\x03\xAB\xA1\x81m\x019`\x1A.\xFA\xBEq~`L\xBBH\x94\x81l)P\x8EE\x85C\xD8\xAAM\xF2\xAB\xEEx\x81\x01\x02\x89\x1D\x01\x02\x87\x1D\x01\x02\x85\x1D\x01\x02\x83\x1D\x01\x02\x90\x1D\x01\x02\x01\x05\x02\x01\x01`\xAE\x1D\x90V[\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x04\x90V[g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\x1B\xC1mgN\xC8\0\0\x90\x04\x90V[g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wc\x01\xE1\x85X\x90\x04\x90V[`\xB5\x81`\x01`\x88\x1B\x81\x10\x15a\x10:W[\x80i\x01\0\0\0\0\0\0\0\0\0b\x01\0\0\x92\x10\x15a\x10-W[e\x01\0\0\0\0\0\x81\x10\x15a\x10 W[c\x01\0\0\0\x81\x10\x15a\x10\x13W[\x01\x02`\x12\x1C`\x01\x90\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x90\x1C\x80\x80\x92\x04\x10\x90\x03\x90V[`\x10\x1C\x91`\x08\x1B\x91a\x0F\xD7V[` \x1C\x91`\x10\x1B\x91a\x0F\xCAV[`@\x1C\x91` \x1B\x91a\x0F\xBBV[Ph\xB5\0\0\0\0\0\0\0\0\x90P`\x80\x82\x90\x1Ca\x0F\xA3V[a\x10\\\x81\x15\x15a\rGV[\x80o\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x10`\x07\x1B\x81\x81\x1Cg\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x10`\x06\x1B\x17\x81\x81\x1Cc\xFF\xFF\xFF\xFF\x10`\x05\x1B\x17\x81\x81\x1Ca\xFF\xFF\x10`\x04\x1B\x17\x81\x81\x1C`\xFF\x10`\x03\x1B\x17\x81\x81\x1C`\x0F\x10`\x02\x1B\x17\x81\x81\x1C`\x03\x10`\x01\x1B\x17\x90\x81\x1C`\x01\x10\x17\x90V\xFE\xA2dipfsX\"\x12 .\xFEi\x03^\x07I%\xF9\x93I\xC8\xD7T\x99b,B\x04\xD2\xEC>\xAA\xFF\xEA\xF2\x0E\x08\"\xC7\xD8\xEEdsolcC\0\x08\x13\x003";
     /// The deployed bytecode of the contract.
-    pub static ARBITERMATH_DEPLOYED_BYTECODE: ::ethers::core::types::Bytes =
-        ::ethers::core::types::Bytes::from_static(__DEPLOYED_BYTECODE);
+    pub static ARBITERMATH_DEPLOYED_BYTECODE: ::ethers::core::types::Bytes = ::ethers::core::types::Bytes::from_static(
+        __DEPLOYED_BYTECODE,
+    );
     pub struct ArbiterMath<M>(::ethers::contract::Contract<M>);
     impl<M> ::core::clone::Clone for ArbiterMath<M> {
         fn clone(&self) -> Self {
@@ -382,38 +483,34 @@ pub mod arbiter_math {
         }
     }
     impl<M: ::ethers::providers::Middleware> ArbiterMath<M> {
-        /// Creates a new contract instance with the specified `ethers` client
-        /// at `address`. The contract derefs to a `ethers::Contract`
-        /// object.
+        /// Creates a new contract instance with the specified `ethers` client at
+        /// `address`. The contract derefs to a `ethers::Contract` object.
         pub fn new<T: Into<::ethers::core::types::Address>>(
             address: T,
             client: ::std::sync::Arc<M>,
         ) -> Self {
-            Self(::ethers::contract::Contract::new(
-                address.into(),
-                ARBITERMATH_ABI.clone(),
-                client,
-            ))
+            Self(
+                ::ethers::contract::Contract::new(
+                    address.into(),
+                    ARBITERMATH_ABI.clone(),
+                    client,
+                ),
+            )
         }
-        /// Constructs the general purpose `Deployer` instance based on the
-        /// provided constructor arguments and sends it. Returns a new
-        /// instance of a deployer that returns an instance of this contract
-        /// after sending the transaction
+        /// Constructs the general purpose `Deployer` instance based on the provided constructor arguments and sends it.
+        /// Returns a new instance of a deployer that returns an instance of this contract after sending the transaction
         ///
         /// Notes:
-        /// - If there are no constructor arguments, you should pass `()` as the
-        ///   argument.
+        /// - If there are no constructor arguments, you should pass `()` as the argument.
         /// - The default poll duration is 7 seconds.
         /// - The default number of confirmations is 1 block.
         ///
         ///
         /// # Example
         ///
-        /// Generate contract bindings with `abigen!` and deploy a new contract
-        /// instance.
+        /// Generate contract bindings with `abigen!` and deploy a new contract instance.
         ///
-        /// *Note*: this requires a `bytecode` and `abi` object in the
-        /// `greeter.json` artifact.
+        /// *Note*: this requires a `bytecode` and `abi` object in the `greeter.json` artifact.
         ///
         /// ```ignore
         /// # async fn deploy<M: ethers::providers::Middleware>(client: ::std::sync::Arc<M>) {
@@ -439,7 +536,7 @@ pub mod arbiter_math {
             let deployer = ::ethers::contract::ContractDeployer::new(deployer);
             Ok(deployer)
         }
-        /// Calls the contract's `cdf` (0xd0b71b1e) function
+        ///Calls the contract's `cdf` (0xd0b71b1e) function
         pub fn cdf(
             &self,
             input: ::ethers::core::types::I256,
@@ -448,7 +545,7 @@ pub mod arbiter_math {
                 .method_hash([208, 183, 27, 30], input)
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `divWadDown` (0x37c6a44a) function
+        ///Calls the contract's `divWadDown` (0x37c6a44a) function
         pub fn div_wad_down(
             &self,
             x: ::ethers::core::types::U256,
@@ -458,7 +555,7 @@ pub mod arbiter_math {
                 .method_hash([55, 198, 164, 74], (x, y))
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `divWadUp` (0xbd252d06) function
+        ///Calls the contract's `divWadUp` (0xbd252d06) function
         pub fn div_wad_up(
             &self,
             x: ::ethers::core::types::U256,
@@ -468,7 +565,7 @@ pub mod arbiter_math {
                 .method_hash([189, 37, 45, 6], (x, y))
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `invariant` (0x2f59773a) function
+        ///Calls the contract's `invariant` (0x2f59773a) function
         pub fn invariant(
             &self,
             r_y: ::ethers::core::types::U256,
@@ -481,7 +578,7 @@ pub mod arbiter_math {
                 .method_hash([47, 89, 119, 58], (r_y, r_x, stk, vol, tau))
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `log` (0x2d5b6cb9) function
+        ///Calls the contract's `log` (0x2d5b6cb9) function
         pub fn log(
             &self,
             x: ::ethers::core::types::I256,
@@ -490,7 +587,7 @@ pub mod arbiter_math {
                 .method_hash([45, 91, 108, 185], x)
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `mulWadDown` (0xe524f849) function
+        ///Calls the contract's `mulWadDown` (0xe524f849) function
         pub fn mul_wad_down(
             &self,
             x: ::ethers::core::types::U256,
@@ -500,7 +597,7 @@ pub mod arbiter_math {
                 .method_hash([229, 36, 248, 73], (x, y))
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `mulWadUp` (0xae9768a8) function
+        ///Calls the contract's `mulWadUp` (0xae9768a8) function
         pub fn mul_wad_up(
             &self,
             x: ::ethers::core::types::U256,
@@ -510,7 +607,7 @@ pub mod arbiter_math {
                 .method_hash([174, 151, 104, 168], (x, y))
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `pdf` (0xd24ce6e5) function
+        ///Calls the contract's `pdf` (0xd24ce6e5) function
         pub fn pdf(
             &self,
             input: ::ethers::core::types::I256,
@@ -519,7 +616,7 @@ pub mod arbiter_math {
                 .method_hash([210, 76, 230, 229], input)
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `ppf` (0x3679723a) function
+        ///Calls the contract's `ppf` (0x3679723a) function
         pub fn ppf(
             &self,
             input: ::ethers::core::types::I256,
@@ -528,7 +625,7 @@ pub mod arbiter_math {
                 .method_hash([54, 121, 114, 58], input)
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `sqrt` (0x677342ce) function
+        ///Calls the contract's `sqrt` (0x677342ce) function
         pub fn sqrt(
             &self,
             x: ::ethers::core::types::U256,
@@ -538,81 +635,98 @@ pub mod arbiter_math {
                 .expect("method not found (this should never happen)")
         }
     }
-    impl<M: ::ethers::providers::Middleware> From<::ethers::contract::Contract<M>> for ArbiterMath<M> {
+    impl<M: ::ethers::providers::Middleware> From<::ethers::contract::Contract<M>>
+    for ArbiterMath<M> {
         fn from(contract: ::ethers::contract::Contract<M>) -> Self {
             Self::new(contract.address(), contract.client())
         }
     }
-    /// Custom Error type `Infinity` with signature `Infinity()` and selector
-    /// `0x07a02127`
+    ///Custom Error type `Infinity` with signature `Infinity()` and selector `0x07a02127`
     #[derive(
         Clone,
         ::ethers::contract::EthError,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[etherror(name = "Infinity", abi = "Infinity()")]
     pub struct Infinity;
-    /// Custom Error type `Min` with signature `Min()` and selector `0x4d2d75b1`
+    ///Custom Error type `Min` with signature `Min()` and selector `0x4d2d75b1`
     #[derive(
         Clone,
         ::ethers::contract::EthError,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[etherror(name = "Min", abi = "Min()")]
     pub struct Min;
-    /// Custom Error type `NegativeInfinity` with signature `NegativeInfinity()`
-    /// and selector `0x8bb56614`
+    ///Custom Error type `NegativeInfinity` with signature `NegativeInfinity()` and selector `0x8bb56614`
     #[derive(
         Clone,
         ::ethers::contract::EthError,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[etherror(name = "NegativeInfinity", abi = "NegativeInfinity()")]
     pub struct NegativeInfinity;
-    /// Custom Error type `OOB` with signature `OOB()` and selector `0xaaf3956f`
+    ///Custom Error type `OOB` with signature `OOB()` and selector `0xaaf3956f`
     #[derive(
         Clone,
         ::ethers::contract::EthError,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[etherror(name = "OOB", abi = "OOB()")]
     pub struct OOB;
-    /// Custom Error type `OutOfBounds` with signature `OutOfBounds()` and
-    /// selector `0xb4120f14`
+    ///Custom Error type `OutOfBounds` with signature `OutOfBounds()` and selector `0xb4120f14`
     #[derive(
         Clone,
         ::ethers::contract::EthError,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[etherror(name = "OutOfBounds", abi = "OutOfBounds()")]
     pub struct OutOfBounds;
-    /// Container type for all of the contract's custom errors
-    #[derive(Clone, ::ethers::contract::EthAbiType, Debug, PartialEq, Eq, Hash)]
+    ///Container type for all of the contract's custom errors
+    #[derive(
+        Clone,
+        ::ethers::contract::EthAbiType,
+        serde::Serialize,
+        serde::Deserialize,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
     pub enum ArbiterMathErrors {
         Infinity(Infinity),
         Min(Min),
@@ -628,25 +742,30 @@ pub mod arbiter_math {
             data: impl AsRef<[u8]>,
         ) -> ::core::result::Result<Self, ::ethers::core::abi::AbiError> {
             let data = data.as_ref();
-            if let Ok(decoded) =
-                <::std::string::String as ::ethers::core::abi::AbiDecode>::decode(data)
-            {
+            if let Ok(decoded) = <::std::string::String as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::RevertString(decoded));
             }
-            if let Ok(decoded) = <Infinity as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <Infinity as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::Infinity(decoded));
             }
             if let Ok(decoded) = <Min as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Min(decoded));
             }
-            if let Ok(decoded) = <NegativeInfinity as ::ethers::core::abi::AbiDecode>::decode(data)
-            {
+            if let Ok(decoded) = <NegativeInfinity as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::NegativeInfinity(decoded));
             }
             if let Ok(decoded) = <OOB as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::OOB(decoded));
             }
-            if let Ok(decoded) = <OutOfBounds as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <OutOfBounds as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::OutOfBounds(decoded));
             }
             Err(::ethers::core::abi::Error::InvalidData.into())
@@ -655,11 +774,17 @@ pub mod arbiter_math {
     impl ::ethers::core::abi::AbiEncode for ArbiterMathErrors {
         fn encode(self) -> ::std::vec::Vec<u8> {
             match self {
-                Self::Infinity(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::Infinity(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
                 Self::Min(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::NegativeInfinity(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::NegativeInfinity(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
                 Self::OOB(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::OutOfBounds(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::OutOfBounds(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
                 Self::RevertString(s) => ::ethers::core::abi::AbiEncode::encode(s),
             }
         }
@@ -668,13 +793,20 @@ pub mod arbiter_math {
         fn valid_selector(selector: [u8; 4]) -> bool {
             match selector {
                 [0x08, 0xc3, 0x79, 0xa0] => true,
-                _ if selector == <Infinity as ::ethers::contract::EthError>::selector() => true,
-                _ if selector == <Min as ::ethers::contract::EthError>::selector() => true,
-                _ if selector == <NegativeInfinity as ::ethers::contract::EthError>::selector() => {
+                _ if selector
+                    == <Infinity as ::ethers::contract::EthError>::selector() => true,
+                _ if selector == <Min as ::ethers::contract::EthError>::selector() => {
                     true
                 }
-                _ if selector == <OOB as ::ethers::contract::EthError>::selector() => true,
-                _ if selector == <OutOfBounds as ::ethers::contract::EthError>::selector() => true,
+                _ if selector
+                    == <NegativeInfinity as ::ethers::contract::EthError>::selector() => {
+                    true
+                }
+                _ if selector == <OOB as ::ethers::contract::EthError>::selector() => {
+                    true
+                }
+                _ if selector
+                    == <OutOfBounds as ::ethers::contract::EthError>::selector() => true,
                 _ => false,
             }
         }
@@ -721,68 +853,71 @@ pub mod arbiter_math {
             Self::OutOfBounds(value)
         }
     }
-    /// Container type for all input parameters for the `cdf` function with
-    /// signature `cdf(int256)` and selector `0xd0b71b1e`
+    ///Container type for all input parameters for the `cdf` function with signature `cdf(int256)` and selector `0xd0b71b1e`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "cdf", abi = "cdf(int256)")]
     pub struct CdfCall {
         pub input: ::ethers::core::types::I256,
     }
-    /// Container type for all input parameters for the `divWadDown` function
-    /// with signature `divWadDown(uint256,uint256)` and selector `0x37c6a44a`
+    ///Container type for all input parameters for the `divWadDown` function with signature `divWadDown(uint256,uint256)` and selector `0x37c6a44a`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "divWadDown", abi = "divWadDown(uint256,uint256)")]
     pub struct DivWadDownCall {
         pub x: ::ethers::core::types::U256,
         pub y: ::ethers::core::types::U256,
     }
-    /// Container type for all input parameters for the `divWadUp` function with
-    /// signature `divWadUp(uint256,uint256)` and selector `0xbd252d06`
+    ///Container type for all input parameters for the `divWadUp` function with signature `divWadUp(uint256,uint256)` and selector `0xbd252d06`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "divWadUp", abi = "divWadUp(uint256,uint256)")]
     pub struct DivWadUpCall {
         pub x: ::ethers::core::types::U256,
         pub y: ::ethers::core::types::U256,
     }
-    /// Container type for all input parameters for the `invariant` function
-    /// with signature `invariant(uint256,uint256,uint256,uint256,uint256)` and
-    /// selector `0x2f59773a`
+    ///Container type for all input parameters for the `invariant` function with signature `invariant(uint256,uint256,uint256,uint256,uint256)` and selector `0x2f59773a`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(
         name = "invariant",
@@ -795,106 +930,121 @@ pub mod arbiter_math {
         pub vol: ::ethers::core::types::U256,
         pub tau: ::ethers::core::types::U256,
     }
-    /// Container type for all input parameters for the `log` function with
-    /// signature `log(int256)` and selector `0x2d5b6cb9`
+    ///Container type for all input parameters for the `log` function with signature `log(int256)` and selector `0x2d5b6cb9`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "log", abi = "log(int256)")]
     pub struct LogCall {
         pub x: ::ethers::core::types::I256,
     }
-    /// Container type for all input parameters for the `mulWadDown` function
-    /// with signature `mulWadDown(uint256,uint256)` and selector `0xe524f849`
+    ///Container type for all input parameters for the `mulWadDown` function with signature `mulWadDown(uint256,uint256)` and selector `0xe524f849`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "mulWadDown", abi = "mulWadDown(uint256,uint256)")]
     pub struct MulWadDownCall {
         pub x: ::ethers::core::types::U256,
         pub y: ::ethers::core::types::U256,
     }
-    /// Container type for all input parameters for the `mulWadUp` function with
-    /// signature `mulWadUp(uint256,uint256)` and selector `0xae9768a8`
+    ///Container type for all input parameters for the `mulWadUp` function with signature `mulWadUp(uint256,uint256)` and selector `0xae9768a8`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "mulWadUp", abi = "mulWadUp(uint256,uint256)")]
     pub struct MulWadUpCall {
         pub x: ::ethers::core::types::U256,
         pub y: ::ethers::core::types::U256,
     }
-    /// Container type for all input parameters for the `pdf` function with
-    /// signature `pdf(int256)` and selector `0xd24ce6e5`
+    ///Container type for all input parameters for the `pdf` function with signature `pdf(int256)` and selector `0xd24ce6e5`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "pdf", abi = "pdf(int256)")]
     pub struct PdfCall {
         pub input: ::ethers::core::types::I256,
     }
-    /// Container type for all input parameters for the `ppf` function with
-    /// signature `ppf(int256)` and selector `0x3679723a`
+    ///Container type for all input parameters for the `ppf` function with signature `ppf(int256)` and selector `0x3679723a`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "ppf", abi = "ppf(int256)")]
     pub struct PpfCall {
         pub input: ::ethers::core::types::I256,
     }
-    /// Container type for all input parameters for the `sqrt` function with
-    /// signature `sqrt(uint256)` and selector `0x677342ce`
+    ///Container type for all input parameters for the `sqrt` function with signature `sqrt(uint256)` and selector `0x677342ce`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "sqrt", abi = "sqrt(uint256)")]
     pub struct SqrtCall {
         pub x: ::ethers::core::types::U256,
     }
-    /// Container type for all of the contract's call
-    #[derive(Clone, ::ethers::contract::EthAbiType, Debug, PartialEq, Eq, Hash)]
+    ///Container type for all of the contract's call
+    #[derive(
+        Clone,
+        ::ethers::contract::EthAbiType,
+        serde::Serialize,
+        serde::Deserialize,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
     pub enum ArbiterMathCalls {
         Cdf(CdfCall),
         DivWadDown(DivWadDownCall),
@@ -912,34 +1062,54 @@ pub mod arbiter_math {
             data: impl AsRef<[u8]>,
         ) -> ::core::result::Result<Self, ::ethers::core::abi::AbiError> {
             let data = data.as_ref();
-            if let Ok(decoded) = <CdfCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <CdfCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::Cdf(decoded));
             }
-            if let Ok(decoded) = <DivWadDownCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <DivWadDownCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::DivWadDown(decoded));
             }
-            if let Ok(decoded) = <DivWadUpCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <DivWadUpCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::DivWadUp(decoded));
             }
-            if let Ok(decoded) = <InvariantCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <InvariantCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::Invariant(decoded));
             }
-            if let Ok(decoded) = <LogCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <LogCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::Log(decoded));
             }
-            if let Ok(decoded) = <MulWadDownCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <MulWadDownCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::MulWadDown(decoded));
             }
-            if let Ok(decoded) = <MulWadUpCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <MulWadUpCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::MulWadUp(decoded));
             }
-            if let Ok(decoded) = <PdfCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <PdfCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::Pdf(decoded));
             }
-            if let Ok(decoded) = <PpfCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <PpfCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::Ppf(decoded));
             }
-            if let Ok(decoded) = <SqrtCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <SqrtCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::Sqrt(decoded));
             }
             Err(::ethers::core::abi::Error::InvalidData.into())
@@ -949,12 +1119,22 @@ pub mod arbiter_math {
         fn encode(self) -> Vec<u8> {
             match self {
                 Self::Cdf(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::DivWadDown(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::DivWadUp(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::Invariant(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::DivWadDown(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
+                Self::DivWadUp(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
+                Self::Invariant(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
                 Self::Log(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::MulWadDown(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::MulWadUp(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::MulWadDown(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
+                Self::MulWadUp(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
                 Self::Pdf(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Ppf(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Sqrt(element) => ::ethers::core::abi::AbiEncode::encode(element),
@@ -1027,153 +1207,162 @@ pub mod arbiter_math {
             Self::Sqrt(value)
         }
     }
-    /// Container type for all return fields from the `cdf` function with
-    /// signature `cdf(int256)` and selector `0xd0b71b1e`
+    ///Container type for all return fields from the `cdf` function with signature `cdf(int256)` and selector `0xd0b71b1e`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct CdfReturn {
         pub output: ::ethers::core::types::I256,
     }
-    /// Container type for all return fields from the `divWadDown` function with
-    /// signature `divWadDown(uint256,uint256)` and selector `0x37c6a44a`
+    ///Container type for all return fields from the `divWadDown` function with signature `divWadDown(uint256,uint256)` and selector `0x37c6a44a`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct DivWadDownReturn {
         pub z: ::ethers::core::types::U256,
     }
-    /// Container type for all return fields from the `divWadUp` function with
-    /// signature `divWadUp(uint256,uint256)` and selector `0xbd252d06`
+    ///Container type for all return fields from the `divWadUp` function with signature `divWadUp(uint256,uint256)` and selector `0xbd252d06`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct DivWadUpReturn {
         pub z: ::ethers::core::types::U256,
     }
-    /// Container type for all return fields from the `invariant` function with
-    /// signature `invariant(uint256,uint256,uint256,uint256,uint256)` and
-    /// selector `0x2f59773a`
+    ///Container type for all return fields from the `invariant` function with signature `invariant(uint256,uint256,uint256,uint256,uint256)` and selector `0x2f59773a`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct InvariantReturn {
         pub k: ::ethers::core::types::I256,
     }
-    /// Container type for all return fields from the `log` function with
-    /// signature `log(int256)` and selector `0x2d5b6cb9`
+    ///Container type for all return fields from the `log` function with signature `log(int256)` and selector `0x2d5b6cb9`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct LogReturn {
         pub z: ::ethers::core::types::I256,
     }
-    /// Container type for all return fields from the `mulWadDown` function with
-    /// signature `mulWadDown(uint256,uint256)` and selector `0xe524f849`
+    ///Container type for all return fields from the `mulWadDown` function with signature `mulWadDown(uint256,uint256)` and selector `0xe524f849`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct MulWadDownReturn {
         pub z: ::ethers::core::types::U256,
     }
-    /// Container type for all return fields from the `mulWadUp` function with
-    /// signature `mulWadUp(uint256,uint256)` and selector `0xae9768a8`
+    ///Container type for all return fields from the `mulWadUp` function with signature `mulWadUp(uint256,uint256)` and selector `0xae9768a8`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct MulWadUpReturn {
         pub z: ::ethers::core::types::U256,
     }
-    /// Container type for all return fields from the `pdf` function with
-    /// signature `pdf(int256)` and selector `0xd24ce6e5`
+    ///Container type for all return fields from the `pdf` function with signature `pdf(int256)` and selector `0xd24ce6e5`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct PdfReturn {
         pub output: ::ethers::core::types::I256,
     }
-    /// Container type for all return fields from the `ppf` function with
-    /// signature `ppf(int256)` and selector `0x3679723a`
+    ///Container type for all return fields from the `ppf` function with signature `ppf(int256)` and selector `0x3679723a`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct PpfReturn {
         pub output: ::ethers::core::types::I256,
     }
-    /// Container type for all return fields from the `sqrt` function with
-    /// signature `sqrt(uint256)` and selector `0x677342ce`
+    ///Container type for all return fields from the `sqrt` function with signature `sqrt(uint256)` and selector `0x677342ce`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct SqrtReturn {
         pub z: ::ethers::core::types::U256,

--- a/arbiter-core/src/bindings/arbiter_math.rs
+++ b/arbiter-core/src/bindings/arbiter_math.rs
@@ -7,7 +7,7 @@ pub use arbiter_math::*;
     clippy::upper_case_acronyms,
     clippy::type_complexity,
     dead_code,
-    non_camel_case_types,
+    non_camel_case_types
 )]
 pub mod arbiter_math {
     #[allow(deprecated)]
@@ -17,447 +17,346 @@ pub mod arbiter_math {
             functions: ::core::convert::From::from([
                 (
                     ::std::borrow::ToOwned::to_owned("cdf"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("cdf"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("input"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("int256"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("output"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("int256"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("cdf"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("input"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("int256"),
+                            ),
+                        },],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("output"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("int256"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("divWadDown"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("divWadDown"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("x"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("y"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("z"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("divWadDown"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("x"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("y"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("z"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint256"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("divWadUp"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("divWadUp"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("x"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("y"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("z"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("divWadUp"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("x"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("y"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("z"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint256"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("invariant"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("invariant"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("R_y"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("R_x"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("stk"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("vol"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("tau"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("k"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("int256"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("invariant"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("R_y"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("R_x"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("stk"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("vol"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("tau"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("k"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("int256"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("log"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("log"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("x"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("int256"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("z"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("int256"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("log"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("x"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("int256"),
+                            ),
+                        },],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("z"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("int256"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("mulWadDown"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("mulWadDown"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("x"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("y"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("z"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("mulWadDown"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("x"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("y"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("z"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint256"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("mulWadUp"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("mulWadUp"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("x"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("y"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("z"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("mulWadUp"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("x"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("y"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("z"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint256"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("pdf"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("pdf"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("input"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("int256"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("output"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("int256"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("pdf"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("input"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("int256"),
+                            ),
+                        },],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("output"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("int256"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("ppf"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("ppf"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("input"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("int256"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("output"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("int256"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("ppf"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("input"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("int256"),
+                            ),
+                        },],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("output"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("int256"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("sqrt"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("sqrt"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("x"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("z"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("sqrt"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("x"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint256"),
+                            ),
+                        },],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("z"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint256"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::Pure,
+                    },],
                 ),
             ]),
             events: ::std::collections::BTreeMap::new(),
             errors: ::core::convert::From::from([
                 (
                     ::std::borrow::ToOwned::to_owned("Infinity"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::AbiError {
-                            name: ::std::borrow::ToOwned::to_owned("Infinity"),
-                            inputs: ::std::vec![],
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::AbiError {
+                        name: ::std::borrow::ToOwned::to_owned("Infinity"),
+                        inputs: ::std::vec![],
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("Min"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::AbiError {
-                            name: ::std::borrow::ToOwned::to_owned("Min"),
-                            inputs: ::std::vec![],
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::AbiError {
+                        name: ::std::borrow::ToOwned::to_owned("Min"),
+                        inputs: ::std::vec![],
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("NegativeInfinity"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::AbiError {
-                            name: ::std::borrow::ToOwned::to_owned("NegativeInfinity"),
-                            inputs: ::std::vec![],
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::AbiError {
+                        name: ::std::borrow::ToOwned::to_owned("NegativeInfinity"),
+                        inputs: ::std::vec![],
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("OOB"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::AbiError {
-                            name: ::std::borrow::ToOwned::to_owned("OOB"),
-                            inputs: ::std::vec![],
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::AbiError {
+                        name: ::std::borrow::ToOwned::to_owned("OOB"),
+                        inputs: ::std::vec![],
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("OutOfBounds"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::AbiError {
-                            name: ::std::borrow::ToOwned::to_owned("OutOfBounds"),
-                            inputs: ::std::vec![],
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::AbiError {
+                        name: ::std::borrow::ToOwned::to_owned("OutOfBounds"),
+                        inputs: ::std::vec![],
+                    },],
                 ),
             ]),
             receive: false,
             fallback: false,
         }
     }
-    ///The parsed JSON ABI of the contract.
-    pub static ARBITERMATH_ABI: ::ethers::contract::Lazy<::ethers::core::abi::Abi> = ::ethers::contract::Lazy::new(
-        __abi,
-    );
+    /// The parsed JSON ABI of the contract.
+    pub static ARBITERMATH_ABI: ::ethers::contract::Lazy<::ethers::core::abi::Abi> =
+        ::ethers::contract::Lazy::new(__abi);
     #[rustfmt::skip]
     const __BYTECODE: &[u8] = b"`\x80\x80`@R4a\0\x19W`@Qa\x10\xF9\x90\x81a\0g\x829\xF3[bF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD\xFE`\x80`@R`\x046\x10a\x03uW`\x005`\xE0\x1C\x80c-[l\xB9\x14a\0\xACW\x80c/Yw:\x14a\0\xA7W\x80c6yr:\x14a\0\xA2W\x80c7\xC6\xA4J\x14a\0\x9DW\x80cgsB\xCE\x14a\0\x98W\x80c\xAE\x97h\xA8\x14a\0\x93W\x80c\xBD%-\x06\x14a\0\x8EW\x80c\xD0\xB7\x1B\x1E\x14a\0\x89W\x80c\xD2L\xE6\xE5\x14a\0\x84Wc\xE5$\xF8I\x03a\x03uWa\x03TV[a\x02\xE9V[a\x02\xD1V[a\x02\x84V[a\x028V[a\x02\x1AV[a\x01\xD3V[a\x01\xBBV[a\x01\x83V[4a\0\xCCW` a\0\xC4a\0\xBF6a\x01lV[a\r\x7FV[`@Q\x90\x81R\xF3[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x90\xFD[` \x90`\x03\x19\x01\x12a\x01~W`\x045\x90V[a\x01\x1CV[4a\x01\xB6W`\xA06`\x03\x19\x01\x12a\x01~W` a\x01\xAA`\x845`d5`D5`$5a\tKV[`@Q\x90`\x045\x03\x81R\xF3[a\0\xCCV[4a\x01\xB6W` a\0\xC4a\x01\xCE6a\x01lV[a\x07wV[4a\x01\xB6W`@6`\x03\x19\x01\x12a\x01~W`\x045`$5\x90g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17\x82\x15\x15\x16\x15a\x02\x15W` \x91`@Q\x91\x04\x81R\xF3[`\0\x80\xFD[4a\x01\xB6W` 6`\x03\x19\x01\x12a\x01~W` a\0\xC4`\x045a\x0F\x93V[4a\x01\xB6W`@6`\x03\x19\x01\x12a\x01~W`\x045`$5\x90\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17`\x01\x16\x15a\x02\x15W` \x90`@Q\x90`\x01g\r\xE0\xB6\xB3\xA7d\0\0`\0\x19\x83\x01\x04\x01\x90\x15\x15\x02\x81R\xF3[4a\x01\xB6W`@6`\x03\x19\x01\x12a\x01~W`\x045`$5g\r\xE0\xB6\xB3\xA7d\0\0\x91\x82\x81\x02\x92\x81\x84\x04\x14\x90\x15\x17\x81\x15\x15\x16\x15a\x02\x15W` \x91`\x01`@Q\x92`\0\x19\x83\x01\x04\x01\x90\x15\x15\x02\x81R\xF3[4a\x01\xB6W` a\0\xC4a\x02\xE46a\x01lV[a\x04VV[4a\x01\xB6Wa\x02\xF76a\x01lV[a\x03\0\x81a\x04EV[\x80\x82\x02\x91`\0\x82\x12`\x01`\xFF\x1B\x82\x14\x16a\x03OW\x81\x83\x05\x14\x90\x15\x17\x15a\x03OWg\"\xC9U\"\x95T\xC1\xB6a\x03Fa\x03Ag\x1B\xC1mgN\xC8\0\0` \x94\x05a\x0B\xC3V[a\x03\xEEV[\x05`@Q\x90\x81R\xF3[a\x03\xD8V[4a\x01\xB6W`@6`\x03\x19\x01\x12a\x01~W` a\0\xC4`$5`\x045a\x0F V[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01Rtnor receive functions`X\x1B`d\x82\x01R`\x84\x90\xFD[cNH{q`\xE0\x1B`\0R`\x11`\x04R`$`\0\xFD[\x90g\r\xE0\xB6\xB3\xA7d\0\0\x91\x82\x81\x02\x92\x81\x84\x05\x14\x90\x15\x17\x15a\x03OWV[`\0\x81\x90\x03\x91\x90`\x01`\xFF\x1B\x81\x14`\x01\x16a\x03OW`\0\x19\x83\x05\x03a\x03OWV[\x90c;\x9A\xCA\0\x91\x82\x81\x02\x92\x81\x84\x05\x14\x90\x15\x17\x15a\x03OWV[`\x01`\xFF\x1B\x81\x14a\x03OW`\0\x03\x90V[a\x04\x85a\x03Aa\x04\x80g\x13\xA0K\xBD\xFD\xC9\xBE\x88a\x04zg\x1B\xC1mgN\xC8\0\0\x95a\x03\xEEV[\x05a\x04EV[a\x069V[\x05\x90V[\x90\x81g\r\xE0\xB6\xB3\xA7d\0\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\x0Bh\xDF\x18\xE4q\xFB\xFF\x19\x01\x91\x82\x12\x15`\x01\x16a\x03OWV[\x90\x81g\x14\xA8EL\x19\xE1\xAC\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\x0F\xC1\x0E\x01W\x82w\xFF\x19\x01\x91\x82\x12\x15`\x01\x16a\x03OWV[\x90\x81g\x03\xDE\xBD\x08;\x8C|\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\x02\x95\xD4\0\xEA2W\xFF\x19\x01\x91\x82\x12\x15`\x01\x16a\x03OWV[\x90\x81g\x01W\xD8\xB2\xEC\xC7\x08\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\x051\n\xA7\xD5!0\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\r\xE0\xCC=\x15a\0\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g \x05\xFEO&\x8E\xA0\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\r\xC5R\x7Fd, \0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90`\0\x82\x12\x80\x15\x16a\x03OWV[\x91\x90\x91`\0\x83\x82\x01\x93\x84\x12\x91\x12\x90\x80\x15\x82\x16\x91\x15\x16\x17a\x03OWV[\x90g\x11\x90\0\xAB\x10\x0F\xFB\xFF\x19\x82\x01\x91\x82\x13`\x01\x16a\x03OWV[\x90g\x1B\xC1mgN\xC8\0\0`\0\x83\x82\x03\x93\x12\x81\x84\x12\x81\x16\x91\x84\x13\x90\x15\x16\x17a\x03OWV[\x90g\r\xE0\xB6\xB3\xA7d\0\0`\0\x83\x82\x03\x93\x12\x81\x84\x12\x81\x16\x91\x84\x13\x90\x15\x16\x17a\x03OWV[\x81\x81\x03\x92\x91`\0\x13\x80\x15\x82\x85\x13\x16\x91\x84\x12\x16\x17a\x03OWV[\x80\x15a\x07jWgV\x98\xEE\xF0fp\0\0\x81\x12\x15a\x07dWgV\x98\xEE\xF0fo\xFF\xFF\x19\x81\x13\x15a\x07WWa\x07Ba\x06l\x82a\t\xEBV[a\x07\0a\x07=a\x06\x8Ba\x06\x86a\x06\x81\x85a\x0FAV[a\x04\x89V[a\x0B\x82V[\x92a\x078a\x073a\x07.a\x07'a\x07!a\x07\x1Ca\x07\x16a\x07\x11a\x07\x0Ba\x07\x06\x8Da\x07\0a\x06\xFBa\x06\xF5a\x06\xF0a\x06\xEAa\x06\xE5a\x06\xDFa\x06\xDAa\x06\xD4a\x06\xCF\x8Aa\n\x18V[a\x04\xA1V[\x89a\n\xBAV[a\x04\xBBV[\x87a\n\xBAV[a\x04\xD3V[\x85a\n\xBAV[a\x04\xEDV[\x83a\n\xBAV[a\x05\x05V[\x90a\n\xBAV[a\x05\x1FV[\x8Ca\n\xBAV[a\x057V[\x8Aa\n\xBAV[a\x05OV[\x88a\n\xBAV[\x93\x80a\n\xBAV[a\x04\x0BV[a\x05\xC1V[a\x05\xA5V[a\x0B\xC3V[\x90`\0\x13\x15a\x07TWa\x07T\x90a\x05\xDAV[\x90V[Pg\x1B\xC1mgN\xC8\0\0\x90V[P`\0\x90V[Pg\r\xE0\xB6\xB3\xA7d\0\0\x90V[g\x06\xF0[Y\xD3\xB2\0\0\x81\x14a\x07dWg\r\xE0\xB6\xB3\xA7d\0\0\x80\x82\x12\x15a\x08\xDCW\x81\x15a\x08\xFDW`\x01\x82\x81\x1B\x91`\x02\x93\x83\x05\x84\x03a\x03OW`\0\x83\x12\x80\x15a\t!W[a\t\x0FW\x82\x15a\x08\xDCWg\x1B\xC1mgN\xC8\0\0\x83\x14a\x08\xFDW\x82\x12\x91\x82\x15a\x08\xEEW\x92[a\x07\xE6\x84a\x0B\x02V[\x80\x15a\x08\xDCWa\x08Ma\x08\x17a\x08\x12a\x08\ra\x08\x08a\x08R\x95\x99\x97\x96\x99a\r\x7FV[a\nCV[a\x0F\x93V[a\x04,V[a\x08Ha\x08+a\x08&\x83a\x0B-V[a\x05gV[a\x08Ba\x06\x81a\x06\xEAa\x08=\x86a\x0BXV[a\x05\x7FV[\x90a\x0B\xA1V[a\x06 V[a\nkV[\x93`\0\x92[\x81\x84\x10a\x08\x89WPPPPa\x07T\x91a\x08v\x91`\0\x14a\x08{Wa\n\xDBV[a\x04EV[a\x08\x84\x90a\x04EV[a\n\xDBV[\x90\x91a\x08\xD2\x86a\x08\xCCa\x08\xA1\x85a\x08H\x86\x99\x9Ba\x069V[a\x08Ba\x08\xBCa\x08\xB7a\x07=a\x08v\x87\x80a\n\xBAV[a\n\x93V[a\x08\xC6\x83\x86a\n\xBAV[\x90a\x06 V[\x90a\x05\xA5V[\x95\x01\x92\x91\x90a\x08WV[`@Qc\x07\xA0!'`\xE0\x1B\x81R`\x04\x90\xFD[a\x08\xF7\x90a\x05\xDAV[\x92a\x07\xDDV[`@Qc\"\xEDY\x85`\xE2\x1B\x81R`\x04\x90\xFD[`@Qc-\x04\x83\xC5`\xE2\x1B\x81R`\x04\x90\xFD[Pg\x1B\xC1mgN\xC8\0\0\x83\x13a\x07\xB9V[\x90c;\x9A\xCA\0\x91\x82\x81\x02\x92\x81\x84\x04\x14\x90\x15\x17\x15a\x03OWV[\x91\x90\x92g\r\xE0\xB6\xB3\xA7d\0\0\x80\x84\x11a\t\xD9W\x83\x14a\t\xD0W\x82\x15a\t\xBFW\x80\x15a\t\xADWa\x02\xE4a\t\xA8\x93a\x08Ha\x01\xCEa\t\xA2a\x07T\x98\x96a\t\x9Ca\t\x97a\x08\ra\x07\0\x99a\x0FlV[a\t2V[\x90a\x0F V[\x92a\x05\xFDV[a\x05\x97V[PPa\x07T\x91a\x07\0a\t\xA8\x92a\x05\xFDV[PPP`\0\x81\x12\x80\x15\x16a\x03OW\x90V[PPPP`\0\x90V[`@Qc\xAA\xF3\x95o`\xE0\x1B\x81R`\x04\x90\xFD[`\x01`\xFF\x1B\x81\x14a\n\x06W`\0\x81\x12\x15a\x07TW\x19`\x01\x01\x90V[`@QcM-u\xB1`\xE0\x1B\x81R`\x04\x90\xFD[g\x02_\x0F\xE1\x05\xA3\x14\0\x90\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[g\x1B\xC1mgN\xC7\xFF\xFF\x19\x81\x81\x02\x91`\x01\x91\x83\x05\x14\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[g\t\xD0(\xCCo _\xFF\x19\x81\x81\x02\x91`\x01\x91\x83\x05\x14\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[g\x0F\xA8\xCE\xDF\xC2\xAD\xDD\xFA\x90\x80\x82\x02\x91\x82\x05\x14`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[g\x13\xA0K\xBD\xFD\xC9\xBE\x88\x90\x80\x82\x02\x91\x82\x05\x14`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\x1B\xC1mgN\xC8\0\0\x90\x05\x90V[g\x03\xC1f\\z\xAB \0\x90\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[f\x9F2u$b\xA0\0\x90\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[`\x01\x81\x15\x15\x16\x15a\x02\x15Wn\xC0\x97\xCE{\xC9\x07\x15\xB3K\x9F\x10\0\0\0\0\x05\x90V[g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17\x82\x15\x15\x16\x15a\x02\x15W\x05\x90V[h\x02H\xCE6\xA7\x0C\xB2k>\x19\x81\x13\x15a\x07dWh\x07U\xBFy\x8BJ\x1B\xF1\xE5\x81\x12\x15a\r\x13We\x03x-\xAC\xE9\xD9\x90`N\x1B\x05t\x02\x9D\x9D\xC3\x85c\xC3.\\/m\xC1\x92\xEEp\xEFe\xF9\x97\x8A\xF3k\xB1r\x17\xF7\xD1\xCFy\xAB\xC9\xE3\xB3\x98\x91``\x90`\x01`_\x1B\x84\x82\x84\x1B\x05\x01\x82\x1D\x93\x84\x02\x90\x03\x80l\x10\xFEh\xE7\xFD7\xD0\0{q?vP\x81\x01\x02\x82\x1D\x90n\x05\x87\xF5\x03\xBBn\xA2\x9D%\xFC\xB7@\x19dPn\x05\x18\x0B\xB1G\x99\xABG\xA8\xA8\xCB*R}W\x82n\x02\xC7#\x88\xD9\xF7OQ\xA93\x1F\xEDi?\x14\x19\x81m\xB1\xBB\xB2\x01\xF4C\xCF\x96/\x1A\x1D=\xB4\xA5\x81m\x1AR\x12U\xE3OjPa\xB2^\xF1\xC9\xC3\x19\x81m\x02wYI\x91\xCF\xC8_n$a\x83|\xD9\x81l$\x0C3\x0E\x9F\xB2\xD9\xCB\xAF\x0F\xD5\xAA\xFB\x19\x81\x01\x02\x8D\x1D\x01\x02\x8B\x1D\x01\x02\x89\x1D\x01\x02\x87\x1D\x01\x02\x85\x1D\x01\x93m6\rz\xEE\xA0\x93&>\xCCn\x0E\xCB)\x17`b\x1B\x93m\x02\xD1g W{\xD1\x9B\xF6\x14\x17o\xE9\xEA\x81\x01\x90\x84m\x01\xD3\x96~\xD3\x0F\xC4\xF8\x9C\x02\xBA\xB5p\x81\x19\x91\x01\x01\x02\x90\x1D\x01\x02\x01\x05\x02\x90`\xC3\x03\x1C\x90V[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x0C`$\x82\x01RkEXP_OVERFLOW`\xA0\x1B`D\x82\x01R`d\x90\xFD[\x15a\rNWV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\t`$\x82\x01Rh\x15S\x91\x11Q\x92S\x91Q`\xBA\x1B`D\x82\x01R`d\x90\xFD[}W\x11^G\x01\x8Cqw\xEE\xBF|\xD3p\xA35j\x1Bxc\0\x8AZ\xE8\x02\x8Cr\xB8\x86B\x84\x90a\r\xAB`\0\x82\x13a\rGV[q\x13@\xDA\xA0\xD5\xF7i\xDB\xA1\x91\\\xEFY\xF0\x81ZU\x06a\r\xC7\x82a\x10QV[``\x92\x83\x82`\x9F\x03\x01\x1B`\x9F\x1C\x90`_\x19\x01}\x02g\xA3l\x0C\x95\xB3\x97Z\xB3\xEE[ :v\x14\xA3\xF7Ss\xF0G\xD8\x03\xAE{f\x87\xF2\xB3\x02\x92l\x0Bz\x86\xD77Th\xFA\xC6g\xA0\xA5'\x82m\x01\x92\r\x80C\xCA\x89\xB5#\x92S(NB\x81m\n\x0Ft #\xDE\xF7\x83\xA3\x07\xA9\x86\x91.\x81m\x13\xCD\xFF\xB2\x9DQ\xD9\x93\"\xBD\xFF_\"\x11\x81m\r\xF9\x9A\xC5\x02\x03\x1B\xF9S\xEF\xF4r\xFD\xCC\x81m\x03\x88\xEA\xA2t\x12\xD5\xAC\xA0&\x81]cn\x81lFWr\xB2\xBB\xBB_\x82K\x15 z0\x81\x01\x02\x8C\x1D\x01\x02\x8A\x1D\x01\x02\x88\x1D\x01\x02\x86\x1D\x01\x02\x84\x1D\x01\x02\x82\x1D\x01\x91x\n\tPp\x84\xCCi\x9B\xB0\xE7\x1E\xA8i\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x19\x91l\xB9\xA0%\xD8\x14\xB2\x9C!+\x8B\x1A\x07\xCD\x19\x90\x82m\x028Gs\xBD\xF1\xACVv\xFA\xCC\xED`\x90\x19\x81l\x8C?8\xE9Zk\x1F\xF2\xAB\x1C;46\x19\x81m\x02$\x7Fz{e\x942\x06I\xAA\x03\xAB\xA1\x81m\x019`\x1A.\xFA\xBEq~`L\xBBH\x94\x81l)P\x8EE\x85C\xD8\xAAM\xF2\xAB\xEEx\x81\x01\x02\x89\x1D\x01\x02\x87\x1D\x01\x02\x85\x1D\x01\x02\x83\x1D\x01\x02\x90\x1D\x01\x02\x01\x05\x02\x01\x01`\xAE\x1D\x90V[\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x04\x90V[g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\x1B\xC1mgN\xC8\0\0\x90\x04\x90V[g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wc\x01\xE1\x85X\x90\x04\x90V[`\xB5\x81`\x01`\x88\x1B\x81\x10\x15a\x10:W[\x80i\x01\0\0\0\0\0\0\0\0\0b\x01\0\0\x92\x10\x15a\x10-W[e\x01\0\0\0\0\0\x81\x10\x15a\x10 W[c\x01\0\0\0\x81\x10\x15a\x10\x13W[\x01\x02`\x12\x1C`\x01\x90\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x90\x1C\x80\x80\x92\x04\x10\x90\x03\x90V[`\x10\x1C\x91`\x08\x1B\x91a\x0F\xD7V[` \x1C\x91`\x10\x1B\x91a\x0F\xCAV[`@\x1C\x91` \x1B\x91a\x0F\xBBV[Ph\xB5\0\0\0\0\0\0\0\0\x90P`\x80\x82\x90\x1Ca\x0F\xA3V[a\x10\\\x81\x15\x15a\rGV[\x80o\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x10`\x07\x1B\x81\x81\x1Cg\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x10`\x06\x1B\x17\x81\x81\x1Cc\xFF\xFF\xFF\xFF\x10`\x05\x1B\x17\x81\x81\x1Ca\xFF\xFF\x10`\x04\x1B\x17\x81\x81\x1C`\xFF\x10`\x03\x1B\x17\x81\x81\x1C`\x0F\x10`\x02\x1B\x17\x81\x81\x1C`\x03\x10`\x01\x1B\x17\x90\x81\x1C`\x01\x10\x17\x90V\xFE\xA2dipfsX\"\x12 .\xFEi\x03^\x07I%\xF9\x93I\xC8\xD7T\x99b,B\x04\xD2\xEC>\xAA\xFF\xEA\xF2\x0E\x08\"\xC7\xD8\xEEdsolcC\0\x08\x13\x003";
     /// The bytecode of the contract.
-    pub static ARBITERMATH_BYTECODE: ::ethers::core::types::Bytes = ::ethers::core::types::Bytes::from_static(
-        __BYTECODE,
-    );
+    pub static ARBITERMATH_BYTECODE: ::ethers::core::types::Bytes =
+        ::ethers::core::types::Bytes::from_static(__BYTECODE);
     #[rustfmt::skip]
     const __DEPLOYED_BYTECODE: &[u8] = b"`\x80`@R`\x046\x10a\x03uW`\x005`\xE0\x1C\x80c-[l\xB9\x14a\0\xACW\x80c/Yw:\x14a\0\xA7W\x80c6yr:\x14a\0\xA2W\x80c7\xC6\xA4J\x14a\0\x9DW\x80cgsB\xCE\x14a\0\x98W\x80c\xAE\x97h\xA8\x14a\0\x93W\x80c\xBD%-\x06\x14a\0\x8EW\x80c\xD0\xB7\x1B\x1E\x14a\0\x89W\x80c\xD2L\xE6\xE5\x14a\0\x84Wc\xE5$\xF8I\x03a\x03uWa\x03TV[a\x02\xE9V[a\x02\xD1V[a\x02\x84V[a\x028V[a\x02\x1AV[a\x01\xD3V[a\x01\xBBV[a\x01\x83V[4a\0\xCCW` a\0\xC4a\0\xBF6a\x01lV[a\r\x7FV[`@Q\x90\x81R\xF3[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x90\xFD[` \x90`\x03\x19\x01\x12a\x01~W`\x045\x90V[a\x01\x1CV[4a\x01\xB6W`\xA06`\x03\x19\x01\x12a\x01~W` a\x01\xAA`\x845`d5`D5`$5a\tKV[`@Q\x90`\x045\x03\x81R\xF3[a\0\xCCV[4a\x01\xB6W` a\0\xC4a\x01\xCE6a\x01lV[a\x07wV[4a\x01\xB6W`@6`\x03\x19\x01\x12a\x01~W`\x045`$5\x90g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17\x82\x15\x15\x16\x15a\x02\x15W` \x91`@Q\x91\x04\x81R\xF3[`\0\x80\xFD[4a\x01\xB6W` 6`\x03\x19\x01\x12a\x01~W` a\0\xC4`\x045a\x0F\x93V[4a\x01\xB6W`@6`\x03\x19\x01\x12a\x01~W`\x045`$5\x90\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17`\x01\x16\x15a\x02\x15W` \x90`@Q\x90`\x01g\r\xE0\xB6\xB3\xA7d\0\0`\0\x19\x83\x01\x04\x01\x90\x15\x15\x02\x81R\xF3[4a\x01\xB6W`@6`\x03\x19\x01\x12a\x01~W`\x045`$5g\r\xE0\xB6\xB3\xA7d\0\0\x91\x82\x81\x02\x92\x81\x84\x04\x14\x90\x15\x17\x81\x15\x15\x16\x15a\x02\x15W` \x91`\x01`@Q\x92`\0\x19\x83\x01\x04\x01\x90\x15\x15\x02\x81R\xF3[4a\x01\xB6W` a\0\xC4a\x02\xE46a\x01lV[a\x04VV[4a\x01\xB6Wa\x02\xF76a\x01lV[a\x03\0\x81a\x04EV[\x80\x82\x02\x91`\0\x82\x12`\x01`\xFF\x1B\x82\x14\x16a\x03OW\x81\x83\x05\x14\x90\x15\x17\x15a\x03OWg\"\xC9U\"\x95T\xC1\xB6a\x03Fa\x03Ag\x1B\xC1mgN\xC8\0\0` \x94\x05a\x0B\xC3V[a\x03\xEEV[\x05`@Q\x90\x81R\xF3[a\x03\xD8V[4a\x01\xB6W`@6`\x03\x19\x01\x12a\x01~W` a\0\xC4`$5`\x045a\x0F V[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01Rtnor receive functions`X\x1B`d\x82\x01R`\x84\x90\xFD[cNH{q`\xE0\x1B`\0R`\x11`\x04R`$`\0\xFD[\x90g\r\xE0\xB6\xB3\xA7d\0\0\x91\x82\x81\x02\x92\x81\x84\x05\x14\x90\x15\x17\x15a\x03OWV[`\0\x81\x90\x03\x91\x90`\x01`\xFF\x1B\x81\x14`\x01\x16a\x03OW`\0\x19\x83\x05\x03a\x03OWV[\x90c;\x9A\xCA\0\x91\x82\x81\x02\x92\x81\x84\x05\x14\x90\x15\x17\x15a\x03OWV[`\x01`\xFF\x1B\x81\x14a\x03OW`\0\x03\x90V[a\x04\x85a\x03Aa\x04\x80g\x13\xA0K\xBD\xFD\xC9\xBE\x88a\x04zg\x1B\xC1mgN\xC8\0\0\x95a\x03\xEEV[\x05a\x04EV[a\x069V[\x05\x90V[\x90\x81g\r\xE0\xB6\xB3\xA7d\0\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\x0Bh\xDF\x18\xE4q\xFB\xFF\x19\x01\x91\x82\x12\x15`\x01\x16a\x03OWV[\x90\x81g\x14\xA8EL\x19\xE1\xAC\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\x0F\xC1\x0E\x01W\x82w\xFF\x19\x01\x91\x82\x12\x15`\x01\x16a\x03OWV[\x90\x81g\x03\xDE\xBD\x08;\x8C|\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\x02\x95\xD4\0\xEA2W\xFF\x19\x01\x91\x82\x12\x15`\x01\x16a\x03OWV[\x90\x81g\x01W\xD8\xB2\xEC\xC7\x08\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\x051\n\xA7\xD5!0\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\r\xE0\xCC=\x15a\0\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g \x05\xFEO&\x8E\xA0\0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90\x81g\r\xC5R\x7Fd, \0\x01\x91\x82\x12`\x01\x16a\x03OWV[\x90`\0\x82\x12\x80\x15\x16a\x03OWV[\x91\x90\x91`\0\x83\x82\x01\x93\x84\x12\x91\x12\x90\x80\x15\x82\x16\x91\x15\x16\x17a\x03OWV[\x90g\x11\x90\0\xAB\x10\x0F\xFB\xFF\x19\x82\x01\x91\x82\x13`\x01\x16a\x03OWV[\x90g\x1B\xC1mgN\xC8\0\0`\0\x83\x82\x03\x93\x12\x81\x84\x12\x81\x16\x91\x84\x13\x90\x15\x16\x17a\x03OWV[\x90g\r\xE0\xB6\xB3\xA7d\0\0`\0\x83\x82\x03\x93\x12\x81\x84\x12\x81\x16\x91\x84\x13\x90\x15\x16\x17a\x03OWV[\x81\x81\x03\x92\x91`\0\x13\x80\x15\x82\x85\x13\x16\x91\x84\x12\x16\x17a\x03OWV[\x80\x15a\x07jWgV\x98\xEE\xF0fp\0\0\x81\x12\x15a\x07dWgV\x98\xEE\xF0fo\xFF\xFF\x19\x81\x13\x15a\x07WWa\x07Ba\x06l\x82a\t\xEBV[a\x07\0a\x07=a\x06\x8Ba\x06\x86a\x06\x81\x85a\x0FAV[a\x04\x89V[a\x0B\x82V[\x92a\x078a\x073a\x07.a\x07'a\x07!a\x07\x1Ca\x07\x16a\x07\x11a\x07\x0Ba\x07\x06\x8Da\x07\0a\x06\xFBa\x06\xF5a\x06\xF0a\x06\xEAa\x06\xE5a\x06\xDFa\x06\xDAa\x06\xD4a\x06\xCF\x8Aa\n\x18V[a\x04\xA1V[\x89a\n\xBAV[a\x04\xBBV[\x87a\n\xBAV[a\x04\xD3V[\x85a\n\xBAV[a\x04\xEDV[\x83a\n\xBAV[a\x05\x05V[\x90a\n\xBAV[a\x05\x1FV[\x8Ca\n\xBAV[a\x057V[\x8Aa\n\xBAV[a\x05OV[\x88a\n\xBAV[\x93\x80a\n\xBAV[a\x04\x0BV[a\x05\xC1V[a\x05\xA5V[a\x0B\xC3V[\x90`\0\x13\x15a\x07TWa\x07T\x90a\x05\xDAV[\x90V[Pg\x1B\xC1mgN\xC8\0\0\x90V[P`\0\x90V[Pg\r\xE0\xB6\xB3\xA7d\0\0\x90V[g\x06\xF0[Y\xD3\xB2\0\0\x81\x14a\x07dWg\r\xE0\xB6\xB3\xA7d\0\0\x80\x82\x12\x15a\x08\xDCW\x81\x15a\x08\xFDW`\x01\x82\x81\x1B\x91`\x02\x93\x83\x05\x84\x03a\x03OW`\0\x83\x12\x80\x15a\t!W[a\t\x0FW\x82\x15a\x08\xDCWg\x1B\xC1mgN\xC8\0\0\x83\x14a\x08\xFDW\x82\x12\x91\x82\x15a\x08\xEEW\x92[a\x07\xE6\x84a\x0B\x02V[\x80\x15a\x08\xDCWa\x08Ma\x08\x17a\x08\x12a\x08\ra\x08\x08a\x08R\x95\x99\x97\x96\x99a\r\x7FV[a\nCV[a\x0F\x93V[a\x04,V[a\x08Ha\x08+a\x08&\x83a\x0B-V[a\x05gV[a\x08Ba\x06\x81a\x06\xEAa\x08=\x86a\x0BXV[a\x05\x7FV[\x90a\x0B\xA1V[a\x06 V[a\nkV[\x93`\0\x92[\x81\x84\x10a\x08\x89WPPPPa\x07T\x91a\x08v\x91`\0\x14a\x08{Wa\n\xDBV[a\x04EV[a\x08\x84\x90a\x04EV[a\n\xDBV[\x90\x91a\x08\xD2\x86a\x08\xCCa\x08\xA1\x85a\x08H\x86\x99\x9Ba\x069V[a\x08Ba\x08\xBCa\x08\xB7a\x07=a\x08v\x87\x80a\n\xBAV[a\n\x93V[a\x08\xC6\x83\x86a\n\xBAV[\x90a\x06 V[\x90a\x05\xA5V[\x95\x01\x92\x91\x90a\x08WV[`@Qc\x07\xA0!'`\xE0\x1B\x81R`\x04\x90\xFD[a\x08\xF7\x90a\x05\xDAV[\x92a\x07\xDDV[`@Qc\"\xEDY\x85`\xE2\x1B\x81R`\x04\x90\xFD[`@Qc-\x04\x83\xC5`\xE2\x1B\x81R`\x04\x90\xFD[Pg\x1B\xC1mgN\xC8\0\0\x83\x13a\x07\xB9V[\x90c;\x9A\xCA\0\x91\x82\x81\x02\x92\x81\x84\x04\x14\x90\x15\x17\x15a\x03OWV[\x91\x90\x92g\r\xE0\xB6\xB3\xA7d\0\0\x80\x84\x11a\t\xD9W\x83\x14a\t\xD0W\x82\x15a\t\xBFW\x80\x15a\t\xADWa\x02\xE4a\t\xA8\x93a\x08Ha\x01\xCEa\t\xA2a\x07T\x98\x96a\t\x9Ca\t\x97a\x08\ra\x07\0\x99a\x0FlV[a\t2V[\x90a\x0F V[\x92a\x05\xFDV[a\x05\x97V[PPa\x07T\x91a\x07\0a\t\xA8\x92a\x05\xFDV[PPP`\0\x81\x12\x80\x15\x16a\x03OW\x90V[PPPP`\0\x90V[`@Qc\xAA\xF3\x95o`\xE0\x1B\x81R`\x04\x90\xFD[`\x01`\xFF\x1B\x81\x14a\n\x06W`\0\x81\x12\x15a\x07TW\x19`\x01\x01\x90V[`@QcM-u\xB1`\xE0\x1B\x81R`\x04\x90\xFD[g\x02_\x0F\xE1\x05\xA3\x14\0\x90\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[g\x1B\xC1mgN\xC7\xFF\xFF\x19\x81\x81\x02\x91`\x01\x91\x83\x05\x14\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[g\t\xD0(\xCCo _\xFF\x19\x81\x81\x02\x91`\x01\x91\x83\x05\x14\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[g\x0F\xA8\xCE\xDF\xC2\xAD\xDD\xFA\x90\x80\x82\x02\x91\x82\x05\x14`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[g\x13\xA0K\xBD\xFD\xC9\xBE\x88\x90\x80\x82\x02\x91\x82\x05\x14`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\x1B\xC1mgN\xC8\0\0\x90\x05\x90V[g\x03\xC1f\\z\xAB \0\x90\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[f\x9F2u$b\xA0\0\x90\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x05\x90V[`\x01\x81\x15\x15\x16\x15a\x02\x15Wn\xC0\x97\xCE{\xC9\x07\x15\xB3K\x9F\x10\0\0\0\0\x05\x90V[g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x05\x14\x90\x15\x17\x82\x15\x15\x16\x15a\x02\x15W\x05\x90V[h\x02H\xCE6\xA7\x0C\xB2k>\x19\x81\x13\x15a\x07dWh\x07U\xBFy\x8BJ\x1B\xF1\xE5\x81\x12\x15a\r\x13We\x03x-\xAC\xE9\xD9\x90`N\x1B\x05t\x02\x9D\x9D\xC3\x85c\xC3.\\/m\xC1\x92\xEEp\xEFe\xF9\x97\x8A\xF3k\xB1r\x17\xF7\xD1\xCFy\xAB\xC9\xE3\xB3\x98\x91``\x90`\x01`_\x1B\x84\x82\x84\x1B\x05\x01\x82\x1D\x93\x84\x02\x90\x03\x80l\x10\xFEh\xE7\xFD7\xD0\0{q?vP\x81\x01\x02\x82\x1D\x90n\x05\x87\xF5\x03\xBBn\xA2\x9D%\xFC\xB7@\x19dPn\x05\x18\x0B\xB1G\x99\xABG\xA8\xA8\xCB*R}W\x82n\x02\xC7#\x88\xD9\xF7OQ\xA93\x1F\xEDi?\x14\x19\x81m\xB1\xBB\xB2\x01\xF4C\xCF\x96/\x1A\x1D=\xB4\xA5\x81m\x1AR\x12U\xE3OjPa\xB2^\xF1\xC9\xC3\x19\x81m\x02wYI\x91\xCF\xC8_n$a\x83|\xD9\x81l$\x0C3\x0E\x9F\xB2\xD9\xCB\xAF\x0F\xD5\xAA\xFB\x19\x81\x01\x02\x8D\x1D\x01\x02\x8B\x1D\x01\x02\x89\x1D\x01\x02\x87\x1D\x01\x02\x85\x1D\x01\x93m6\rz\xEE\xA0\x93&>\xCCn\x0E\xCB)\x17`b\x1B\x93m\x02\xD1g W{\xD1\x9B\xF6\x14\x17o\xE9\xEA\x81\x01\x90\x84m\x01\xD3\x96~\xD3\x0F\xC4\xF8\x9C\x02\xBA\xB5p\x81\x19\x91\x01\x01\x02\x90\x1D\x01\x02\x01\x05\x02\x90`\xC3\x03\x1C\x90V[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x0C`$\x82\x01RkEXP_OVERFLOW`\xA0\x1B`D\x82\x01R`d\x90\xFD[\x15a\rNWV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\t`$\x82\x01Rh\x15S\x91\x11Q\x92S\x91Q`\xBA\x1B`D\x82\x01R`d\x90\xFD[}W\x11^G\x01\x8Cqw\xEE\xBF|\xD3p\xA35j\x1Bxc\0\x8AZ\xE8\x02\x8Cr\xB8\x86B\x84\x90a\r\xAB`\0\x82\x13a\rGV[q\x13@\xDA\xA0\xD5\xF7i\xDB\xA1\x91\\\xEFY\xF0\x81ZU\x06a\r\xC7\x82a\x10QV[``\x92\x83\x82`\x9F\x03\x01\x1B`\x9F\x1C\x90`_\x19\x01}\x02g\xA3l\x0C\x95\xB3\x97Z\xB3\xEE[ :v\x14\xA3\xF7Ss\xF0G\xD8\x03\xAE{f\x87\xF2\xB3\x02\x92l\x0Bz\x86\xD77Th\xFA\xC6g\xA0\xA5'\x82m\x01\x92\r\x80C\xCA\x89\xB5#\x92S(NB\x81m\n\x0Ft #\xDE\xF7\x83\xA3\x07\xA9\x86\x91.\x81m\x13\xCD\xFF\xB2\x9DQ\xD9\x93\"\xBD\xFF_\"\x11\x81m\r\xF9\x9A\xC5\x02\x03\x1B\xF9S\xEF\xF4r\xFD\xCC\x81m\x03\x88\xEA\xA2t\x12\xD5\xAC\xA0&\x81]cn\x81lFWr\xB2\xBB\xBB_\x82K\x15 z0\x81\x01\x02\x8C\x1D\x01\x02\x8A\x1D\x01\x02\x88\x1D\x01\x02\x86\x1D\x01\x02\x84\x1D\x01\x02\x82\x1D\x01\x91x\n\tPp\x84\xCCi\x9B\xB0\xE7\x1E\xA8i\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x19\x91l\xB9\xA0%\xD8\x14\xB2\x9C!+\x8B\x1A\x07\xCD\x19\x90\x82m\x028Gs\xBD\xF1\xACVv\xFA\xCC\xED`\x90\x19\x81l\x8C?8\xE9Zk\x1F\xF2\xAB\x1C;46\x19\x81m\x02$\x7Fz{e\x942\x06I\xAA\x03\xAB\xA1\x81m\x019`\x1A.\xFA\xBEq~`L\xBBH\x94\x81l)P\x8EE\x85C\xD8\xAAM\xF2\xAB\xEEx\x81\x01\x02\x89\x1D\x01\x02\x87\x1D\x01\x02\x85\x1D\x01\x02\x83\x1D\x01\x02\x90\x1D\x01\x02\x01\x05\x02\x01\x01`\xAE\x1D\x90V[\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\r\xE0\xB6\xB3\xA7d\0\0\x90\x04\x90V[g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wg\x1B\xC1mgN\xC8\0\0\x90\x04\x90V[g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17`\x01\x16\x15a\x02\x15Wc\x01\xE1\x85X\x90\x04\x90V[`\xB5\x81`\x01`\x88\x1B\x81\x10\x15a\x10:W[\x80i\x01\0\0\0\0\0\0\0\0\0b\x01\0\0\x92\x10\x15a\x10-W[e\x01\0\0\0\0\0\x81\x10\x15a\x10 W[c\x01\0\0\0\x81\x10\x15a\x10\x13W[\x01\x02`\x12\x1C`\x01\x90\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x81\x1C\x80\x83\x04\x01\x90\x1C\x80\x80\x92\x04\x10\x90\x03\x90V[`\x10\x1C\x91`\x08\x1B\x91a\x0F\xD7V[` \x1C\x91`\x10\x1B\x91a\x0F\xCAV[`@\x1C\x91` \x1B\x91a\x0F\xBBV[Ph\xB5\0\0\0\0\0\0\0\0\x90P`\x80\x82\x90\x1Ca\x0F\xA3V[a\x10\\\x81\x15\x15a\rGV[\x80o\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x10`\x07\x1B\x81\x81\x1Cg\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x10`\x06\x1B\x17\x81\x81\x1Cc\xFF\xFF\xFF\xFF\x10`\x05\x1B\x17\x81\x81\x1Ca\xFF\xFF\x10`\x04\x1B\x17\x81\x81\x1C`\xFF\x10`\x03\x1B\x17\x81\x81\x1C`\x0F\x10`\x02\x1B\x17\x81\x81\x1C`\x03\x10`\x01\x1B\x17\x90\x81\x1C`\x01\x10\x17\x90V\xFE\xA2dipfsX\"\x12 .\xFEi\x03^\x07I%\xF9\x93I\xC8\xD7T\x99b,B\x04\xD2\xEC>\xAA\xFF\xEA\xF2\x0E\x08\"\xC7\xD8\xEEdsolcC\0\x08\x13\x003";
     /// The deployed bytecode of the contract.
-    pub static ARBITERMATH_DEPLOYED_BYTECODE: ::ethers::core::types::Bytes = ::ethers::core::types::Bytes::from_static(
-        __DEPLOYED_BYTECODE,
-    );
+    pub static ARBITERMATH_DEPLOYED_BYTECODE: ::ethers::core::types::Bytes =
+        ::ethers::core::types::Bytes::from_static(__DEPLOYED_BYTECODE);
     pub struct ArbiterMath<M>(::ethers::contract::Contract<M>);
     impl<M> ::core::clone::Clone for ArbiterMath<M> {
         fn clone(&self) -> Self {
@@ -483,34 +382,38 @@ pub mod arbiter_math {
         }
     }
     impl<M: ::ethers::providers::Middleware> ArbiterMath<M> {
-        /// Creates a new contract instance with the specified `ethers` client at
-        /// `address`. The contract derefs to a `ethers::Contract` object.
+        /// Creates a new contract instance with the specified `ethers` client
+        /// at `address`. The contract derefs to a `ethers::Contract`
+        /// object.
         pub fn new<T: Into<::ethers::core::types::Address>>(
             address: T,
             client: ::std::sync::Arc<M>,
         ) -> Self {
-            Self(
-                ::ethers::contract::Contract::new(
-                    address.into(),
-                    ARBITERMATH_ABI.clone(),
-                    client,
-                ),
-            )
+            Self(::ethers::contract::Contract::new(
+                address.into(),
+                ARBITERMATH_ABI.clone(),
+                client,
+            ))
         }
-        /// Constructs the general purpose `Deployer` instance based on the provided constructor arguments and sends it.
-        /// Returns a new instance of a deployer that returns an instance of this contract after sending the transaction
+        /// Constructs the general purpose `Deployer` instance based on the
+        /// provided constructor arguments and sends it. Returns a new
+        /// instance of a deployer that returns an instance of this contract
+        /// after sending the transaction
         ///
         /// Notes:
-        /// - If there are no constructor arguments, you should pass `()` as the argument.
+        /// - If there are no constructor arguments, you should pass `()` as the
+        ///   argument.
         /// - The default poll duration is 7 seconds.
         /// - The default number of confirmations is 1 block.
         ///
         ///
         /// # Example
         ///
-        /// Generate contract bindings with `abigen!` and deploy a new contract instance.
+        /// Generate contract bindings with `abigen!` and deploy a new contract
+        /// instance.
         ///
-        /// *Note*: this requires a `bytecode` and `abi` object in the `greeter.json` artifact.
+        /// *Note*: this requires a `bytecode` and `abi` object in the
+        /// `greeter.json` artifact.
         ///
         /// ```ignore
         /// # async fn deploy<M: ethers::providers::Middleware>(client: ::std::sync::Arc<M>) {
@@ -536,7 +439,7 @@ pub mod arbiter_math {
             let deployer = ::ethers::contract::ContractDeployer::new(deployer);
             Ok(deployer)
         }
-        ///Calls the contract's `cdf` (0xd0b71b1e) function
+        /// Calls the contract's `cdf` (0xd0b71b1e) function
         pub fn cdf(
             &self,
             input: ::ethers::core::types::I256,
@@ -545,7 +448,7 @@ pub mod arbiter_math {
                 .method_hash([208, 183, 27, 30], input)
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `divWadDown` (0x37c6a44a) function
+        /// Calls the contract's `divWadDown` (0x37c6a44a) function
         pub fn div_wad_down(
             &self,
             x: ::ethers::core::types::U256,
@@ -555,7 +458,7 @@ pub mod arbiter_math {
                 .method_hash([55, 198, 164, 74], (x, y))
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `divWadUp` (0xbd252d06) function
+        /// Calls the contract's `divWadUp` (0xbd252d06) function
         pub fn div_wad_up(
             &self,
             x: ::ethers::core::types::U256,
@@ -565,7 +468,7 @@ pub mod arbiter_math {
                 .method_hash([189, 37, 45, 6], (x, y))
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `invariant` (0x2f59773a) function
+        /// Calls the contract's `invariant` (0x2f59773a) function
         pub fn invariant(
             &self,
             r_y: ::ethers::core::types::U256,
@@ -578,7 +481,7 @@ pub mod arbiter_math {
                 .method_hash([47, 89, 119, 58], (r_y, r_x, stk, vol, tau))
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `log` (0x2d5b6cb9) function
+        /// Calls the contract's `log` (0x2d5b6cb9) function
         pub fn log(
             &self,
             x: ::ethers::core::types::I256,
@@ -587,7 +490,7 @@ pub mod arbiter_math {
                 .method_hash([45, 91, 108, 185], x)
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `mulWadDown` (0xe524f849) function
+        /// Calls the contract's `mulWadDown` (0xe524f849) function
         pub fn mul_wad_down(
             &self,
             x: ::ethers::core::types::U256,
@@ -597,7 +500,7 @@ pub mod arbiter_math {
                 .method_hash([229, 36, 248, 73], (x, y))
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `mulWadUp` (0xae9768a8) function
+        /// Calls the contract's `mulWadUp` (0xae9768a8) function
         pub fn mul_wad_up(
             &self,
             x: ::ethers::core::types::U256,
@@ -607,7 +510,7 @@ pub mod arbiter_math {
                 .method_hash([174, 151, 104, 168], (x, y))
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `pdf` (0xd24ce6e5) function
+        /// Calls the contract's `pdf` (0xd24ce6e5) function
         pub fn pdf(
             &self,
             input: ::ethers::core::types::I256,
@@ -616,7 +519,7 @@ pub mod arbiter_math {
                 .method_hash([210, 76, 230, 229], input)
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `ppf` (0x3679723a) function
+        /// Calls the contract's `ppf` (0x3679723a) function
         pub fn ppf(
             &self,
             input: ::ethers::core::types::I256,
@@ -625,7 +528,7 @@ pub mod arbiter_math {
                 .method_hash([54, 121, 114, 58], input)
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `sqrt` (0x677342ce) function
+        /// Calls the contract's `sqrt` (0x677342ce) function
         pub fn sqrt(
             &self,
             x: ::ethers::core::types::U256,
@@ -635,13 +538,13 @@ pub mod arbiter_math {
                 .expect("method not found (this should never happen)")
         }
     }
-    impl<M: ::ethers::providers::Middleware> From<::ethers::contract::Contract<M>>
-    for ArbiterMath<M> {
+    impl<M: ::ethers::providers::Middleware> From<::ethers::contract::Contract<M>> for ArbiterMath<M> {
         fn from(contract: ::ethers::contract::Contract<M>) -> Self {
             Self::new(contract.address(), contract.client())
         }
     }
-    ///Custom Error type `Infinity` with signature `Infinity()` and selector `0x07a02127`
+    /// Custom Error type `Infinity` with signature `Infinity()` and selector
+    /// `0x07a02127`
     #[derive(
         Clone,
         ::ethers::contract::EthError,
@@ -652,11 +555,11 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[etherror(name = "Infinity", abi = "Infinity()")]
     pub struct Infinity;
-    ///Custom Error type `Min` with signature `Min()` and selector `0x4d2d75b1`
+    /// Custom Error type `Min` with signature `Min()` and selector `0x4d2d75b1`
     #[derive(
         Clone,
         ::ethers::contract::EthError,
@@ -667,11 +570,12 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[etherror(name = "Min", abi = "Min()")]
     pub struct Min;
-    ///Custom Error type `NegativeInfinity` with signature `NegativeInfinity()` and selector `0x8bb56614`
+    /// Custom Error type `NegativeInfinity` with signature `NegativeInfinity()`
+    /// and selector `0x8bb56614`
     #[derive(
         Clone,
         ::ethers::contract::EthError,
@@ -682,11 +586,11 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[etherror(name = "NegativeInfinity", abi = "NegativeInfinity()")]
     pub struct NegativeInfinity;
-    ///Custom Error type `OOB` with signature `OOB()` and selector `0xaaf3956f`
+    /// Custom Error type `OOB` with signature `OOB()` and selector `0xaaf3956f`
     #[derive(
         Clone,
         ::ethers::contract::EthError,
@@ -697,11 +601,12 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[etherror(name = "OOB", abi = "OOB()")]
     pub struct OOB;
-    ///Custom Error type `OutOfBounds` with signature `OutOfBounds()` and selector `0xb4120f14`
+    /// Custom Error type `OutOfBounds` with signature `OutOfBounds()` and
+    /// selector `0xb4120f14`
     #[derive(
         Clone,
         ::ethers::contract::EthError,
@@ -712,11 +617,11 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[etherror(name = "OutOfBounds", abi = "OutOfBounds()")]
     pub struct OutOfBounds;
-    ///Container type for all of the contract's custom errors
+    /// Container type for all of the contract's custom errors
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -725,7 +630,7 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub enum ArbiterMathErrors {
         Infinity(Infinity),
@@ -742,30 +647,25 @@ pub mod arbiter_math {
             data: impl AsRef<[u8]>,
         ) -> ::core::result::Result<Self, ::ethers::core::abi::AbiError> {
             let data = data.as_ref();
-            if let Ok(decoded) = <::std::string::String as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) =
+                <::std::string::String as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::RevertString(decoded));
             }
-            if let Ok(decoded) = <Infinity as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <Infinity as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Infinity(decoded));
             }
             if let Ok(decoded) = <Min as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Min(decoded));
             }
-            if let Ok(decoded) = <NegativeInfinity as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <NegativeInfinity as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::NegativeInfinity(decoded));
             }
             if let Ok(decoded) = <OOB as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::OOB(decoded));
             }
-            if let Ok(decoded) = <OutOfBounds as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <OutOfBounds as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::OutOfBounds(decoded));
             }
             Err(::ethers::core::abi::Error::InvalidData.into())
@@ -774,17 +674,11 @@ pub mod arbiter_math {
     impl ::ethers::core::abi::AbiEncode for ArbiterMathErrors {
         fn encode(self) -> ::std::vec::Vec<u8> {
             match self {
-                Self::Infinity(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                Self::Infinity(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Min(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::NegativeInfinity(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                Self::NegativeInfinity(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::OOB(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::OutOfBounds(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                Self::OutOfBounds(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::RevertString(s) => ::ethers::core::abi::AbiEncode::encode(s),
             }
         }
@@ -793,20 +687,13 @@ pub mod arbiter_math {
         fn valid_selector(selector: [u8; 4]) -> bool {
             match selector {
                 [0x08, 0xc3, 0x79, 0xa0] => true,
-                _ if selector
-                    == <Infinity as ::ethers::contract::EthError>::selector() => true,
-                _ if selector == <Min as ::ethers::contract::EthError>::selector() => {
+                _ if selector == <Infinity as ::ethers::contract::EthError>::selector() => true,
+                _ if selector == <Min as ::ethers::contract::EthError>::selector() => true,
+                _ if selector == <NegativeInfinity as ::ethers::contract::EthError>::selector() => {
                     true
                 }
-                _ if selector
-                    == <NegativeInfinity as ::ethers::contract::EthError>::selector() => {
-                    true
-                }
-                _ if selector == <OOB as ::ethers::contract::EthError>::selector() => {
-                    true
-                }
-                _ if selector
-                    == <OutOfBounds as ::ethers::contract::EthError>::selector() => true,
+                _ if selector == <OOB as ::ethers::contract::EthError>::selector() => true,
+                _ if selector == <OutOfBounds as ::ethers::contract::EthError>::selector() => true,
                 _ => false,
             }
         }
@@ -853,7 +740,8 @@ pub mod arbiter_math {
             Self::OutOfBounds(value)
         }
     }
-    ///Container type for all input parameters for the `cdf` function with signature `cdf(int256)` and selector `0xd0b71b1e`
+    /// Container type for all input parameters for the `cdf` function with
+    /// signature `cdf(int256)` and selector `0xd0b71b1e`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -864,13 +752,14 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "cdf", abi = "cdf(int256)")]
     pub struct CdfCall {
         pub input: ::ethers::core::types::I256,
     }
-    ///Container type for all input parameters for the `divWadDown` function with signature `divWadDown(uint256,uint256)` and selector `0x37c6a44a`
+    /// Container type for all input parameters for the `divWadDown` function
+    /// with signature `divWadDown(uint256,uint256)` and selector `0x37c6a44a`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -881,14 +770,15 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "divWadDown", abi = "divWadDown(uint256,uint256)")]
     pub struct DivWadDownCall {
         pub x: ::ethers::core::types::U256,
         pub y: ::ethers::core::types::U256,
     }
-    ///Container type for all input parameters for the `divWadUp` function with signature `divWadUp(uint256,uint256)` and selector `0xbd252d06`
+    /// Container type for all input parameters for the `divWadUp` function with
+    /// signature `divWadUp(uint256,uint256)` and selector `0xbd252d06`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -899,14 +789,16 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "divWadUp", abi = "divWadUp(uint256,uint256)")]
     pub struct DivWadUpCall {
         pub x: ::ethers::core::types::U256,
         pub y: ::ethers::core::types::U256,
     }
-    ///Container type for all input parameters for the `invariant` function with signature `invariant(uint256,uint256,uint256,uint256,uint256)` and selector `0x2f59773a`
+    /// Container type for all input parameters for the `invariant` function
+    /// with signature `invariant(uint256,uint256,uint256,uint256,uint256)` and
+    /// selector `0x2f59773a`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -917,7 +809,7 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(
         name = "invariant",
@@ -930,7 +822,8 @@ pub mod arbiter_math {
         pub vol: ::ethers::core::types::U256,
         pub tau: ::ethers::core::types::U256,
     }
-    ///Container type for all input parameters for the `log` function with signature `log(int256)` and selector `0x2d5b6cb9`
+    /// Container type for all input parameters for the `log` function with
+    /// signature `log(int256)` and selector `0x2d5b6cb9`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -941,13 +834,14 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "log", abi = "log(int256)")]
     pub struct LogCall {
         pub x: ::ethers::core::types::I256,
     }
-    ///Container type for all input parameters for the `mulWadDown` function with signature `mulWadDown(uint256,uint256)` and selector `0xe524f849`
+    /// Container type for all input parameters for the `mulWadDown` function
+    /// with signature `mulWadDown(uint256,uint256)` and selector `0xe524f849`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -958,14 +852,15 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "mulWadDown", abi = "mulWadDown(uint256,uint256)")]
     pub struct MulWadDownCall {
         pub x: ::ethers::core::types::U256,
         pub y: ::ethers::core::types::U256,
     }
-    ///Container type for all input parameters for the `mulWadUp` function with signature `mulWadUp(uint256,uint256)` and selector `0xae9768a8`
+    /// Container type for all input parameters for the `mulWadUp` function with
+    /// signature `mulWadUp(uint256,uint256)` and selector `0xae9768a8`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -976,14 +871,15 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "mulWadUp", abi = "mulWadUp(uint256,uint256)")]
     pub struct MulWadUpCall {
         pub x: ::ethers::core::types::U256,
         pub y: ::ethers::core::types::U256,
     }
-    ///Container type for all input parameters for the `pdf` function with signature `pdf(int256)` and selector `0xd24ce6e5`
+    /// Container type for all input parameters for the `pdf` function with
+    /// signature `pdf(int256)` and selector `0xd24ce6e5`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -994,13 +890,14 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "pdf", abi = "pdf(int256)")]
     pub struct PdfCall {
         pub input: ::ethers::core::types::I256,
     }
-    ///Container type for all input parameters for the `ppf` function with signature `ppf(int256)` and selector `0x3679723a`
+    /// Container type for all input parameters for the `ppf` function with
+    /// signature `ppf(int256)` and selector `0x3679723a`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -1011,13 +908,14 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "ppf", abi = "ppf(int256)")]
     pub struct PpfCall {
         pub input: ::ethers::core::types::I256,
     }
-    ///Container type for all input parameters for the `sqrt` function with signature `sqrt(uint256)` and selector `0x677342ce`
+    /// Container type for all input parameters for the `sqrt` function with
+    /// signature `sqrt(uint256)` and selector `0x677342ce`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -1028,13 +926,13 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "sqrt", abi = "sqrt(uint256)")]
     pub struct SqrtCall {
         pub x: ::ethers::core::types::U256,
     }
-    ///Container type for all of the contract's call
+    /// Container type for all of the contract's call
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1043,7 +941,7 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub enum ArbiterMathCalls {
         Cdf(CdfCall),
@@ -1062,54 +960,34 @@ pub mod arbiter_math {
             data: impl AsRef<[u8]>,
         ) -> ::core::result::Result<Self, ::ethers::core::abi::AbiError> {
             let data = data.as_ref();
-            if let Ok(decoded) = <CdfCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <CdfCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Cdf(decoded));
             }
-            if let Ok(decoded) = <DivWadDownCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <DivWadDownCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::DivWadDown(decoded));
             }
-            if let Ok(decoded) = <DivWadUpCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <DivWadUpCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::DivWadUp(decoded));
             }
-            if let Ok(decoded) = <InvariantCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <InvariantCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Invariant(decoded));
             }
-            if let Ok(decoded) = <LogCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <LogCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Log(decoded));
             }
-            if let Ok(decoded) = <MulWadDownCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <MulWadDownCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::MulWadDown(decoded));
             }
-            if let Ok(decoded) = <MulWadUpCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <MulWadUpCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::MulWadUp(decoded));
             }
-            if let Ok(decoded) = <PdfCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <PdfCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Pdf(decoded));
             }
-            if let Ok(decoded) = <PpfCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <PpfCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Ppf(decoded));
             }
-            if let Ok(decoded) = <SqrtCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <SqrtCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Sqrt(decoded));
             }
             Err(::ethers::core::abi::Error::InvalidData.into())
@@ -1119,22 +997,12 @@ pub mod arbiter_math {
         fn encode(self) -> Vec<u8> {
             match self {
                 Self::Cdf(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::DivWadDown(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::DivWadUp(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::Invariant(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                Self::DivWadDown(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::DivWadUp(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::Invariant(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Log(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::MulWadDown(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::MulWadUp(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                Self::MulWadDown(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::MulWadUp(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Pdf(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Ppf(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Sqrt(element) => ::ethers::core::abi::AbiEncode::encode(element),
@@ -1207,7 +1075,8 @@ pub mod arbiter_math {
             Self::Sqrt(value)
         }
     }
-    ///Container type for all return fields from the `cdf` function with signature `cdf(int256)` and selector `0xd0b71b1e`
+    /// Container type for all return fields from the `cdf` function with
+    /// signature `cdf(int256)` and selector `0xd0b71b1e`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1218,12 +1087,13 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct CdfReturn {
         pub output: ::ethers::core::types::I256,
     }
-    ///Container type for all return fields from the `divWadDown` function with signature `divWadDown(uint256,uint256)` and selector `0x37c6a44a`
+    /// Container type for all return fields from the `divWadDown` function with
+    /// signature `divWadDown(uint256,uint256)` and selector `0x37c6a44a`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1234,12 +1104,13 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct DivWadDownReturn {
         pub z: ::ethers::core::types::U256,
     }
-    ///Container type for all return fields from the `divWadUp` function with signature `divWadUp(uint256,uint256)` and selector `0xbd252d06`
+    /// Container type for all return fields from the `divWadUp` function with
+    /// signature `divWadUp(uint256,uint256)` and selector `0xbd252d06`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1250,12 +1121,14 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct DivWadUpReturn {
         pub z: ::ethers::core::types::U256,
     }
-    ///Container type for all return fields from the `invariant` function with signature `invariant(uint256,uint256,uint256,uint256,uint256)` and selector `0x2f59773a`
+    /// Container type for all return fields from the `invariant` function with
+    /// signature `invariant(uint256,uint256,uint256,uint256,uint256)` and
+    /// selector `0x2f59773a`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1266,12 +1139,13 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct InvariantReturn {
         pub k: ::ethers::core::types::I256,
     }
-    ///Container type for all return fields from the `log` function with signature `log(int256)` and selector `0x2d5b6cb9`
+    /// Container type for all return fields from the `log` function with
+    /// signature `log(int256)` and selector `0x2d5b6cb9`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1282,12 +1156,13 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct LogReturn {
         pub z: ::ethers::core::types::I256,
     }
-    ///Container type for all return fields from the `mulWadDown` function with signature `mulWadDown(uint256,uint256)` and selector `0xe524f849`
+    /// Container type for all return fields from the `mulWadDown` function with
+    /// signature `mulWadDown(uint256,uint256)` and selector `0xe524f849`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1298,12 +1173,13 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct MulWadDownReturn {
         pub z: ::ethers::core::types::U256,
     }
-    ///Container type for all return fields from the `mulWadUp` function with signature `mulWadUp(uint256,uint256)` and selector `0xae9768a8`
+    /// Container type for all return fields from the `mulWadUp` function with
+    /// signature `mulWadUp(uint256,uint256)` and selector `0xae9768a8`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1314,12 +1190,13 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct MulWadUpReturn {
         pub z: ::ethers::core::types::U256,
     }
-    ///Container type for all return fields from the `pdf` function with signature `pdf(int256)` and selector `0xd24ce6e5`
+    /// Container type for all return fields from the `pdf` function with
+    /// signature `pdf(int256)` and selector `0xd24ce6e5`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1330,12 +1207,13 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct PdfReturn {
         pub output: ::ethers::core::types::I256,
     }
-    ///Container type for all return fields from the `ppf` function with signature `ppf(int256)` and selector `0x3679723a`
+    /// Container type for all return fields from the `ppf` function with
+    /// signature `ppf(int256)` and selector `0x3679723a`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1346,12 +1224,13 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct PpfReturn {
         pub output: ::ethers::core::types::I256,
     }
-    ///Container type for all return fields from the `sqrt` function with signature `sqrt(uint256)` and selector `0x677342ce`
+    /// Container type for all return fields from the `sqrt` function with
+    /// signature `sqrt(uint256)` and selector `0x677342ce`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1362,7 +1241,7 @@ pub mod arbiter_math {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct SqrtReturn {
         pub z: ::ethers::core::types::U256,

--- a/arbiter-core/src/bindings/arbiter_token.rs
+++ b/arbiter-core/src/bindings/arbiter_token.rs
@@ -7,7 +7,7 @@ pub use arbiter_token::*;
     clippy::upper_case_acronyms,
     clippy::type_complexity,
     dead_code,
-    non_camel_case_types
+    non_camel_case_types,
 )]
 pub mod arbiter_token {
     #[allow(deprecated)]
@@ -41,415 +41,507 @@ pub mod arbiter_token {
             functions: ::core::convert::From::from([
                 (
                     ::std::borrow::ToOwned::to_owned("DOMAIN_SEPARATOR"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("DOMAIN_SEPARATOR"),
-                        inputs: ::std::vec![],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::string::String::new(),
-                            kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(32usize,),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("bytes32"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("DOMAIN_SEPARATOR"),
+                            inputs: ::std::vec![],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
+                                        32usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("bytes32"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("admin"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("admin"),
-                        inputs: ::std::vec![],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::string::String::new(),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("address"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("admin"),
+                            inputs: ::std::vec![],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("address"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("allowance"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("allowance"),
-                        inputs: ::std::vec![
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::string::String::new(),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("address"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::string::String::new(),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("address"),
-                                ),
-                            },
-                        ],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::string::String::new(),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("uint256"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("allowance"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("address"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("address"),
+                                    ),
+                                },
+                            ],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("approve"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("approve"),
-                        inputs: ::std::vec![
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("spender"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("address"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("amount"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint256"),
-                                ),
-                            },
-                        ],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::string::String::new(),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Bool,
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("bool"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("approve"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("spender"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("address"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("amount"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Bool,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("bool"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("balanceOf"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("balanceOf"),
-                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::string::String::new(),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("address"),
-                            ),
-                        },],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::string::String::new(),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("uint256"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("balanceOf"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("address"),
+                                    ),
+                                },
+                            ],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("decimals"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("decimals"),
-                        inputs: ::std::vec![],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::string::String::new(),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(8usize),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("uint8"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("decimals"),
+                            inputs: ::std::vec![],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(8usize),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint8"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("mint"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("mint"),
-                        inputs: ::std::vec![
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("receiver"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("address"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("amount"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint256"),
-                                ),
-                            },
-                        ],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::string::String::new(),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Bool,
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("bool"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("mint"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("receiver"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("address"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("amount"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Bool,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("bool"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("name"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("name"),
-                        inputs: ::std::vec![],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::string::String::new(),
-                            kind: ::ethers::core::abi::ethabi::ParamType::String,
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("string"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("name"),
+                            inputs: ::std::vec![],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::String,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("string"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("nonces"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("nonces"),
-                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::string::String::new(),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("address"),
-                            ),
-                        },],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::string::String::new(),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("uint256"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("nonces"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("address"),
+                                    ),
+                                },
+                            ],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("permit"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("permit"),
-                        inputs: ::std::vec![
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("owner"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("address"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("spender"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("address"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("value"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint256"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("deadline"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint256"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("v"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(8usize),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint8"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("r"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(32usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("bytes32"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("s"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(32usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("bytes32"),
-                                ),
-                            },
-                        ],
-                        outputs: ::std::vec![],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("permit"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("owner"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("address"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("spender"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("address"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("value"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("deadline"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("v"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(8usize),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint8"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("r"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
+                                        32usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("bytes32"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("s"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
+                                        32usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("bytes32"),
+                                    ),
+                                },
+                            ],
+                            outputs: ::std::vec![],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("symbol"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("symbol"),
-                        inputs: ::std::vec![],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::string::String::new(),
-                            kind: ::ethers::core::abi::ethabi::ParamType::String,
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("string"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("symbol"),
+                            inputs: ::std::vec![],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::String,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("string"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("totalSupply"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("totalSupply"),
-                        inputs: ::std::vec![],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::string::String::new(),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("uint256"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("totalSupply"),
+                            inputs: ::std::vec![],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("transfer"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("transfer"),
-                        inputs: ::std::vec![
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("to"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("address"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("amount"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint256"),
-                                ),
-                            },
-                        ],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::string::String::new(),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Bool,
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("bool"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("transfer"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("to"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("address"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("amount"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Bool,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("bool"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("transferFrom"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("transferFrom"),
-                        inputs: ::std::vec![
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("from"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("address"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("to"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("address"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("amount"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint256"),
-                                ),
-                            },
-                        ],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::string::String::new(),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Bool,
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("bool"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("transferFrom"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("from"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("address"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("to"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("address"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("amount"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Bool,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("bool"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                        },
+                    ],
                 ),
             ]),
             events: ::core::convert::From::from([
                 (
                     ::std::borrow::ToOwned::to_owned("Approval"),
-                    ::std::vec![::ethers::core::abi::ethabi::Event {
-                        name: ::std::borrow::ToOwned::to_owned("Approval"),
-                        inputs: ::std::vec![
-                            ::ethers::core::abi::ethabi::EventParam {
-                                name: ::std::borrow::ToOwned::to_owned("owner"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                indexed: true,
-                            },
-                            ::ethers::core::abi::ethabi::EventParam {
-                                name: ::std::borrow::ToOwned::to_owned("spender"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                indexed: true,
-                            },
-                            ::ethers::core::abi::ethabi::EventParam {
-                                name: ::std::borrow::ToOwned::to_owned("amount"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                indexed: false,
-                            },
-                        ],
-                        anonymous: false,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Event {
+                            name: ::std::borrow::ToOwned::to_owned("Approval"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::EventParam {
+                                    name: ::std::borrow::ToOwned::to_owned("owner"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    indexed: true,
+                                },
+                                ::ethers::core::abi::ethabi::EventParam {
+                                    name: ::std::borrow::ToOwned::to_owned("spender"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    indexed: true,
+                                },
+                                ::ethers::core::abi::ethabi::EventParam {
+                                    name: ::std::borrow::ToOwned::to_owned("amount"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    indexed: false,
+                                },
+                            ],
+                            anonymous: false,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("Transfer"),
-                    ::std::vec![::ethers::core::abi::ethabi::Event {
-                        name: ::std::borrow::ToOwned::to_owned("Transfer"),
-                        inputs: ::std::vec![
-                            ::ethers::core::abi::ethabi::EventParam {
-                                name: ::std::borrow::ToOwned::to_owned("from"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                indexed: true,
-                            },
-                            ::ethers::core::abi::ethabi::EventParam {
-                                name: ::std::borrow::ToOwned::to_owned("to"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                indexed: true,
-                            },
-                            ::ethers::core::abi::ethabi::EventParam {
-                                name: ::std::borrow::ToOwned::to_owned("amount"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                indexed: false,
-                            },
-                        ],
-                        anonymous: false,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Event {
+                            name: ::std::borrow::ToOwned::to_owned("Transfer"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::EventParam {
+                                    name: ::std::borrow::ToOwned::to_owned("from"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    indexed: true,
+                                },
+                                ::ethers::core::abi::ethabi::EventParam {
+                                    name: ::std::borrow::ToOwned::to_owned("to"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    indexed: true,
+                                },
+                                ::ethers::core::abi::ethabi::EventParam {
+                                    name: ::std::borrow::ToOwned::to_owned("amount"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    indexed: false,
+                                },
+                            ],
+                            anonymous: false,
+                        },
+                    ],
                 ),
             ]),
             errors: ::std::collections::BTreeMap::new(),
@@ -457,19 +549,22 @@ pub mod arbiter_token {
             fallback: false,
         }
     }
-    /// The parsed JSON ABI of the contract.
-    pub static ARBITERTOKEN_ABI: ::ethers::contract::Lazy<::ethers::core::abi::Abi> =
-        ::ethers::contract::Lazy::new(__abi);
+    ///The parsed JSON ABI of the contract.
+    pub static ARBITERTOKEN_ABI: ::ethers::contract::Lazy<::ethers::core::abi::Abi> = ::ethers::contract::Lazy::new(
+        __abi,
+    );
     #[rustfmt::skip]
-    const __BYTECODE: &[u8] = b"`\xE0`@R4\x80\x15b\0\0^W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01\x90\x81Ra7\xB7`\xF1\x1B`d\x83\x01R`\x84\x82\xFD[P`@Qb\0\x13!8\x03\x80b\0\x13!\x839\x81\x01`@\x81\x90Rb\0\0\x81\x91b\0\x03OV[\x82\x82\x82`\0b\0\0\x92\x84\x82b\0\x04\xAFV[P`\x01b\0\0\xA1\x83\x82b\0\x04\xAFV[P`\xFF\x81\x16`\x80RF`\xA0Rb\0\0\xB7b\0\0\xD9V[`\xC0RPP`\x06\x80T`\x01`\x01`\xA0\x1B\x03\x19\x163\x17\x90UPb\0\x05\xF9\x92PPPV[`\0\x7F\x8Bs\xC3\xC6\x9B\xB8\xFE=Q.\xCCL\xF7Y\xCCy#\x9F{\x17\x9B\x0F\xFA\xCA\xA9\xA7]R+9@\x0F`\0`@Qb\0\x01\r\x91\x90b\0\x05{V[`@\x80Q\x91\x82\x90\x03\x82 ` \x83\x01\x93\x90\x93R\x81\x01\x91\x90\x91R\x7F\xC8\x9E\xFD\xAAT\xC0\xF2\x0Cz\xDFa(\x82\xDF\tP\xF5\xA9Qc~\x03\x07\xCD\xCBLg/)\x8B\x8B\xC6``\x82\x01RF`\x80\x82\x01R0`\xA0\x82\x01R`\xC0\x01`@Q` \x81\x83\x03\x03\x81R\x90`@R\x80Q\x90` \x01 \x90P\x90V[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: invalid tuple offs`D\x82\x01Ra\x19]`\xF2\x1B`d\x82\x01R`\x84\x81\xFD[cNH{q`\xE0\x1B`\0R`A`\x04R`$`\0\xFD[`\0[\x83\x81\x10\x15b\0\x01\xF8W\x81\x81\x01Q\x83\x82\x01R` \x01b\0\x01\xDEV[PP`\0\x91\x01RV[`\0\x82`\x1F\x83\x01\x12b\0\x02gW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`+`$\x82\x01R\x7FABI decoding: invalid calldata a`D\x82\x01Rj\x1C\x9C\x98^H\x1B\xD9\x99\x9C\xD9]`\xAA\x1B`d\x82\x01R`\x84\x81\xFD[\x81Q`\x01`\x01`@\x1B\x03\x80\x82\x11\x15b\0\x02\x84Wb\0\x02\x84b\0\x01\xC5V[`@Q`\x1F\x83\x01`\x1F\x19\x90\x81\x16`?\x01\x16\x81\x01\x90\x82\x82\x11\x81\x83\x10\x17\x15b\0\x02\xAFWb\0\x02\xAFb\0\x01\xC5V[\x81`@R\x83\x81R\x86` \x85\x88\x01\x01\x11\x15b\0\x03\x1BW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`'`$\x82\x01R\x7FABI decoding: invalid byte array`D\x82\x01Rf\x04\r\x8C\xAD\xCC\xEE\x8D`\xCB\x1B`d\x82\x01R\x92P`\x84\x83\xFD[b\0\x03.\x84` \x83\x01` \x89\x01b\0\x01\xDBV[\x96\x95PPPPPPV[\x80Q`\xFF\x81\x16\x81\x14b\0\x03JW`\0\x80\xFD[\x91\x90PV[`\0\x80`\0``\x84\x86\x03\x12\x15b\0\x03\xB0W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x81\xFD[\x83Q`\x01`\x01`@\x1B\x03\x80\x82\x11\x15b\0\x03\xCDWb\0\x03\xCDb\0\x01uV[b\0\x03\xDB\x87\x83\x88\x01b\0\x02\x01V[\x94P` \x86\x01Q\x91P\x80\x82\x11\x15b\0\x03\xF7Wb\0\x03\xF7b\0\x01uV[Pb\0\x04\x06\x86\x82\x87\x01b\0\x02\x01V[\x92PPb\0\x04\x17`@\x85\x01b\0\x038V[\x90P\x92P\x92P\x92V[`\x01\x81\x81\x1C\x90\x82\x16\x80b\0\x045W`\x7F\x82\x16\x91P[` \x82\x10\x81\x03b\0\x04VWcNH{q`\xE0\x1B`\0R`\"`\x04R`$`\0\xFD[P\x91\x90PV[`\x1F\x82\x11\x15b\0\x04\xAAW`\0\x81\x81R` \x81 `\x1F\x85\x01`\x05\x1C\x81\x01` \x86\x10\x15b\0\x04\x85WP\x80[`\x1F\x85\x01`\x05\x1C\x82\x01\x91P[\x81\x81\x10\x15b\0\x04\xA6W\x82\x81U`\x01\x01b\0\x04\x91V[PPP[PPPV[\x81Q`\x01`\x01`@\x1B\x03\x81\x11\x15b\0\x04\xCBWb\0\x04\xCBb\0\x01\xC5V[b\0\x04\xE3\x81b\0\x04\xDC\x84Tb\0\x04 V[\x84b\0\x04\\V[` \x80`\x1F\x83\x11`\x01\x81\x14b\0\x05\x1BW`\0\x84\x15b\0\x05\x02WP\x85\x83\x01Q[`\0\x19`\x03\x86\x90\x1B\x1C\x19\x16`\x01\x85\x90\x1B\x17\x85Ub\0\x04\xA6V[`\0\x85\x81R` \x81 `\x1F\x19\x86\x16\x91[\x82\x81\x10\x15b\0\x05LW\x88\x86\x01Q\x82U\x94\x84\x01\x94`\x01\x90\x91\x01\x90\x84\x01b\0\x05+V[P\x85\x82\x10\x15b\0\x05kW\x87\x85\x01Q`\0\x19`\x03\x88\x90\x1B`\xF8\x16\x1C\x19\x16\x81U[PPPPP`\x01\x90\x81\x1B\x01\x90UPV[`\0\x80\x83Tb\0\x05\x8B\x81b\0\x04 V[`\x01\x82\x81\x16\x80\x15b\0\x05\xA6W`\x01\x81\x14b\0\x05\xBCWb\0\x05\xEDV[`\xFF\x19\x84\x16\x87R\x82\x15\x15\x83\x02\x87\x01\x94Pb\0\x05\xEDV[\x87`\0R` \x80`\0 `\0[\x85\x81\x10\x15b\0\x05\xE4W\x81T\x8A\x82\x01R\x90\x84\x01\x90\x82\x01b\0\x05\xC9V[PPP\x82\x87\x01\x94P[P\x92\x96\x95PPPPPPV[`\x80Q`\xA0Q`\xC0Qa\x0C\xF8b\0\x06)`\09`\0a\x05G\x01R`\0a\x05\x12\x01R`\0a\x02\x0C\x01Ra\x0C\xF8`\0\xF3\xFE`\x80`@R4\x80\x15a\0]W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01\x90\x81Ra7\xB7`\xF1\x1B`d\x83\x01R`\x84\x82\xFD[P`\x046\x10a\x017W`\x005`\xE0\x1C\x80cp\xA0\x821\x11a\0\xD9W\x80c\xA9\x05\x9C\xBB\x11a\0\xB3W\x80c\xA9\x05\x9C\xBB\x14a\x02\xA3W\x80c\xD5\x05\xAC\xCF\x14a\x02\xB6W\x80c\xDDb\xED>\x14a\x02\xCBW\x80c\xF8Q\xA4@\x14a\x02\xF6Wa\x017V[\x80cp\xA0\x821\x14a\x02[W\x80c~\xCE\xBE\0\x14a\x02{W\x80c\x95\xD8\x9BA\x14a\x02\x9BWa\x017V[\x80c#\xB8r\xDD\x11a\x01\x15W\x80c#\xB8r\xDD\x14a\x01\xF4W\x80c1<\xE5g\x14a\x02\x07W\x80c6D\xE5\x15\x14a\x02@W\x80c@\xC1\x0F\x19\x14a\x02HWa\x017V[\x80c\x06\xFD\xDE\x03\x14a\x01\x9CW\x80c\t^\xA7\xB3\x14a\x01\xBAW\x80c\x18\x16\r\xDD\x14a\x01\xDDW[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01\x90\x81Rtnor receive functions`X\x1B`d\x83\x01R`\x84\x82\xFD[a\x01\xA4a\x03!V[`@Qa\x01\xB1\x91\x90a\t\xB6V[`@Q\x80\x91\x03\x90\xF3[a\x01\xCDa\x01\xC86`\x04a\npV[a\x03\xAFV[`@Q\x90\x15\x15\x81R` \x01a\x01\xB1V[a\x01\xE6`\x02T\x81V[`@Q\x90\x81R` \x01a\x01\xB1V[a\x01\xCDa\x02\x026`\x04a\n\x9DV[a\x04\x1CV[a\x02.\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81V[`@Q`\xFF\x90\x91\x16\x81R` \x01a\x01\xB1V[a\x01\xE6a\x05\x0EV[a\x01\xCDa\x02V6`\x04a\npV[a\x05iV[a\x01\xE6a\x02i6`\x04a\n\xDCV[`\x03` R`\0\x90\x81R`@\x90 T\x81V[a\x01\xE6a\x02\x896`\x04a\n\xDCV[`\x05` R`\0\x90\x81R`@\x90 T\x81V[a\x01\xA4a\x05\xE8V[a\x01\xCDa\x02\xB16`\x04a\npV[a\x05\xF5V[a\x02\xC9a\x02\xC46`\x04a\x0B\x01V[a\x06mV[\0[a\x01\xE6a\x02\xD96`\x04a\x0BwV[`\x04` \x90\x81R`\0\x92\x83R`@\x80\x84 \x90\x91R\x90\x82R\x90 T\x81V[`\x06Ta\x03\t\x90`\x01`\x01`\xA0\x1B\x03\x16\x81V[`@Q`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x81R` \x01a\x01\xB1V[`\0\x80Ta\x03.\x90a\x0B\xADV[\x80`\x1F\x01` \x80\x91\x04\x02` \x01`@Q\x90\x81\x01`@R\x80\x92\x91\x90\x81\x81R` \x01\x82\x80Ta\x03Z\x90a\x0B\xADV[\x80\x15a\x03\xA7W\x80`\x1F\x10a\x03|Wa\x01\0\x80\x83T\x04\x02\x83R\x91` \x01\x91a\x03\xA7V[\x82\x01\x91\x90`\0R` `\0 \x90[\x81T\x81R\x90`\x01\x01\x90` \x01\x80\x83\x11a\x03\x8AW\x82\x90\x03`\x1F\x16\x82\x01\x91[PPPPP\x81V[3`\0\x81\x81R`\x04` \x90\x81R`@\x80\x83 `\x01`\x01`\xA0\x1B\x03\x87\x16\x80\x85R\x92R\x80\x83 \x85\x90UQ\x91\x92\x90\x91\x7F\x8C[\xE1\xE5\xEB\xEC}[\xD1OqB}\x1E\x84\xF3\xDD\x03\x14\xC0\xF7\xB2)\x1E[ \n\xC8\xC7\xC3\xB9%\x90a\x04\n\x90\x86\x81R` \x01\x90V[`@Q\x80\x91\x03\x90\xA3P`\x01[\x92\x91PPV[`\x01`\x01`\xA0\x1B\x03\x83\x16`\0\x90\x81R`\x04` \x90\x81R`@\x80\x83 3\x84R\x90\x91R\x81 T`\0\x19\x81\x14a\x04xWa\x04S\x83\x82a\x0B\xFDV[`\x01`\x01`\xA0\x1B\x03\x86\x16`\0\x90\x81R`\x04` \x90\x81R`@\x80\x83 3\x84R\x90\x91R\x90 U[`\x01`\x01`\xA0\x1B\x03\x85\x16`\0\x90\x81R`\x03` R`@\x81 \x80T\x85\x92\x90a\x04\xA0\x90\x84\x90a\x0B\xFDV[\x90\x91UPP`\x01`\x01`\xA0\x1B\x03\x80\x85\x16`\0\x81\x81R`\x03` R`@\x90\x81\x90 \x80T\x87\x01\x90UQ\x90\x91\x87\x16\x90\x7F\xDD\xF2R\xAD\x1B\xE2\xC8\x9Bi\xC2\xB0h\xFC7\x8D\xAA\x95+\xA7\xF1c\xC4\xA1\x16(\xF5ZM\xF5#\xB3\xEF\x90a\x04\xFB\x90\x87\x81R` \x01\x90V[`@Q\x80\x91\x03\x90\xA3P`\x01\x94\x93PPPPV[`\0\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0F\x14a\x05DWa\x05?a\x08\xB1V[\x90P\x90V[P\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x90V[`\x06T`\0\x90`\x01`\x01`\xA0\x1B\x03\x163\x14a\x05\xD5W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`!`$\x82\x01R\x7FOnly admin can call this functio`D\x82\x01R`7`\xF9\x1B`d\x82\x01R`\x84\x01[`@Q\x80\x91\x03\x90\xFD[a\x05\xDF\x83\x83a\tKV[P`\x01\x92\x91PPV[`\x01\x80Ta\x03.\x90a\x0B\xADV[3`\0\x90\x81R`\x03` R`@\x81 \x80T\x83\x91\x90\x83\x90a\x06\x16\x90\x84\x90a\x0B\xFDV[\x90\x91UPP`\x01`\x01`\xA0\x1B\x03\x83\x16`\0\x81\x81R`\x03` R`@\x90\x81\x90 \x80T\x85\x01\x90UQ3\x90\x7F\xDD\xF2R\xAD\x1B\xE2\xC8\x9Bi\xC2\xB0h\xFC7\x8D\xAA\x95+\xA7\xF1c\xC4\xA1\x16(\xF5ZM\xF5#\xB3\xEF\x90a\x04\n\x90\x86\x81R` \x01\x90V[B\x84\x10\x15a\x06\xBDW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x17`$\x82\x01R\x7FPERMIT_DEADLINE_EXPIRED\0\0\0\0\0\0\0\0\0`D\x82\x01R`d\x01a\x05\xCCV[`\0`\x01a\x06\xC9a\x05\x0EV[`\x01`\x01`\xA0\x1B\x03\x8A\x81\x16`\0\x81\x81R`\x05` \x90\x81R`@\x91\x82\x90 \x80T`\x01\x81\x01\x90\x91U\x82Q\x7Fnq\xED\xAE\x12\xB1\xB9\x7FM\x1F`7\x0F\xEF\x10\x10_\xA2\xFA\xAE\x01&\x11J\x16\x9Cd\x84]a&\xC9\x81\x84\x01R\x80\x84\x01\x94\x90\x94R\x93\x8D\x16``\x84\x01R`\x80\x83\x01\x8C\x90R`\xA0\x83\x01\x93\x90\x93R`\xC0\x80\x83\x01\x8B\x90R\x81Q\x80\x84\x03\x90\x91\x01\x81R`\xE0\x83\x01\x90\x91R\x80Q\x92\x01\x91\x90\x91 a\x19\x01`\xF0\x1Ba\x01\0\x83\x01Ra\x01\x02\x82\x01\x92\x90\x92Ra\x01\"\x81\x01\x91\x90\x91Ra\x01B\x01`@\x80Q`\x1F\x19\x81\x84\x03\x01\x81R\x82\x82R\x80Q` \x91\x82\x01 `\0\x84R\x90\x83\x01\x80\x83RR`\xFF\x87\x16\x90\x82\x01R``\x81\x01\x85\x90R`\x80\x81\x01\x84\x90R`\xA0\x01` `@Q` \x81\x03\x90\x80\x84\x03\x90\x85Z\xFA\x15\x80\x15a\x07\xD5W=`\0\x80>=`\0\xFD[PP`@Q`\x1F\x19\x01Q\x91PP`\x01`\x01`\xA0\x1B\x03\x81\x16\x15\x80\x15\x90a\x08\x0BWP\x87`\x01`\x01`\xA0\x1B\x03\x16\x81`\x01`\x01`\xA0\x1B\x03\x16\x14[a\x08HW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x0E`$\x82\x01Rm$\xA7+ \xA6$\xA2/\xA9\xA4\xA3\xA7\"\xA9`\x91\x1B`D\x82\x01R`d\x01a\x05\xCCV[`\x01`\x01`\xA0\x1B\x03\x90\x81\x16`\0\x90\x81R`\x04` \x90\x81R`@\x80\x83 \x8A\x85\x16\x80\x85R\x90\x83R\x92\x81\x90 \x89\x90UQ\x88\x81R\x91\x92\x8A\x16\x91\x7F\x8C[\xE1\xE5\xEB\xEC}[\xD1OqB}\x1E\x84\xF3\xDD\x03\x14\xC0\xF7\xB2)\x1E[ \n\xC8\xC7\xC3\xB9%\x91\x01`@Q\x80\x91\x03\x90\xA3PPPPPPPV[`\0\x7F\x8Bs\xC3\xC6\x9B\xB8\xFE=Q.\xCCL\xF7Y\xCCy#\x9F{\x17\x9B\x0F\xFA\xCA\xA9\xA7]R+9@\x0F`\0`@Qa\x08\xE3\x91\x90a\x0C\x10V[`@\x80Q\x91\x82\x90\x03\x82 ` \x83\x01\x93\x90\x93R\x81\x01\x91\x90\x91R\x7F\xC8\x9E\xFD\xAAT\xC0\xF2\x0Cz\xDFa(\x82\xDF\tP\xF5\xA9Qc~\x03\x07\xCD\xCBLg/)\x8B\x8B\xC6``\x82\x01RF`\x80\x82\x01R0`\xA0\x82\x01R`\xC0\x01`@Q` \x81\x83\x03\x03\x81R\x90`@R\x80Q\x90` \x01 \x90P\x90V[\x80`\x02`\0\x82\x82Ta\t]\x91\x90a\x0C\xAFV[\x90\x91UPP`\x01`\x01`\xA0\x1B\x03\x82\x16`\0\x81\x81R`\x03` \x90\x81R`@\x80\x83 \x80T\x86\x01\x90UQ\x84\x81R\x7F\xDD\xF2R\xAD\x1B\xE2\xC8\x9Bi\xC2\xB0h\xFC7\x8D\xAA\x95+\xA7\xF1c\xC4\xA1\x16(\xF5ZM\xF5#\xB3\xEF\x91\x01`@Q\x80\x91\x03\x90\xA3PPV[`\0` \x80\x83R\x83Q\x80\x82\x85\x01R`\0[\x81\x81\x10\x15a\t\xE3W\x85\x81\x01\x83\x01Q\x85\x82\x01`@\x01R\x82\x01a\t\xC7V[P`\0`@\x82\x86\x01\x01R`@`\x1F\x19`\x1F\x83\x01\x16\x85\x01\x01\x92PPP\x92\x91PPV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x81\xFD[\x805`\x01`\x01`\xA0\x1B\x03\x81\x16\x81\x14a\nkW`\0\x80\xFD[\x91\x90PV[`\0\x80`@\x83\x85\x03\x12\x15a\n\x86Wa\n\x86a\n\x04V[a\n\x8F\x83a\nTV[\x94` \x93\x90\x93\x015\x93PPPV[`\0\x80`\0``\x84\x86\x03\x12\x15a\n\xB5Wa\n\xB5a\n\x04V[a\n\xBE\x84a\nTV[\x92Pa\n\xCC` \x85\x01a\nTV[\x91P`@\x84\x015\x90P\x92P\x92P\x92V[`\0` \x82\x84\x03\x12\x15a\n\xF1Wa\n\xF1a\n\x04V[a\n\xFA\x82a\nTV[\x93\x92PPPV[`\0\x80`\0\x80`\0\x80`\0`\xE0\x88\x8A\x03\x12\x15a\x0B\x1FWa\x0B\x1Fa\n\x04V[a\x0B(\x88a\nTV[\x96Pa\x0B6` \x89\x01a\nTV[\x95P`@\x88\x015\x94P``\x88\x015\x93P`\x80\x88\x015`\xFF\x81\x16\x81\x14a\x0BZW`\0\x80\xFD[\x96\x99\x95\x98P\x93\x96\x92\x95\x94`\xA0\x84\x015\x94P`\xC0\x90\x93\x015\x92\x91PPV[`\0\x80`@\x83\x85\x03\x12\x15a\x0B\x8DWa\x0B\x8Da\n\x04V[a\x0B\x96\x83a\nTV[\x91Pa\x0B\xA4` \x84\x01a\nTV[\x90P\x92P\x92\x90PV[`\x01\x81\x81\x1C\x90\x82\x16\x80a\x0B\xC1W`\x7F\x82\x16\x91P[` \x82\x10\x81\x03a\x0B\xE1WcNH{q`\xE0\x1B`\0R`\"`\x04R`$`\0\xFD[P\x91\x90PV[cNH{q`\xE0\x1B`\0R`\x11`\x04R`$`\0\xFD[\x81\x81\x03\x81\x81\x11\x15a\x04\x16Wa\x04\x16a\x0B\xE7V[`\0\x80\x83T\x81`\x01\x82\x81\x1C\x91P\x80\x83\x16\x80a\x0C,W`\x7F\x83\x16\x92P[` \x80\x84\x10\x82\x03a\x0CKWcNH{q`\xE0\x1B\x86R`\"`\x04R`$\x86\xFD[\x81\x80\x15a\x0C_W`\x01\x81\x14a\x0CtWa\x0C\xA1V[`\xFF\x19\x86\x16\x89R\x84\x15\x15\x85\x02\x89\x01\x96Pa\x0C\xA1V[`\0\x8A\x81R` \x90 `\0[\x86\x81\x10\x15a\x0C\x99W\x81T\x8B\x82\x01R\x90\x85\x01\x90\x83\x01a\x0C\x80V[PP\x84\x89\x01\x96P[P\x94\x98\x97PPPPPPPPV[\x80\x82\x01\x80\x82\x11\x15a\x04\x16Wa\x04\x16a\x0B\xE7V\xFE\xA2dipfsX\"\x12 \xD7m\x8C\x9F\x13Z?B\x9C\x92\xC0\xC4\x8A\x91!\xAF\x9F\xEA\xEC\xD1k\\\xF2+\x1Au\rSL\x1E\xA22dsolcC\0\x08\x13\x003";
+    const __BYTECODE: &[u8] = b"`\xE0`@\x90\x80\x82R4b\0\x04\xABWPb\0\x13T\x808\x03\x80\x83Q\x92b\0\0%\x82\x85b\0\x04\xF8V[\x839\x81\x01``\x82\x82\x03\x12b\0\x04\\W\x81Q`\x01`\x01`@\x1B\x03\x93\x90\x84\x81\x11b\0\x04VW\x82b\0\0V\x91\x85\x01b\0\x05lV[\x92` \x92\x83\x82\x01Q\x86\x81\x11b\0\x04VW\x83\x91b\0\0u\x91\x84\x01b\0\x05lV[\x91\x01Q`\xFF\x81\x16\x81\x03b\0\x04QW\x84Q\x94\x86\x86\x11b\0\x04;W`\0\x95\x80b\0\0\x9E\x88Tb\0\x06\x91V[\x92`\x1F\x93\x84\x81\x11b\0\x03\xEAW[P\x87\x90\x84\x83\x11`\x01\x14b\0\x03\x82W\x89\x92b\0\x03vW[PP\x81`\x01\x1B\x91`\0\x19\x90`\x03\x1B\x1C\x19\x16\x17\x86U[\x82Q\x90\x87\x82\x11b\0\x03bW\x81\x90`\x01\x94b\0\0\xF2\x86Tb\0\x06\x91V[\x82\x81\x11b\0\x03\rW[P\x87\x91\x83\x11`\x01\x14b\0\x02\xA9W\x88\x92b\0\x02\x9DW[PP`\0\x19`\x03\x83\x90\x1B\x1C\x19\x16\x90\x83\x1B\x17\x82U[`\x80RF`\xA0R\x81Q\x84T\x91\x81\x86b\0\x01=\x85b\0\x06\x91V[\x92\x83\x83R\x87\x83\x01\x95\x88\x82\x82\x16\x91\x82`\0\x14b\0\x02}WPP`\x01\x14b\0\x02=W[Pb\0\x01m\x92P\x03\x82b\0\x04\xF8V[Q\x90 \x92\x81Q\x92\x83\x01\x93\x7F\x8Bs\xC3\xC6\x9B\xB8\xFE=Q.\xCCL\xF7Y\xCCy#\x9F{\x17\x9B\x0F\xFA\xCA\xA9\xA7]R+9@\x0F\x85R\x82\x84\x01R\x7F\xC8\x9E\xFD\xAAT\xC0\xF2\x0Cz\xDFa(\x82\xDF\tP\xF5\xA9Qc~\x03\x07\xCD\xCBLg/)\x8B\x8B\xC6``\x84\x01RF`\x80\x84\x01R0`\xA0\x84\x01R`\xA0\x83R`\xC0\x83\x01\x94\x83\x86\x10\x90\x86\x11\x17b\0\x02)WP\x83\x90RQ\x90 `\xC0R`\x06\x80T`\x01`\x01`\xA0\x1B\x03\x19\x163\x17\x90Ua\x0C\x85\x90\x81b\0\x06\xCF\x829`\x80Q\x81a\x06\xCC\x01R`\xA0Q\x81a\n\xAE\x01R`\xC0Q\x81a\n\xD5\x01R\xF3[cNH{q`\xE0\x1B\x81R`A`\x04R`$\x90\xFD[\x87\x91P\x88\x80R\x81\x89 \x90\x89\x91[\x85\x83\x10b\0\x02dWPPb\0\x01m\x93P\x82\x01\x018b\0\x01^V[\x80T\x83\x88\x01\x85\x01R\x86\x94P\x89\x93\x90\x92\x01\x91\x81\x01b\0\x02JV[`\xFF\x19\x16\x88Rb\0\x01m\x95\x15\x15`\x05\x1B\x85\x01\x01\x92P8\x91Pb\0\x01^\x90PV[\x01Q\x90P8\x80b\0\x01\x10V[\x85\x89R\x87\x89 \x86\x94P\x91\x90`\x1F\x19\x84\x16\x8A[\x8A\x82\x82\x10b\0\x02\xF6WPP\x84\x11b\0\x02\xDCW[PPP\x81\x1B\x01\x82Ub\0\x01$V[\x01Q`\0\x19`\xF8\x84`\x03\x1B\x16\x1C\x19\x16\x90U8\x80\x80b\0\x02\xCEV[\x83\x85\x01Q\x86U\x89\x97\x90\x95\x01\x94\x93\x84\x01\x93\x01b\0\x02\xBBV[\x90\x91\x92P\x85\x89R\x87\x89 \x83\x80\x86\x01`\x05\x1C\x82\x01\x92\x8A\x87\x10b\0\x03XW[\x91\x86\x95\x89\x92\x95\x94\x93\x01`\x05\x1C\x01\x91[\x82\x81\x10b\0\x03IWPPb\0\0\xFBV[\x8B\x81U\x86\x95P\x88\x91\x01b\0\x039V[\x92P\x81\x92b\0\x03*V[cNH{q`\xE0\x1B\x87R`A`\x04R`$\x87\xFD[\x01Q\x90P8\x80b\0\0\xC1V[\x89\x80R\x88\x8A \x92P`\x1F\x19\x84\x16\x8A[\x8A\x82\x82\x10b\0\x03\xD3WPP\x90\x84`\x01\x95\x94\x93\x92\x10b\0\x03\xB9W[PPP\x81\x1B\x01\x86Ub\0\0\xD6V[\x01Q`\0\x19`\xF8\x84`\x03\x1B\x16\x1C\x19\x16\x90U8\x80\x80b\0\x03\xABV[`\x01\x85\x96\x82\x93\x96\x86\x01Q\x81U\x01\x95\x01\x93\x01b\0\x03\x91V[\x90\x91P\x88\x80R\x87\x89 \x84\x80\x85\x01`\x05\x1C\x82\x01\x92\x8A\x86\x10b\0\x041W[\x90\x85\x94\x93\x92\x91\x01`\x05\x1C\x01\x90[\x81\x81\x10b\0\x04\"WPb\0\0\xABV[\x8A\x81U\x84\x93P`\x01\x01b\0\x04\x13V[\x92P\x81\x92b\0\x04\x06V[cNH{q`\xE0\x1B`\0R`A`\x04R`$`\0\xFD[`\0\x80\xFD[b\0\x05\x1CV[\x82QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x90\xFD[bF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD[`\x1F\x90\x91\x01`\x1F\x19\x16\x81\x01\x90`\x01`\x01`@\x1B\x03\x82\x11\x90\x82\x10\x17b\0\x04;W`@RV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: invalid tuple offs`D\x82\x01Ra\x19]`\xF2\x1B`d\x82\x01R`\x84\x90\xFD[\x91\x90\x80`\x1F\x84\x01\x12\x15b\0\x068W\x82Q\x90`\x01`\x01`@\x1B\x03\x82\x11b\0\x04;W`@Q\x91` \x91b\0\x05\xA8`\x1F\x83\x01`\x1F\x19\x16\x84\x01\x85b\0\x04\xF8V[\x81\x84R\x82\x82\x87\x01\x01\x11b\0\x05\xE3W`\0[\x81\x81\x10b\0\x05\xCFWP\x82`\0\x93\x94\x95P\x01\x01R\x90V[\x85\x81\x01\x83\x01Q\x84\x82\x01\x84\x01R\x82\x01b\0\x05\xB9V[`@QbF\x1B\xCD`\xE5\x1B\x81R`\x04\x81\x01\x83\x90R`'`$\x82\x01R\x7FABI decoding: invalid byte array`D\x82\x01Rf\x04\r\x8C\xAD\xCC\xEE\x8D`\xCB\x1B`d\x82\x01R`\x84\x90\xFD[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`+`$\x82\x01R\x7FABI decoding: invalid calldata a`D\x82\x01Rj\x1C\x9C\x98^H\x1B\xD9\x99\x9C\xD9]`\xAA\x1B`d\x82\x01R`\x84\x90\xFD[\x90`\x01\x82\x81\x1C\x92\x16\x80\x15b\0\x06\xC3W[` \x83\x10\x14b\0\x06\xADWV[cNH{q`\xE0\x1B`\0R`\"`\x04R`$`\0\xFD[\x91`\x7F\x16\x91b\0\x06\xA1V\xFE`@`\x80\x81R`\x04\x806\x10\x15a\0pW[` `\x84\x92Q\x91bF\x1B\xCD`\xE5\x1B\x83R\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01Rtnor receive functions`X\x1B`d\x82\x01R\xFD[`\0\x805`\xE0\x1C\x80c\x06\xFD\xDE\x03\x14a\x08RW\x80c\t^\xA7\xB3\x14a\x07\xE2W\x80c\x18\x16\r\xDD\x14a\x07\xC4W\x80c#\xB8r\xDD\x14a\x06\xF0W\x80c1<\xE5g\x14a\x06\xB3W\x80c6D\xE5\x15\x14a\x06\x90W\x80c@\xC1\x0F\x19\x14a\x05\xA4W\x80cp\xA0\x821\x14a\x05lW\x80c~\xCE\xBE\0\x14a\x054W\x80c\x95\xD8\x9BA\x14a\x04UW\x80c\xA9\x05\x9C\xBB\x14a\x03\xD1W\x80c\xD5\x05\xAC\xCF\x14a\x01\x92W\x80c\xDDb\xED>\x14a\x01HWc\xF8Q\xA4@\x14a\x01\x16WPa\0\x10V[\x90P4a\x01CW6`\x03\x19\x01\x12a\x01>W`\x06T\x90Q`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x81R` \x90\xF3[a\tJV[a\x08\xFAV[P\x91\x904a\x01CW\x81`\x03\x196\x01\x12a\x01>W` \x92\x82\x91a\x01ha\nUV[a\x01pa\npV[`\x01`\x01`\xA0\x1B\x03\x91\x82\x16\x84R\x91\x86R\x83\x83 \x91\x16\x82R\x84R T\x90Q\x90\x81R\xF3[P\x824a\x01CW`\xE06`\x03\x19\x01\x12a\x01>Wa\x01\xADa\nUV[\x90a\x01\xB6a\npV[\x91`D5`d5\x92`\x845\x92`\xFF\x84\x16\x80\x94\x03a\x03\xCDWB\x85\x10a\x03\x8AWa\x01\xDCa\n\xA9V[\x95`\x01\x80`\xA0\x1B\x03\x80\x92\x16\x95\x86\x89R` \x95`\x05\x87R\x84\x8A \x98\x89T\x99`\x01\x8B\x01\x90U\x85Q\x92\x85\x89\x85\x01\x95\x7Fnq\xED\xAE\x12\xB1\xB9\x7FM\x1F`7\x0F\xEF\x10\x10_\xA2\xFA\xAE\x01&\x11J\x16\x9Cd\x84]a&\xC9\x87R\x8B\x89\x87\x01R\x16\x9A\x8B``\x86\x01R\x88`\x80\x86\x01R`\xA0\x85\x01R`\xC0\x84\x01R`\xC0\x83R`\xE0\x83\x01g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x94\x84\x82\x10\x86\x83\x11\x17a\x03vW\x81\x88R\x84Q\x90 a\x01\0\x85\x01\x92a\x19\x01`\xF0\x1B\x84Ra\x01\x02\x86\x01Ra\x01\"\x85\x01R`B\x81Ra\x01`\x84\x01\x94\x81\x86\x10\x90\x86\x11\x17a\x03cW\x84\x87RQ\x90 \x83Ra\x01\x80\x82\x01R`\xA45a\x01\xA0\x82\x01R`\xC45a\x01\xC0\x90\x91\x01R\x87\x80R\x84\x90\x88\x90`\x80\x90`\x01Z\xFA\x15a\x03YW\x86Q\x16\x96\x87\x15\x15\x80a\x03PW[\x15a\x03\x1EW\x86\x97\x7F\x8C[\xE1\xE5\xEB\xEC}[\xD1OqB}\x1E\x84\xF3\xDD\x03\x14\xC0\xF7\xB2)\x1E[ \n\xC8\xC7\xC3\xB9%\x95\x96\x97R\x83R\x80\x87 \x86\x88R\x83R\x81\x81\x88 UQ\x90\x81R\xA3\x80\xF3[\x83`d\x92Q\x91bF\x1B\xCD`\xE5\x1B\x83R\x82\x01R`\x0E`$\x82\x01Rm$\xA7+ \xA6$\xA2/\xA9\xA4\xA3\xA7\"\xA9`\x91\x1B`D\x82\x01R\xFD[P\x84\x88\x14a\x02\xDBV[\x81Q=\x88\x82>=\x90\xFD[cNH{q`\xE0\x1B\x8CR`A\x8DR`$\x8C\xFD[PcNH{q`\xE0\x1B\x8CR`A\x8DR`$\x8C\xFD[\x81QbF\x1B\xCD`\xE5\x1B\x81R` \x81\x8A\x01R`\x17`$\x82\x01R\x7FPERMIT_DEADLINE_EXPIRED\0\0\0\0\0\0\0\0\0`D\x82\x01R`d\x90\xFD[\x86\x80\xFD[P\x824a\x01CW\x80`\x03\x196\x01\x12a\x01>W` \x91a\x03\xEEa\nUV[\x82`$5\x913\x84R`\x03\x86R\x81\x84 a\x04\x08\x84\x82Ta\n\x86V[\x90U`\x01`\x01`\xA0\x1B\x03\x16\x80\x84R`\x03\x86R\x92 \x80T\x82\x01\x90U\x82Q\x90\x81R3\x90\x7F\xDD\xF2R\xAD\x1B\xE2\xC8\x9Bi\xC2\xB0h\xFC7\x8D\xAA\x95+\xA7\xF1c\xC4\xA1\x16(\xF5ZM\xF5#\xB3\xEF\x90\x85\x90\xA3Q`\x01\x81R\xF3[P\x824a\x01CW\x81`\x03\x196\x01\x12a\x01>W\x80Q\x90\x82`\x01\x80T\x91a\x04y\x83a\t\x9AV[\x80\x86R\x92\x82\x81\x16\x90\x81\x15a\x05\x0CWP`\x01\x14a\x04\xB0W[PPPa\x04\xA2\x82a\x04\xAC\x94\x03\x83a\t\xD4V[Q\x91\x82\x91\x82a\n\x0CV[\x03\x90\xF3[\x94P\x80\x85R\x7F\xB1\x0E-Rv\x12\x07;&\xEE\xCD\xFDq~j2\x0C\xF4KJ\xFA\xC2\xB0s-\x9F\xCB\xE2\xB7\xFA\x0C\xF6[\x82\x86\x10a\x04\xF4WPPPa\x04\xA2\x82` a\x04\xAC\x95\x82\x01\x01\x94a\x04\x90V[\x80T` \x87\x87\x01\x81\x01\x91\x90\x91R\x90\x95\x01\x94\x81\x01a\x04\xD7V[a\x04\xAC\x97P\x86\x93P` \x92Pa\x04\xA2\x94\x91P`\xFF\x19\x16\x82\x84\x01R\x15\x15`\x05\x1B\x82\x01\x01\x94a\x04\x90V[P\x824a\x01CW` 6`\x03\x19\x01\x12a\x01>W` \x91\x81\x90`\x01`\x01`\xA0\x1B\x03a\x05\\a\nUV[\x16\x81R`\x05\x84R T\x90Q\x90\x81R\xF3[P\x824a\x01CW` 6`\x03\x19\x01\x12a\x01>W` \x91\x81\x90`\x01`\x01`\xA0\x1B\x03a\x05\x94a\nUV[\x16\x81R`\x03\x84R T\x90Q\x90\x81R\xF3[P\x82\x904a\x01CW\x81`\x03\x196\x01\x12a\x01>Wa\x05\xBFa\nUV[`\x06T`$5\x92\x91`\x01`\x01`\xA0\x1B\x03\x91\x82\x163\x03a\x06CW`\x02T\x84\x81\x01\x80\x91\x11a\x060W` \x96P\x91\x86\x91\x7F\xDD\xF2R\xAD\x1B\xE2\xC8\x9Bi\xC2\xB0h\xFC7\x8D\xAA\x95+\xA7\xF1c\xC4\xA1\x16(\xF5ZM\xF5#\xB3\xEF\x93`\x02U\x16\x93\x84\x84R`\x03\x82R\x85\x84 \x81\x81T\x01\x90U\x85Q\x90\x81R\xA3Q`\x01\x81R\xF3[cNH{q`\xE0\x1B\x84R`\x11\x87R`$\x84\xFD[\x84QbF\x1B\xCD`\xE5\x1B\x81R` \x81\x88\x01R`!`$\x82\x01R\x7FOnly admin can call this functio`D\x82\x01R`7`\xF9\x1B`d\x82\x01R`\x84\x90\xFD[\x83\x824a\x01CW6`\x03\x19\x01\x12a\x01>W` \x90a\x06\xACa\n\xA9V[\x90Q\x90\x81R\xF3[\x83\x824a\x01CW6`\x03\x19\x01\x12a\x01>W` \x90Q`\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x81R\xF3[P\x82\x904a\x01CW``6`\x03\x19\x01\x12a\x01>Wa\x07\x0Ca\nUV[\x7F\xDD\xF2R\xAD\x1B\xE2\xC8\x9Bi\xC2\xB0h\xFC7\x8D\xAA\x95+\xA7\xF1c\xC4\xA1\x16(\xF5ZM\xF5#\xB3\xEFa\x075a\npV[`\x01`\x01`\xA0\x1B\x03\x92\x83\x16\x80\x85R` \x87\x81R\x86\x86 3\x87R\x81R\x86\x86 T\x90\x97\x91\x94\x88\x93`D5\x93\x89\x93\x85`\x01\x82\x01a\x07\xA1W[PPP\x86\x88R`\x03\x85R\x82\x88 a\x07\x82\x85\x82Ta\n\x86V[\x90U\x16\x95\x86\x81R`\x03\x84R \x81\x81T\x01\x90U\x85Q\x90\x81R\xA3Q`\x01\x81R\xF3[a\x07\xAA\x91a\n\x86V[\x90\x88\x8AR\x86R\x83\x89 3\x8AR\x86R\x83\x89 U\x8A\x80\x85a\x07jV[\x83\x824a\x01CW6`\x03\x19\x01\x12a\x01>W` \x90`\x02T\x90Q\x90\x81R\xF3[P\x91\x904a\x01CW\x81`\x03\x196\x01\x12a\x01>W` \x92a\x08\0a\nUV[\x91\x83`$5\x92\x83\x923\x82R\x87R\x81\x81 \x94`\x01\x80`\xA0\x1B\x03\x16\x94\x85\x82R\x87R U\x82Q\x90\x81R\x7F\x8C[\xE1\xE5\xEB\xEC}[\xD1OqB}\x1E\x84\xF3\xDD\x03\x14\xC0\xF7\xB2)\x1E[ \n\xC8\xC7\xC3\xB9%\x843\x92\xA3Q`\x01\x81R\xF3[P\x824a\x08\xFAW\x81`\x03\x196\x01\x12a\x01>W\x80Q\x90\x82\x80Ta\x08s\x81a\t\x9AV[\x80\x85R\x91`\x01\x91\x80\x83\x16\x90\x81\x15a\x05\x0CWP`\x01\x14a\x08\x9EWPPPa\x04\xA2\x82a\x04\xAC\x94\x03\x83a\t\xD4V[\x80\x80\x96PR\x7F)\r\xEC\xD9T\x8Bb\xA8\xD6\x03E\xA9\x888o\xC8K\xA6\xBC\x95H@\x08\xF66/\x93\x16\x0E\xF3\xE5c[\x82\x86\x10a\x08\xE2WPPPa\x04\xA2\x82` a\x04\xAC\x95\x82\x01\x01\x94a\x04\x90V[\x80T` \x87\x87\x01\x81\x01\x91\x90\x91R\x90\x95\x01\x94\x81\x01a\x08\xC5V[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x90\xFD[\x90`\x01\x82\x81\x1C\x92\x16\x80\x15a\t\xCAW[` \x83\x10\x14a\t\xB4WV[cNH{q`\xE0\x1B`\0R`\"`\x04R`$`\0\xFD[\x91`\x7F\x16\x91a\t\xA9V[\x90`\x1F\x80\x19\x91\x01\x16\x81\x01\x90\x81\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11\x17a\t\xF6W`@RV[cNH{q`\xE0\x1B`\0R`A`\x04R`$`\0\xFD[` \x80\x82R\x82Q\x81\x83\x01\x81\x90R\x90\x93\x92`\0[\x82\x81\x10a\nAWPP`@\x92\x93P`\0\x83\x82\x84\x01\x01R`\x1F\x80\x19\x91\x01\x16\x01\x01\x90V[\x81\x81\x01\x86\x01Q\x84\x82\x01`@\x01R\x85\x01a\n\x1FV[`\x045\x90`\x01`\x01`\xA0\x1B\x03\x82\x16\x82\x03a\nkWV[`\0\x80\xFD[`$5\x90`\x01`\x01`\xA0\x1B\x03\x82\x16\x82\x03a\nkWV[\x91\x90\x82\x03\x91\x82\x11a\n\x93WV[cNH{q`\xE0\x1B`\0R`\x11`\x04R`$`\0\xFD[`\0F\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x03a\n\xF7WP\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x90V[`@Q\x81T\x82\x91a\x0B\x07\x82a\t\x9AV[\x80\x82R\x81` \x94\x85\x82\x01\x94`\x01\x90\x87\x82\x82\x16\x91\x82`\0\x14a\x0C1WPP`\x01\x14a\x0B\xD8W[Pa\x0B9\x92P\x03\x82a\t\xD4V[Q\x90 \x91`@Q\x91\x82\x01\x92\x7F\x8Bs\xC3\xC6\x9B\xB8\xFE=Q.\xCCL\xF7Y\xCCy#\x9F{\x17\x9B\x0F\xFA\xCA\xA9\xA7]R+9@\x0F\x84R`@\x83\x01R\x7F\xC8\x9E\xFD\xAAT\xC0\xF2\x0Cz\xDFa(\x82\xDF\tP\xF5\xA9Qc~\x03\x07\xCD\xCBLg/)\x8B\x8B\xC6``\x83\x01RF`\x80\x83\x01R0`\xA0\x83\x01R`\xA0\x82R`\xC0\x82\x01\x90\x82\x82\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x83\x11\x17a\x0B\xC4WP`@RQ\x90 \x90V[cNH{q`\xE0\x1B\x81R`A`\x04R`$\x90\xFD[\x87\x80R\x86\x91P\x87\x90\x7F)\r\xEC\xD9T\x8Bb\xA8\xD6\x03E\xA9\x888o\xC8K\xA6\xBC\x95H@\x08\xF66/\x93\x16\x0E\xF3\xE5c[\x85\x83\x10a\x0C\x19WPPa\x0B9\x93P\x82\x01\x018a\x0B,V[\x80T\x83\x88\x01\x85\x01R\x86\x94P\x88\x93\x90\x92\x01\x91\x81\x01a\x0C\x02V[`\xFF\x19\x16\x88Ra\x0B9\x95\x15\x15`\x05\x1B\x85\x01\x01\x92P8\x91Pa\x0B,\x90PV\xFE\xA2dipfsX\"\x12 \xE3W;\xFC\xD8\xCC\xEE\x0E\x810\x99\x8C`\x1FF*\xCAO\xF0_\x18L\xAD=\x04U+\x03\xCE\xD1\xB5\xC9dsolcC\0\x08\x13\x003";
     /// The bytecode of the contract.
-    pub static ARBITERTOKEN_BYTECODE: ::ethers::core::types::Bytes =
-        ::ethers::core::types::Bytes::from_static(__BYTECODE);
+    pub static ARBITERTOKEN_BYTECODE: ::ethers::core::types::Bytes = ::ethers::core::types::Bytes::from_static(
+        __BYTECODE,
+    );
     #[rustfmt::skip]
-    const __DEPLOYED_BYTECODE: &[u8] = b"`\x80`@R4\x80\x15a\0]W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01\x90\x81Ra7\xB7`\xF1\x1B`d\x83\x01R`\x84\x82\xFD[P`\x046\x10a\x017W`\x005`\xE0\x1C\x80cp\xA0\x821\x11a\0\xD9W\x80c\xA9\x05\x9C\xBB\x11a\0\xB3W\x80c\xA9\x05\x9C\xBB\x14a\x02\xA3W\x80c\xD5\x05\xAC\xCF\x14a\x02\xB6W\x80c\xDDb\xED>\x14a\x02\xCBW\x80c\xF8Q\xA4@\x14a\x02\xF6Wa\x017V[\x80cp\xA0\x821\x14a\x02[W\x80c~\xCE\xBE\0\x14a\x02{W\x80c\x95\xD8\x9BA\x14a\x02\x9BWa\x017V[\x80c#\xB8r\xDD\x11a\x01\x15W\x80c#\xB8r\xDD\x14a\x01\xF4W\x80c1<\xE5g\x14a\x02\x07W\x80c6D\xE5\x15\x14a\x02@W\x80c@\xC1\x0F\x19\x14a\x02HWa\x017V[\x80c\x06\xFD\xDE\x03\x14a\x01\x9CW\x80c\t^\xA7\xB3\x14a\x01\xBAW\x80c\x18\x16\r\xDD\x14a\x01\xDDW[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01\x90\x81Rtnor receive functions`X\x1B`d\x83\x01R`\x84\x82\xFD[a\x01\xA4a\x03!V[`@Qa\x01\xB1\x91\x90a\t\xB6V[`@Q\x80\x91\x03\x90\xF3[a\x01\xCDa\x01\xC86`\x04a\npV[a\x03\xAFV[`@Q\x90\x15\x15\x81R` \x01a\x01\xB1V[a\x01\xE6`\x02T\x81V[`@Q\x90\x81R` \x01a\x01\xB1V[a\x01\xCDa\x02\x026`\x04a\n\x9DV[a\x04\x1CV[a\x02.\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81V[`@Q`\xFF\x90\x91\x16\x81R` \x01a\x01\xB1V[a\x01\xE6a\x05\x0EV[a\x01\xCDa\x02V6`\x04a\npV[a\x05iV[a\x01\xE6a\x02i6`\x04a\n\xDCV[`\x03` R`\0\x90\x81R`@\x90 T\x81V[a\x01\xE6a\x02\x896`\x04a\n\xDCV[`\x05` R`\0\x90\x81R`@\x90 T\x81V[a\x01\xA4a\x05\xE8V[a\x01\xCDa\x02\xB16`\x04a\npV[a\x05\xF5V[a\x02\xC9a\x02\xC46`\x04a\x0B\x01V[a\x06mV[\0[a\x01\xE6a\x02\xD96`\x04a\x0BwV[`\x04` \x90\x81R`\0\x92\x83R`@\x80\x84 \x90\x91R\x90\x82R\x90 T\x81V[`\x06Ta\x03\t\x90`\x01`\x01`\xA0\x1B\x03\x16\x81V[`@Q`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x81R` \x01a\x01\xB1V[`\0\x80Ta\x03.\x90a\x0B\xADV[\x80`\x1F\x01` \x80\x91\x04\x02` \x01`@Q\x90\x81\x01`@R\x80\x92\x91\x90\x81\x81R` \x01\x82\x80Ta\x03Z\x90a\x0B\xADV[\x80\x15a\x03\xA7W\x80`\x1F\x10a\x03|Wa\x01\0\x80\x83T\x04\x02\x83R\x91` \x01\x91a\x03\xA7V[\x82\x01\x91\x90`\0R` `\0 \x90[\x81T\x81R\x90`\x01\x01\x90` \x01\x80\x83\x11a\x03\x8AW\x82\x90\x03`\x1F\x16\x82\x01\x91[PPPPP\x81V[3`\0\x81\x81R`\x04` \x90\x81R`@\x80\x83 `\x01`\x01`\xA0\x1B\x03\x87\x16\x80\x85R\x92R\x80\x83 \x85\x90UQ\x91\x92\x90\x91\x7F\x8C[\xE1\xE5\xEB\xEC}[\xD1OqB}\x1E\x84\xF3\xDD\x03\x14\xC0\xF7\xB2)\x1E[ \n\xC8\xC7\xC3\xB9%\x90a\x04\n\x90\x86\x81R` \x01\x90V[`@Q\x80\x91\x03\x90\xA3P`\x01[\x92\x91PPV[`\x01`\x01`\xA0\x1B\x03\x83\x16`\0\x90\x81R`\x04` \x90\x81R`@\x80\x83 3\x84R\x90\x91R\x81 T`\0\x19\x81\x14a\x04xWa\x04S\x83\x82a\x0B\xFDV[`\x01`\x01`\xA0\x1B\x03\x86\x16`\0\x90\x81R`\x04` \x90\x81R`@\x80\x83 3\x84R\x90\x91R\x90 U[`\x01`\x01`\xA0\x1B\x03\x85\x16`\0\x90\x81R`\x03` R`@\x81 \x80T\x85\x92\x90a\x04\xA0\x90\x84\x90a\x0B\xFDV[\x90\x91UPP`\x01`\x01`\xA0\x1B\x03\x80\x85\x16`\0\x81\x81R`\x03` R`@\x90\x81\x90 \x80T\x87\x01\x90UQ\x90\x91\x87\x16\x90\x7F\xDD\xF2R\xAD\x1B\xE2\xC8\x9Bi\xC2\xB0h\xFC7\x8D\xAA\x95+\xA7\xF1c\xC4\xA1\x16(\xF5ZM\xF5#\xB3\xEF\x90a\x04\xFB\x90\x87\x81R` \x01\x90V[`@Q\x80\x91\x03\x90\xA3P`\x01\x94\x93PPPPV[`\0\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0F\x14a\x05DWa\x05?a\x08\xB1V[\x90P\x90V[P\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x90V[`\x06T`\0\x90`\x01`\x01`\xA0\x1B\x03\x163\x14a\x05\xD5W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`!`$\x82\x01R\x7FOnly admin can call this functio`D\x82\x01R`7`\xF9\x1B`d\x82\x01R`\x84\x01[`@Q\x80\x91\x03\x90\xFD[a\x05\xDF\x83\x83a\tKV[P`\x01\x92\x91PPV[`\x01\x80Ta\x03.\x90a\x0B\xADV[3`\0\x90\x81R`\x03` R`@\x81 \x80T\x83\x91\x90\x83\x90a\x06\x16\x90\x84\x90a\x0B\xFDV[\x90\x91UPP`\x01`\x01`\xA0\x1B\x03\x83\x16`\0\x81\x81R`\x03` R`@\x90\x81\x90 \x80T\x85\x01\x90UQ3\x90\x7F\xDD\xF2R\xAD\x1B\xE2\xC8\x9Bi\xC2\xB0h\xFC7\x8D\xAA\x95+\xA7\xF1c\xC4\xA1\x16(\xF5ZM\xF5#\xB3\xEF\x90a\x04\n\x90\x86\x81R` \x01\x90V[B\x84\x10\x15a\x06\xBDW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x17`$\x82\x01R\x7FPERMIT_DEADLINE_EXPIRED\0\0\0\0\0\0\0\0\0`D\x82\x01R`d\x01a\x05\xCCV[`\0`\x01a\x06\xC9a\x05\x0EV[`\x01`\x01`\xA0\x1B\x03\x8A\x81\x16`\0\x81\x81R`\x05` \x90\x81R`@\x91\x82\x90 \x80T`\x01\x81\x01\x90\x91U\x82Q\x7Fnq\xED\xAE\x12\xB1\xB9\x7FM\x1F`7\x0F\xEF\x10\x10_\xA2\xFA\xAE\x01&\x11J\x16\x9Cd\x84]a&\xC9\x81\x84\x01R\x80\x84\x01\x94\x90\x94R\x93\x8D\x16``\x84\x01R`\x80\x83\x01\x8C\x90R`\xA0\x83\x01\x93\x90\x93R`\xC0\x80\x83\x01\x8B\x90R\x81Q\x80\x84\x03\x90\x91\x01\x81R`\xE0\x83\x01\x90\x91R\x80Q\x92\x01\x91\x90\x91 a\x19\x01`\xF0\x1Ba\x01\0\x83\x01Ra\x01\x02\x82\x01\x92\x90\x92Ra\x01\"\x81\x01\x91\x90\x91Ra\x01B\x01`@\x80Q`\x1F\x19\x81\x84\x03\x01\x81R\x82\x82R\x80Q` \x91\x82\x01 `\0\x84R\x90\x83\x01\x80\x83RR`\xFF\x87\x16\x90\x82\x01R``\x81\x01\x85\x90R`\x80\x81\x01\x84\x90R`\xA0\x01` `@Q` \x81\x03\x90\x80\x84\x03\x90\x85Z\xFA\x15\x80\x15a\x07\xD5W=`\0\x80>=`\0\xFD[PP`@Q`\x1F\x19\x01Q\x91PP`\x01`\x01`\xA0\x1B\x03\x81\x16\x15\x80\x15\x90a\x08\x0BWP\x87`\x01`\x01`\xA0\x1B\x03\x16\x81`\x01`\x01`\xA0\x1B\x03\x16\x14[a\x08HW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x0E`$\x82\x01Rm$\xA7+ \xA6$\xA2/\xA9\xA4\xA3\xA7\"\xA9`\x91\x1B`D\x82\x01R`d\x01a\x05\xCCV[`\x01`\x01`\xA0\x1B\x03\x90\x81\x16`\0\x90\x81R`\x04` \x90\x81R`@\x80\x83 \x8A\x85\x16\x80\x85R\x90\x83R\x92\x81\x90 \x89\x90UQ\x88\x81R\x91\x92\x8A\x16\x91\x7F\x8C[\xE1\xE5\xEB\xEC}[\xD1OqB}\x1E\x84\xF3\xDD\x03\x14\xC0\xF7\xB2)\x1E[ \n\xC8\xC7\xC3\xB9%\x91\x01`@Q\x80\x91\x03\x90\xA3PPPPPPPV[`\0\x7F\x8Bs\xC3\xC6\x9B\xB8\xFE=Q.\xCCL\xF7Y\xCCy#\x9F{\x17\x9B\x0F\xFA\xCA\xA9\xA7]R+9@\x0F`\0`@Qa\x08\xE3\x91\x90a\x0C\x10V[`@\x80Q\x91\x82\x90\x03\x82 ` \x83\x01\x93\x90\x93R\x81\x01\x91\x90\x91R\x7F\xC8\x9E\xFD\xAAT\xC0\xF2\x0Cz\xDFa(\x82\xDF\tP\xF5\xA9Qc~\x03\x07\xCD\xCBLg/)\x8B\x8B\xC6``\x82\x01RF`\x80\x82\x01R0`\xA0\x82\x01R`\xC0\x01`@Q` \x81\x83\x03\x03\x81R\x90`@R\x80Q\x90` \x01 \x90P\x90V[\x80`\x02`\0\x82\x82Ta\t]\x91\x90a\x0C\xAFV[\x90\x91UPP`\x01`\x01`\xA0\x1B\x03\x82\x16`\0\x81\x81R`\x03` \x90\x81R`@\x80\x83 \x80T\x86\x01\x90UQ\x84\x81R\x7F\xDD\xF2R\xAD\x1B\xE2\xC8\x9Bi\xC2\xB0h\xFC7\x8D\xAA\x95+\xA7\xF1c\xC4\xA1\x16(\xF5ZM\xF5#\xB3\xEF\x91\x01`@Q\x80\x91\x03\x90\xA3PPV[`\0` \x80\x83R\x83Q\x80\x82\x85\x01R`\0[\x81\x81\x10\x15a\t\xE3W\x85\x81\x01\x83\x01Q\x85\x82\x01`@\x01R\x82\x01a\t\xC7V[P`\0`@\x82\x86\x01\x01R`@`\x1F\x19`\x1F\x83\x01\x16\x85\x01\x01\x92PPP\x92\x91PPV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x81\xFD[\x805`\x01`\x01`\xA0\x1B\x03\x81\x16\x81\x14a\nkW`\0\x80\xFD[\x91\x90PV[`\0\x80`@\x83\x85\x03\x12\x15a\n\x86Wa\n\x86a\n\x04V[a\n\x8F\x83a\nTV[\x94` \x93\x90\x93\x015\x93PPPV[`\0\x80`\0``\x84\x86\x03\x12\x15a\n\xB5Wa\n\xB5a\n\x04V[a\n\xBE\x84a\nTV[\x92Pa\n\xCC` \x85\x01a\nTV[\x91P`@\x84\x015\x90P\x92P\x92P\x92V[`\0` \x82\x84\x03\x12\x15a\n\xF1Wa\n\xF1a\n\x04V[a\n\xFA\x82a\nTV[\x93\x92PPPV[`\0\x80`\0\x80`\0\x80`\0`\xE0\x88\x8A\x03\x12\x15a\x0B\x1FWa\x0B\x1Fa\n\x04V[a\x0B(\x88a\nTV[\x96Pa\x0B6` \x89\x01a\nTV[\x95P`@\x88\x015\x94P``\x88\x015\x93P`\x80\x88\x015`\xFF\x81\x16\x81\x14a\x0BZW`\0\x80\xFD[\x96\x99\x95\x98P\x93\x96\x92\x95\x94`\xA0\x84\x015\x94P`\xC0\x90\x93\x015\x92\x91PPV[`\0\x80`@\x83\x85\x03\x12\x15a\x0B\x8DWa\x0B\x8Da\n\x04V[a\x0B\x96\x83a\nTV[\x91Pa\x0B\xA4` \x84\x01a\nTV[\x90P\x92P\x92\x90PV[`\x01\x81\x81\x1C\x90\x82\x16\x80a\x0B\xC1W`\x7F\x82\x16\x91P[` \x82\x10\x81\x03a\x0B\xE1WcNH{q`\xE0\x1B`\0R`\"`\x04R`$`\0\xFD[P\x91\x90PV[cNH{q`\xE0\x1B`\0R`\x11`\x04R`$`\0\xFD[\x81\x81\x03\x81\x81\x11\x15a\x04\x16Wa\x04\x16a\x0B\xE7V[`\0\x80\x83T\x81`\x01\x82\x81\x1C\x91P\x80\x83\x16\x80a\x0C,W`\x7F\x83\x16\x92P[` \x80\x84\x10\x82\x03a\x0CKWcNH{q`\xE0\x1B\x86R`\"`\x04R`$\x86\xFD[\x81\x80\x15a\x0C_W`\x01\x81\x14a\x0CtWa\x0C\xA1V[`\xFF\x19\x86\x16\x89R\x84\x15\x15\x85\x02\x89\x01\x96Pa\x0C\xA1V[`\0\x8A\x81R` \x90 `\0[\x86\x81\x10\x15a\x0C\x99W\x81T\x8B\x82\x01R\x90\x85\x01\x90\x83\x01a\x0C\x80V[PP\x84\x89\x01\x96P[P\x94\x98\x97PPPPPPPPV[\x80\x82\x01\x80\x82\x11\x15a\x04\x16Wa\x04\x16a\x0B\xE7V\xFE\xA2dipfsX\"\x12 \xD7m\x8C\x9F\x13Z?B\x9C\x92\xC0\xC4\x8A\x91!\xAF\x9F\xEA\xEC\xD1k\\\xF2+\x1Au\rSL\x1E\xA22dsolcC\0\x08\x13\x003";
+    const __DEPLOYED_BYTECODE: &[u8] = b"`@`\x80\x81R`\x04\x806\x10\x15a\0pW[` `\x84\x92Q\x91bF\x1B\xCD`\xE5\x1B\x83R\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01Rtnor receive functions`X\x1B`d\x82\x01R\xFD[`\0\x805`\xE0\x1C\x80c\x06\xFD\xDE\x03\x14a\x08RW\x80c\t^\xA7\xB3\x14a\x07\xE2W\x80c\x18\x16\r\xDD\x14a\x07\xC4W\x80c#\xB8r\xDD\x14a\x06\xF0W\x80c1<\xE5g\x14a\x06\xB3W\x80c6D\xE5\x15\x14a\x06\x90W\x80c@\xC1\x0F\x19\x14a\x05\xA4W\x80cp\xA0\x821\x14a\x05lW\x80c~\xCE\xBE\0\x14a\x054W\x80c\x95\xD8\x9BA\x14a\x04UW\x80c\xA9\x05\x9C\xBB\x14a\x03\xD1W\x80c\xD5\x05\xAC\xCF\x14a\x01\x92W\x80c\xDDb\xED>\x14a\x01HWc\xF8Q\xA4@\x14a\x01\x16WPa\0\x10V[\x90P4a\x01CW6`\x03\x19\x01\x12a\x01>W`\x06T\x90Q`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x81R` \x90\xF3[a\tJV[a\x08\xFAV[P\x91\x904a\x01CW\x81`\x03\x196\x01\x12a\x01>W` \x92\x82\x91a\x01ha\nUV[a\x01pa\npV[`\x01`\x01`\xA0\x1B\x03\x91\x82\x16\x84R\x91\x86R\x83\x83 \x91\x16\x82R\x84R T\x90Q\x90\x81R\xF3[P\x824a\x01CW`\xE06`\x03\x19\x01\x12a\x01>Wa\x01\xADa\nUV[\x90a\x01\xB6a\npV[\x91`D5`d5\x92`\x845\x92`\xFF\x84\x16\x80\x94\x03a\x03\xCDWB\x85\x10a\x03\x8AWa\x01\xDCa\n\xA9V[\x95`\x01\x80`\xA0\x1B\x03\x80\x92\x16\x95\x86\x89R` \x95`\x05\x87R\x84\x8A \x98\x89T\x99`\x01\x8B\x01\x90U\x85Q\x92\x85\x89\x85\x01\x95\x7Fnq\xED\xAE\x12\xB1\xB9\x7FM\x1F`7\x0F\xEF\x10\x10_\xA2\xFA\xAE\x01&\x11J\x16\x9Cd\x84]a&\xC9\x87R\x8B\x89\x87\x01R\x16\x9A\x8B``\x86\x01R\x88`\x80\x86\x01R`\xA0\x85\x01R`\xC0\x84\x01R`\xC0\x83R`\xE0\x83\x01g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x94\x84\x82\x10\x86\x83\x11\x17a\x03vW\x81\x88R\x84Q\x90 a\x01\0\x85\x01\x92a\x19\x01`\xF0\x1B\x84Ra\x01\x02\x86\x01Ra\x01\"\x85\x01R`B\x81Ra\x01`\x84\x01\x94\x81\x86\x10\x90\x86\x11\x17a\x03cW\x84\x87RQ\x90 \x83Ra\x01\x80\x82\x01R`\xA45a\x01\xA0\x82\x01R`\xC45a\x01\xC0\x90\x91\x01R\x87\x80R\x84\x90\x88\x90`\x80\x90`\x01Z\xFA\x15a\x03YW\x86Q\x16\x96\x87\x15\x15\x80a\x03PW[\x15a\x03\x1EW\x86\x97\x7F\x8C[\xE1\xE5\xEB\xEC}[\xD1OqB}\x1E\x84\xF3\xDD\x03\x14\xC0\xF7\xB2)\x1E[ \n\xC8\xC7\xC3\xB9%\x95\x96\x97R\x83R\x80\x87 \x86\x88R\x83R\x81\x81\x88 UQ\x90\x81R\xA3\x80\xF3[\x83`d\x92Q\x91bF\x1B\xCD`\xE5\x1B\x83R\x82\x01R`\x0E`$\x82\x01Rm$\xA7+ \xA6$\xA2/\xA9\xA4\xA3\xA7\"\xA9`\x91\x1B`D\x82\x01R\xFD[P\x84\x88\x14a\x02\xDBV[\x81Q=\x88\x82>=\x90\xFD[cNH{q`\xE0\x1B\x8CR`A\x8DR`$\x8C\xFD[PcNH{q`\xE0\x1B\x8CR`A\x8DR`$\x8C\xFD[\x81QbF\x1B\xCD`\xE5\x1B\x81R` \x81\x8A\x01R`\x17`$\x82\x01R\x7FPERMIT_DEADLINE_EXPIRED\0\0\0\0\0\0\0\0\0`D\x82\x01R`d\x90\xFD[\x86\x80\xFD[P\x824a\x01CW\x80`\x03\x196\x01\x12a\x01>W` \x91a\x03\xEEa\nUV[\x82`$5\x913\x84R`\x03\x86R\x81\x84 a\x04\x08\x84\x82Ta\n\x86V[\x90U`\x01`\x01`\xA0\x1B\x03\x16\x80\x84R`\x03\x86R\x92 \x80T\x82\x01\x90U\x82Q\x90\x81R3\x90\x7F\xDD\xF2R\xAD\x1B\xE2\xC8\x9Bi\xC2\xB0h\xFC7\x8D\xAA\x95+\xA7\xF1c\xC4\xA1\x16(\xF5ZM\xF5#\xB3\xEF\x90\x85\x90\xA3Q`\x01\x81R\xF3[P\x824a\x01CW\x81`\x03\x196\x01\x12a\x01>W\x80Q\x90\x82`\x01\x80T\x91a\x04y\x83a\t\x9AV[\x80\x86R\x92\x82\x81\x16\x90\x81\x15a\x05\x0CWP`\x01\x14a\x04\xB0W[PPPa\x04\xA2\x82a\x04\xAC\x94\x03\x83a\t\xD4V[Q\x91\x82\x91\x82a\n\x0CV[\x03\x90\xF3[\x94P\x80\x85R\x7F\xB1\x0E-Rv\x12\x07;&\xEE\xCD\xFDq~j2\x0C\xF4KJ\xFA\xC2\xB0s-\x9F\xCB\xE2\xB7\xFA\x0C\xF6[\x82\x86\x10a\x04\xF4WPPPa\x04\xA2\x82` a\x04\xAC\x95\x82\x01\x01\x94a\x04\x90V[\x80T` \x87\x87\x01\x81\x01\x91\x90\x91R\x90\x95\x01\x94\x81\x01a\x04\xD7V[a\x04\xAC\x97P\x86\x93P` \x92Pa\x04\xA2\x94\x91P`\xFF\x19\x16\x82\x84\x01R\x15\x15`\x05\x1B\x82\x01\x01\x94a\x04\x90V[P\x824a\x01CW` 6`\x03\x19\x01\x12a\x01>W` \x91\x81\x90`\x01`\x01`\xA0\x1B\x03a\x05\\a\nUV[\x16\x81R`\x05\x84R T\x90Q\x90\x81R\xF3[P\x824a\x01CW` 6`\x03\x19\x01\x12a\x01>W` \x91\x81\x90`\x01`\x01`\xA0\x1B\x03a\x05\x94a\nUV[\x16\x81R`\x03\x84R T\x90Q\x90\x81R\xF3[P\x82\x904a\x01CW\x81`\x03\x196\x01\x12a\x01>Wa\x05\xBFa\nUV[`\x06T`$5\x92\x91`\x01`\x01`\xA0\x1B\x03\x91\x82\x163\x03a\x06CW`\x02T\x84\x81\x01\x80\x91\x11a\x060W` \x96P\x91\x86\x91\x7F\xDD\xF2R\xAD\x1B\xE2\xC8\x9Bi\xC2\xB0h\xFC7\x8D\xAA\x95+\xA7\xF1c\xC4\xA1\x16(\xF5ZM\xF5#\xB3\xEF\x93`\x02U\x16\x93\x84\x84R`\x03\x82R\x85\x84 \x81\x81T\x01\x90U\x85Q\x90\x81R\xA3Q`\x01\x81R\xF3[cNH{q`\xE0\x1B\x84R`\x11\x87R`$\x84\xFD[\x84QbF\x1B\xCD`\xE5\x1B\x81R` \x81\x88\x01R`!`$\x82\x01R\x7FOnly admin can call this functio`D\x82\x01R`7`\xF9\x1B`d\x82\x01R`\x84\x90\xFD[\x83\x824a\x01CW6`\x03\x19\x01\x12a\x01>W` \x90a\x06\xACa\n\xA9V[\x90Q\x90\x81R\xF3[\x83\x824a\x01CW6`\x03\x19\x01\x12a\x01>W` \x90Q`\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x81R\xF3[P\x82\x904a\x01CW``6`\x03\x19\x01\x12a\x01>Wa\x07\x0Ca\nUV[\x7F\xDD\xF2R\xAD\x1B\xE2\xC8\x9Bi\xC2\xB0h\xFC7\x8D\xAA\x95+\xA7\xF1c\xC4\xA1\x16(\xF5ZM\xF5#\xB3\xEFa\x075a\npV[`\x01`\x01`\xA0\x1B\x03\x92\x83\x16\x80\x85R` \x87\x81R\x86\x86 3\x87R\x81R\x86\x86 T\x90\x97\x91\x94\x88\x93`D5\x93\x89\x93\x85`\x01\x82\x01a\x07\xA1W[PPP\x86\x88R`\x03\x85R\x82\x88 a\x07\x82\x85\x82Ta\n\x86V[\x90U\x16\x95\x86\x81R`\x03\x84R \x81\x81T\x01\x90U\x85Q\x90\x81R\xA3Q`\x01\x81R\xF3[a\x07\xAA\x91a\n\x86V[\x90\x88\x8AR\x86R\x83\x89 3\x8AR\x86R\x83\x89 U\x8A\x80\x85a\x07jV[\x83\x824a\x01CW6`\x03\x19\x01\x12a\x01>W` \x90`\x02T\x90Q\x90\x81R\xF3[P\x91\x904a\x01CW\x81`\x03\x196\x01\x12a\x01>W` \x92a\x08\0a\nUV[\x91\x83`$5\x92\x83\x923\x82R\x87R\x81\x81 \x94`\x01\x80`\xA0\x1B\x03\x16\x94\x85\x82R\x87R U\x82Q\x90\x81R\x7F\x8C[\xE1\xE5\xEB\xEC}[\xD1OqB}\x1E\x84\xF3\xDD\x03\x14\xC0\xF7\xB2)\x1E[ \n\xC8\xC7\xC3\xB9%\x843\x92\xA3Q`\x01\x81R\xF3[P\x824a\x08\xFAW\x81`\x03\x196\x01\x12a\x01>W\x80Q\x90\x82\x80Ta\x08s\x81a\t\x9AV[\x80\x85R\x91`\x01\x91\x80\x83\x16\x90\x81\x15a\x05\x0CWP`\x01\x14a\x08\x9EWPPPa\x04\xA2\x82a\x04\xAC\x94\x03\x83a\t\xD4V[\x80\x80\x96PR\x7F)\r\xEC\xD9T\x8Bb\xA8\xD6\x03E\xA9\x888o\xC8K\xA6\xBC\x95H@\x08\xF66/\x93\x16\x0E\xF3\xE5c[\x82\x86\x10a\x08\xE2WPPPa\x04\xA2\x82` a\x04\xAC\x95\x82\x01\x01\x94a\x04\x90V[\x80T` \x87\x87\x01\x81\x01\x91\x90\x91R\x90\x95\x01\x94\x81\x01a\x08\xC5V[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x90\xFD[\x90`\x01\x82\x81\x1C\x92\x16\x80\x15a\t\xCAW[` \x83\x10\x14a\t\xB4WV[cNH{q`\xE0\x1B`\0R`\"`\x04R`$`\0\xFD[\x91`\x7F\x16\x91a\t\xA9V[\x90`\x1F\x80\x19\x91\x01\x16\x81\x01\x90\x81\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11\x17a\t\xF6W`@RV[cNH{q`\xE0\x1B`\0R`A`\x04R`$`\0\xFD[` \x80\x82R\x82Q\x81\x83\x01\x81\x90R\x90\x93\x92`\0[\x82\x81\x10a\nAWPP`@\x92\x93P`\0\x83\x82\x84\x01\x01R`\x1F\x80\x19\x91\x01\x16\x01\x01\x90V[\x81\x81\x01\x86\x01Q\x84\x82\x01`@\x01R\x85\x01a\n\x1FV[`\x045\x90`\x01`\x01`\xA0\x1B\x03\x82\x16\x82\x03a\nkWV[`\0\x80\xFD[`$5\x90`\x01`\x01`\xA0\x1B\x03\x82\x16\x82\x03a\nkWV[\x91\x90\x82\x03\x91\x82\x11a\n\x93WV[cNH{q`\xE0\x1B`\0R`\x11`\x04R`$`\0\xFD[`\0F\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x03a\n\xF7WP\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x90V[`@Q\x81T\x82\x91a\x0B\x07\x82a\t\x9AV[\x80\x82R\x81` \x94\x85\x82\x01\x94`\x01\x90\x87\x82\x82\x16\x91\x82`\0\x14a\x0C1WPP`\x01\x14a\x0B\xD8W[Pa\x0B9\x92P\x03\x82a\t\xD4V[Q\x90 \x91`@Q\x91\x82\x01\x92\x7F\x8Bs\xC3\xC6\x9B\xB8\xFE=Q.\xCCL\xF7Y\xCCy#\x9F{\x17\x9B\x0F\xFA\xCA\xA9\xA7]R+9@\x0F\x84R`@\x83\x01R\x7F\xC8\x9E\xFD\xAAT\xC0\xF2\x0Cz\xDFa(\x82\xDF\tP\xF5\xA9Qc~\x03\x07\xCD\xCBLg/)\x8B\x8B\xC6``\x83\x01RF`\x80\x83\x01R0`\xA0\x83\x01R`\xA0\x82R`\xC0\x82\x01\x90\x82\x82\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x83\x11\x17a\x0B\xC4WP`@RQ\x90 \x90V[cNH{q`\xE0\x1B\x81R`A`\x04R`$\x90\xFD[\x87\x80R\x86\x91P\x87\x90\x7F)\r\xEC\xD9T\x8Bb\xA8\xD6\x03E\xA9\x888o\xC8K\xA6\xBC\x95H@\x08\xF66/\x93\x16\x0E\xF3\xE5c[\x85\x83\x10a\x0C\x19WPPa\x0B9\x93P\x82\x01\x018a\x0B,V[\x80T\x83\x88\x01\x85\x01R\x86\x94P\x88\x93\x90\x92\x01\x91\x81\x01a\x0C\x02V[`\xFF\x19\x16\x88Ra\x0B9\x95\x15\x15`\x05\x1B\x85\x01\x01\x92P8\x91Pa\x0B,\x90PV\xFE\xA2dipfsX\"\x12 \xE3W;\xFC\xD8\xCC\xEE\x0E\x810\x99\x8C`\x1FF*\xCAO\xF0_\x18L\xAD=\x04U+\x03\xCE\xD1\xB5\xC9dsolcC\0\x08\x13\x003";
     /// The deployed bytecode of the contract.
-    pub static ARBITERTOKEN_DEPLOYED_BYTECODE: ::ethers::core::types::Bytes =
-        ::ethers::core::types::Bytes::from_static(__DEPLOYED_BYTECODE);
+    pub static ARBITERTOKEN_DEPLOYED_BYTECODE: ::ethers::core::types::Bytes = ::ethers::core::types::Bytes::from_static(
+        __DEPLOYED_BYTECODE,
+    );
     pub struct ArbiterToken<M>(::ethers::contract::Contract<M>);
     impl<M> ::core::clone::Clone for ArbiterToken<M> {
         fn clone(&self) -> Self {
@@ -495,38 +590,34 @@ pub mod arbiter_token {
         }
     }
     impl<M: ::ethers::providers::Middleware> ArbiterToken<M> {
-        /// Creates a new contract instance with the specified `ethers` client
-        /// at `address`. The contract derefs to a `ethers::Contract`
-        /// object.
+        /// Creates a new contract instance with the specified `ethers` client at
+        /// `address`. The contract derefs to a `ethers::Contract` object.
         pub fn new<T: Into<::ethers::core::types::Address>>(
             address: T,
             client: ::std::sync::Arc<M>,
         ) -> Self {
-            Self(::ethers::contract::Contract::new(
-                address.into(),
-                ARBITERTOKEN_ABI.clone(),
-                client,
-            ))
+            Self(
+                ::ethers::contract::Contract::new(
+                    address.into(),
+                    ARBITERTOKEN_ABI.clone(),
+                    client,
+                ),
+            )
         }
-        /// Constructs the general purpose `Deployer` instance based on the
-        /// provided constructor arguments and sends it. Returns a new
-        /// instance of a deployer that returns an instance of this contract
-        /// after sending the transaction
+        /// Constructs the general purpose `Deployer` instance based on the provided constructor arguments and sends it.
+        /// Returns a new instance of a deployer that returns an instance of this contract after sending the transaction
         ///
         /// Notes:
-        /// - If there are no constructor arguments, you should pass `()` as the
-        ///   argument.
+        /// - If there are no constructor arguments, you should pass `()` as the argument.
         /// - The default poll duration is 7 seconds.
         /// - The default number of confirmations is 1 block.
         ///
         ///
         /// # Example
         ///
-        /// Generate contract bindings with `abigen!` and deploy a new contract
-        /// instance.
+        /// Generate contract bindings with `abigen!` and deploy a new contract instance.
         ///
-        /// *Note*: this requires a `bytecode` and `abi` object in the
-        /// `greeter.json` artifact.
+        /// *Note*: this requires a `bytecode` and `abi` object in the `greeter.json` artifact.
         ///
         /// ```ignore
         /// # async fn deploy<M: ethers::providers::Middleware>(client: ::std::sync::Arc<M>) {
@@ -552,21 +643,26 @@ pub mod arbiter_token {
             let deployer = ::ethers::contract::ContractDeployer::new(deployer);
             Ok(deployer)
         }
-        /// Calls the contract's `DOMAIN_SEPARATOR` (0x3644e515) function
-        pub fn domain_separator(&self) -> ::ethers::contract::builders::ContractCall<M, [u8; 32]> {
+        ///Calls the contract's `DOMAIN_SEPARATOR` (0x3644e515) function
+        pub fn domain_separator(
+            &self,
+        ) -> ::ethers::contract::builders::ContractCall<M, [u8; 32]> {
             self.0
                 .method_hash([54, 68, 229, 21], ())
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `admin` (0xf851a440) function
+        ///Calls the contract's `admin` (0xf851a440) function
         pub fn admin(
             &self,
-        ) -> ::ethers::contract::builders::ContractCall<M, ::ethers::core::types::Address> {
+        ) -> ::ethers::contract::builders::ContractCall<
+            M,
+            ::ethers::core::types::Address,
+        > {
             self.0
                 .method_hash([248, 81, 164, 64], ())
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `allowance` (0xdd62ed3e) function
+        ///Calls the contract's `allowance` (0xdd62ed3e) function
         pub fn allowance(
             &self,
             p0: ::ethers::core::types::Address,
@@ -576,7 +672,7 @@ pub mod arbiter_token {
                 .method_hash([221, 98, 237, 62], (p0, p1))
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `approve` (0x095ea7b3) function
+        ///Calls the contract's `approve` (0x095ea7b3) function
         pub fn approve(
             &self,
             spender: ::ethers::core::types::Address,
@@ -586,7 +682,7 @@ pub mod arbiter_token {
                 .method_hash([9, 94, 167, 179], (spender, amount))
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `balanceOf` (0x70a08231) function
+        ///Calls the contract's `balanceOf` (0x70a08231) function
         pub fn balance_of(
             &self,
             p0: ::ethers::core::types::Address,
@@ -595,13 +691,13 @@ pub mod arbiter_token {
                 .method_hash([112, 160, 130, 49], p0)
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `decimals` (0x313ce567) function
+        ///Calls the contract's `decimals` (0x313ce567) function
         pub fn decimals(&self) -> ::ethers::contract::builders::ContractCall<M, u8> {
             self.0
                 .method_hash([49, 60, 229, 103], ())
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `mint` (0x40c10f19) function
+        ///Calls the contract's `mint` (0x40c10f19) function
         pub fn mint(
             &self,
             receiver: ::ethers::core::types::Address,
@@ -611,13 +707,15 @@ pub mod arbiter_token {
                 .method_hash([64, 193, 15, 25], (receiver, amount))
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `name` (0x06fdde03) function
-        pub fn name(&self) -> ::ethers::contract::builders::ContractCall<M, ::std::string::String> {
+        ///Calls the contract's `name` (0x06fdde03) function
+        pub fn name(
+            &self,
+        ) -> ::ethers::contract::builders::ContractCall<M, ::std::string::String> {
             self.0
                 .method_hash([6, 253, 222, 3], ())
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `nonces` (0x7ecebe00) function
+        ///Calls the contract's `nonces` (0x7ecebe00) function
         pub fn nonces(
             &self,
             p0: ::ethers::core::types::Address,
@@ -626,7 +724,7 @@ pub mod arbiter_token {
                 .method_hash([126, 206, 190, 0], p0)
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `permit` (0xd505accf) function
+        ///Calls the contract's `permit` (0xd505accf) function
         pub fn permit(
             &self,
             owner: ::ethers::core::types::Address,
@@ -644,7 +742,7 @@ pub mod arbiter_token {
                 )
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `symbol` (0x95d89b41) function
+        ///Calls the contract's `symbol` (0x95d89b41) function
         pub fn symbol(
             &self,
         ) -> ::ethers::contract::builders::ContractCall<M, ::std::string::String> {
@@ -652,7 +750,7 @@ pub mod arbiter_token {
                 .method_hash([149, 216, 155, 65], ())
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `totalSupply` (0x18160ddd) function
+        ///Calls the contract's `totalSupply` (0x18160ddd) function
         pub fn total_supply(
             &self,
         ) -> ::ethers::contract::builders::ContractCall<M, ::ethers::core::types::U256> {
@@ -660,7 +758,7 @@ pub mod arbiter_token {
                 .method_hash([24, 22, 13, 221], ())
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `transfer` (0xa9059cbb) function
+        ///Calls the contract's `transfer` (0xa9059cbb) function
         pub fn transfer(
             &self,
             to: ::ethers::core::types::Address,
@@ -670,7 +768,7 @@ pub mod arbiter_token {
                 .method_hash([169, 5, 156, 187], (to, amount))
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `transferFrom` (0x23b872dd) function
+        ///Calls the contract's `transferFrom` (0x23b872dd) function
         pub fn transfer_from(
             &self,
             from: ::ethers::core::types::Address,
@@ -681,28 +779,39 @@ pub mod arbiter_token {
                 .method_hash([35, 184, 114, 221], (from, to, amount))
                 .expect("method not found (this should never happen)")
         }
-        /// Gets the contract's `Approval` event
+        ///Gets the contract's `Approval` event
         pub fn approval_filter(
             &self,
-        ) -> ::ethers::contract::builders::Event<::std::sync::Arc<M>, M, ApprovalFilter> {
+        ) -> ::ethers::contract::builders::Event<
+            ::std::sync::Arc<M>,
+            M,
+            ApprovalFilter,
+        > {
             self.0.event()
         }
-        /// Gets the contract's `Transfer` event
+        ///Gets the contract's `Transfer` event
         pub fn transfer_filter(
             &self,
-        ) -> ::ethers::contract::builders::Event<::std::sync::Arc<M>, M, TransferFilter> {
+        ) -> ::ethers::contract::builders::Event<
+            ::std::sync::Arc<M>,
+            M,
+            TransferFilter,
+        > {
             self.0.event()
         }
         /// Returns an `Event` builder for all the events of this contract.
         pub fn events(
             &self,
-        ) -> ::ethers::contract::builders::Event<::std::sync::Arc<M>, M, ArbiterTokenEvents>
-        {
-            self.0
-                .event_with_filter(::core::default::Default::default())
+        ) -> ::ethers::contract::builders::Event<
+            ::std::sync::Arc<M>,
+            M,
+            ArbiterTokenEvents,
+        > {
+            self.0.event_with_filter(::core::default::Default::default())
         }
     }
-    impl<M: ::ethers::providers::Middleware> From<::ethers::contract::Contract<M>> for ArbiterToken<M> {
+    impl<M: ::ethers::providers::Middleware> From<::ethers::contract::Contract<M>>
+    for ArbiterToken<M> {
         fn from(contract: ::ethers::contract::Contract<M>) -> Self {
             Self::new(contract.address(), contract.client())
         }
@@ -711,11 +820,13 @@ pub mod arbiter_token {
         Clone,
         ::ethers::contract::EthEvent,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethevent(name = "Approval", abi = "Approval(address,address,uint256)")]
     pub struct ApprovalFilter {
@@ -729,11 +840,13 @@ pub mod arbiter_token {
         Clone,
         ::ethers::contract::EthEvent,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethevent(name = "Transfer", abi = "Transfer(address,address,uint256)")]
     pub struct TransferFilter {
@@ -743,8 +856,17 @@ pub mod arbiter_token {
         pub to: ::ethers::core::types::Address,
         pub amount: ::ethers::core::types::U256,
     }
-    /// Container type for all of the contract's events
-    #[derive(Clone, ::ethers::contract::EthAbiType, Debug, PartialEq, Eq, Hash)]
+    ///Container type for all of the contract's events
+    #[derive(
+        Clone,
+        ::ethers::contract::EthAbiType,
+        serde::Serialize,
+        serde::Deserialize,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
     pub enum ArbiterTokenEvents {
         ApprovalFilter(ApprovalFilter),
         TransferFilter(TransferFilter),
@@ -780,153 +902,162 @@ pub mod arbiter_token {
             Self::TransferFilter(value)
         }
     }
-    /// Container type for all input parameters for the `DOMAIN_SEPARATOR`
-    /// function with signature `DOMAIN_SEPARATOR()` and selector `0x3644e515`
+    ///Container type for all input parameters for the `DOMAIN_SEPARATOR` function with signature `DOMAIN_SEPARATOR()` and selector `0x3644e515`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "DOMAIN_SEPARATOR", abi = "DOMAIN_SEPARATOR()")]
     pub struct DomainSeparatorCall;
-    /// Container type for all input parameters for the `admin` function with
-    /// signature `admin()` and selector `0xf851a440`
+    ///Container type for all input parameters for the `admin` function with signature `admin()` and selector `0xf851a440`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "admin", abi = "admin()")]
     pub struct AdminCall;
-    /// Container type for all input parameters for the `allowance` function
-    /// with signature `allowance(address,address)` and selector `0xdd62ed3e`
+    ///Container type for all input parameters for the `allowance` function with signature `allowance(address,address)` and selector `0xdd62ed3e`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "allowance", abi = "allowance(address,address)")]
     pub struct AllowanceCall(
         pub ::ethers::core::types::Address,
         pub ::ethers::core::types::Address,
     );
-    /// Container type for all input parameters for the `approve` function with
-    /// signature `approve(address,uint256)` and selector `0x095ea7b3`
+    ///Container type for all input parameters for the `approve` function with signature `approve(address,uint256)` and selector `0x095ea7b3`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "approve", abi = "approve(address,uint256)")]
     pub struct ApproveCall {
         pub spender: ::ethers::core::types::Address,
         pub amount: ::ethers::core::types::U256,
     }
-    /// Container type for all input parameters for the `balanceOf` function
-    /// with signature `balanceOf(address)` and selector `0x70a08231`
+    ///Container type for all input parameters for the `balanceOf` function with signature `balanceOf(address)` and selector `0x70a08231`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "balanceOf", abi = "balanceOf(address)")]
     pub struct BalanceOfCall(pub ::ethers::core::types::Address);
-    /// Container type for all input parameters for the `decimals` function with
-    /// signature `decimals()` and selector `0x313ce567`
+    ///Container type for all input parameters for the `decimals` function with signature `decimals()` and selector `0x313ce567`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "decimals", abi = "decimals()")]
     pub struct DecimalsCall;
-    /// Container type for all input parameters for the `mint` function with
-    /// signature `mint(address,uint256)` and selector `0x40c10f19`
+    ///Container type for all input parameters for the `mint` function with signature `mint(address,uint256)` and selector `0x40c10f19`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "mint", abi = "mint(address,uint256)")]
     pub struct MintCall {
         pub receiver: ::ethers::core::types::Address,
         pub amount: ::ethers::core::types::U256,
     }
-    /// Container type for all input parameters for the `name` function with
-    /// signature `name()` and selector `0x06fdde03`
+    ///Container type for all input parameters for the `name` function with signature `name()` and selector `0x06fdde03`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "name", abi = "name()")]
     pub struct NameCall;
-    /// Container type for all input parameters for the `nonces` function with
-    /// signature `nonces(address)` and selector `0x7ecebe00`
+    ///Container type for all input parameters for the `nonces` function with signature `nonces(address)` and selector `0x7ecebe00`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "nonces", abi = "nonces(address)")]
     pub struct NoncesCall(pub ::ethers::core::types::Address);
-    /// Container type for all input parameters for the `permit` function with
-    /// signature `permit(address,address,uint256,uint256,uint8,bytes32,
-    /// bytes32)` and selector `0xd505accf`
+    ///Container type for all input parameters for the `permit` function with signature `permit(address,address,uint256,uint256,uint8,bytes32,bytes32)` and selector `0xd505accf`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(
         name = "permit",
@@ -941,63 +1072,66 @@ pub mod arbiter_token {
         pub r: [u8; 32],
         pub s: [u8; 32],
     }
-    /// Container type for all input parameters for the `symbol` function with
-    /// signature `symbol()` and selector `0x95d89b41`
+    ///Container type for all input parameters for the `symbol` function with signature `symbol()` and selector `0x95d89b41`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "symbol", abi = "symbol()")]
     pub struct SymbolCall;
-    /// Container type for all input parameters for the `totalSupply` function
-    /// with signature `totalSupply()` and selector `0x18160ddd`
+    ///Container type for all input parameters for the `totalSupply` function with signature `totalSupply()` and selector `0x18160ddd`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "totalSupply", abi = "totalSupply()")]
     pub struct TotalSupplyCall;
-    /// Container type for all input parameters for the `transfer` function with
-    /// signature `transfer(address,uint256)` and selector `0xa9059cbb`
+    ///Container type for all input parameters for the `transfer` function with signature `transfer(address,uint256)` and selector `0xa9059cbb`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "transfer", abi = "transfer(address,uint256)")]
     pub struct TransferCall {
         pub to: ::ethers::core::types::Address,
         pub amount: ::ethers::core::types::U256,
     }
-    /// Container type for all input parameters for the `transferFrom` function
-    /// with signature `transferFrom(address,address,uint256)` and selector
-    /// `0x23b872dd`
+    ///Container type for all input parameters for the `transferFrom` function with signature `transferFrom(address,address,uint256)` and selector `0x23b872dd`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "transferFrom", abi = "transferFrom(address,address,uint256)")]
     pub struct TransferFromCall {
@@ -1005,8 +1139,17 @@ pub mod arbiter_token {
         pub to: ::ethers::core::types::Address,
         pub amount: ::ethers::core::types::U256,
     }
-    /// Container type for all of the contract's call
-    #[derive(Clone, ::ethers::contract::EthAbiType, Debug, PartialEq, Eq, Hash)]
+    ///Container type for all of the contract's call
+    #[derive(
+        Clone,
+        ::ethers::contract::EthAbiType,
+        serde::Serialize,
+        serde::Deserialize,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
     pub enum ArbiterTokenCalls {
         DomainSeparator(DomainSeparatorCall),
         Admin(AdminCall),
@@ -1028,49 +1171,74 @@ pub mod arbiter_token {
             data: impl AsRef<[u8]>,
         ) -> ::core::result::Result<Self, ::ethers::core::abi::AbiError> {
             let data = data.as_ref();
-            if let Ok(decoded) =
-                <DomainSeparatorCall as ::ethers::core::abi::AbiDecode>::decode(data)
-            {
+            if let Ok(decoded) = <DomainSeparatorCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::DomainSeparator(decoded));
             }
-            if let Ok(decoded) = <AdminCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <AdminCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::Admin(decoded));
             }
-            if let Ok(decoded) = <AllowanceCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <AllowanceCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::Allowance(decoded));
             }
-            if let Ok(decoded) = <ApproveCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <ApproveCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::Approve(decoded));
             }
-            if let Ok(decoded) = <BalanceOfCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <BalanceOfCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::BalanceOf(decoded));
             }
-            if let Ok(decoded) = <DecimalsCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <DecimalsCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::Decimals(decoded));
             }
-            if let Ok(decoded) = <MintCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <MintCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::Mint(decoded));
             }
-            if let Ok(decoded) = <NameCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <NameCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::Name(decoded));
             }
-            if let Ok(decoded) = <NoncesCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <NoncesCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::Nonces(decoded));
             }
-            if let Ok(decoded) = <PermitCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <PermitCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::Permit(decoded));
             }
-            if let Ok(decoded) = <SymbolCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <SymbolCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::Symbol(decoded));
             }
-            if let Ok(decoded) = <TotalSupplyCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <TotalSupplyCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::TotalSupply(decoded));
             }
-            if let Ok(decoded) = <TransferCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <TransferCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::Transfer(decoded));
             }
-            if let Ok(decoded) = <TransferFromCall as ::ethers::core::abi::AbiDecode>::decode(data)
-            {
+            if let Ok(decoded) = <TransferFromCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::TransferFrom(decoded));
             }
             Err(::ethers::core::abi::Error::InvalidData.into())
@@ -1079,20 +1247,34 @@ pub mod arbiter_token {
     impl ::ethers::core::abi::AbiEncode for ArbiterTokenCalls {
         fn encode(self) -> Vec<u8> {
             match self {
-                Self::DomainSeparator(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::DomainSeparator(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
                 Self::Admin(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::Allowance(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::Allowance(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
                 Self::Approve(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::BalanceOf(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::Decimals(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::BalanceOf(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
+                Self::Decimals(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
                 Self::Mint(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Name(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Nonces(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Permit(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Symbol(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::TotalSupply(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::Transfer(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::TransferFrom(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::TotalSupply(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
+                Self::Transfer(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
+                Self::TransferFrom(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
             }
         }
     }
@@ -1186,174 +1368,186 @@ pub mod arbiter_token {
             Self::TransferFrom(value)
         }
     }
-    /// Container type for all return fields from the `DOMAIN_SEPARATOR`
-    /// function with signature `DOMAIN_SEPARATOR()` and selector `0x3644e515`
+    ///Container type for all return fields from the `DOMAIN_SEPARATOR` function with signature `DOMAIN_SEPARATOR()` and selector `0x3644e515`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct DomainSeparatorReturn(pub [u8; 32]);
-    /// Container type for all return fields from the `admin` function with
-    /// signature `admin()` and selector `0xf851a440`
+    ///Container type for all return fields from the `admin` function with signature `admin()` and selector `0xf851a440`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct AdminReturn(pub ::ethers::core::types::Address);
-    /// Container type for all return fields from the `allowance` function with
-    /// signature `allowance(address,address)` and selector `0xdd62ed3e`
+    ///Container type for all return fields from the `allowance` function with signature `allowance(address,address)` and selector `0xdd62ed3e`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct AllowanceReturn(pub ::ethers::core::types::U256);
-    /// Container type for all return fields from the `approve` function with
-    /// signature `approve(address,uint256)` and selector `0x095ea7b3`
+    ///Container type for all return fields from the `approve` function with signature `approve(address,uint256)` and selector `0x095ea7b3`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct ApproveReturn(pub bool);
-    /// Container type for all return fields from the `balanceOf` function with
-    /// signature `balanceOf(address)` and selector `0x70a08231`
+    ///Container type for all return fields from the `balanceOf` function with signature `balanceOf(address)` and selector `0x70a08231`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct BalanceOfReturn(pub ::ethers::core::types::U256);
-    /// Container type for all return fields from the `decimals` function with
-    /// signature `decimals()` and selector `0x313ce567`
+    ///Container type for all return fields from the `decimals` function with signature `decimals()` and selector `0x313ce567`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct DecimalsReturn(pub u8);
-    /// Container type for all return fields from the `mint` function with
-    /// signature `mint(address,uint256)` and selector `0x40c10f19`
+    ///Container type for all return fields from the `mint` function with signature `mint(address,uint256)` and selector `0x40c10f19`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct MintReturn(pub bool);
-    /// Container type for all return fields from the `name` function with
-    /// signature `name()` and selector `0x06fdde03`
+    ///Container type for all return fields from the `name` function with signature `name()` and selector `0x06fdde03`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct NameReturn(pub ::std::string::String);
-    /// Container type for all return fields from the `nonces` function with
-    /// signature `nonces(address)` and selector `0x7ecebe00`
+    ///Container type for all return fields from the `nonces` function with signature `nonces(address)` and selector `0x7ecebe00`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct NoncesReturn(pub ::ethers::core::types::U256);
-    /// Container type for all return fields from the `symbol` function with
-    /// signature `symbol()` and selector `0x95d89b41`
+    ///Container type for all return fields from the `symbol` function with signature `symbol()` and selector `0x95d89b41`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct SymbolReturn(pub ::std::string::String);
-    /// Container type for all return fields from the `totalSupply` function
-    /// with signature `totalSupply()` and selector `0x18160ddd`
+    ///Container type for all return fields from the `totalSupply` function with signature `totalSupply()` and selector `0x18160ddd`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct TotalSupplyReturn(pub ::ethers::core::types::U256);
-    /// Container type for all return fields from the `transfer` function with
-    /// signature `transfer(address,uint256)` and selector `0xa9059cbb`
+    ///Container type for all return fields from the `transfer` function with signature `transfer(address,uint256)` and selector `0xa9059cbb`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct TransferReturn(pub bool);
-    /// Container type for all return fields from the `transferFrom` function
-    /// with signature `transferFrom(address,address,uint256)` and selector
-    /// `0x23b872dd`
+    ///Container type for all return fields from the `transferFrom` function with signature `transferFrom(address,address,uint256)` and selector `0x23b872dd`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct TransferFromReturn(pub bool);
 }

--- a/arbiter-core/src/bindings/arbiter_token.rs
+++ b/arbiter-core/src/bindings/arbiter_token.rs
@@ -7,7 +7,7 @@ pub use arbiter_token::*;
     clippy::upper_case_acronyms,
     clippy::type_complexity,
     dead_code,
-    non_camel_case_types,
+    non_camel_case_types
 )]
 pub mod arbiter_token {
     #[allow(deprecated)]
@@ -41,507 +41,415 @@ pub mod arbiter_token {
             functions: ::core::convert::From::from([
                 (
                     ::std::borrow::ToOwned::to_owned("DOMAIN_SEPARATOR"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("DOMAIN_SEPARATOR"),
-                            inputs: ::std::vec![],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bytes32"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("DOMAIN_SEPARATOR"),
+                        inputs: ::std::vec![],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(32usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("bytes32"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("admin"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("admin"),
-                            inputs: ::std::vec![],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("admin"),
+                        inputs: ::std::vec![],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("address"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("allowance"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("allowance"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("allowance"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::string::String::new(),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("address"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::string::String::new(),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("address"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint256"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("approve"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("approve"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("spender"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("amount"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Bool,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bool"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("approve"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("spender"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("address"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("amount"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Bool,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("bool"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("balanceOf"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("balanceOf"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("balanceOf"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("address"),
+                            ),
+                        },],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint256"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("decimals"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("decimals"),
-                            inputs: ::std::vec![],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(8usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint8"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("decimals"),
+                        inputs: ::std::vec![],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(8usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint8"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("mint"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("mint"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("receiver"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("amount"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Bool,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bool"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("mint"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("receiver"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("address"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("amount"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Bool,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("bool"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("name"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("name"),
-                            inputs: ::std::vec![],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::String,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("string"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("name"),
+                        inputs: ::std::vec![],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::String,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("string"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("nonces"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("nonces"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("nonces"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("address"),
+                            ),
+                        },],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint256"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("permit"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("permit"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("owner"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("spender"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("value"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("deadline"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("v"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(8usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint8"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("r"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bytes32"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("s"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bytes32"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("permit"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("owner"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("address"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("spender"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("address"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("value"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("deadline"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("v"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(8usize),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint8"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("r"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(32usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("bytes32"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("s"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(32usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("bytes32"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("symbol"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("symbol"),
-                            inputs: ::std::vec![],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::String,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("string"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("symbol"),
+                        inputs: ::std::vec![],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::String,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("string"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("totalSupply"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("totalSupply"),
-                            inputs: ::std::vec![],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("totalSupply"),
+                        inputs: ::std::vec![],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint256"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("transfer"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("transfer"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("to"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("amount"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Bool,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bool"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("transfer"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("to"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("address"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("amount"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Bool,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("bool"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("transferFrom"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("transferFrom"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("from"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("to"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("amount"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Bool,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bool"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("transferFrom"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("from"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("address"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("to"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("address"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("amount"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Bool,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("bool"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                    },],
                 ),
             ]),
             events: ::core::convert::From::from([
                 (
                     ::std::borrow::ToOwned::to_owned("Approval"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Event {
-                            name: ::std::borrow::ToOwned::to_owned("Approval"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("owner"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    indexed: true,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("spender"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    indexed: true,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("amount"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    indexed: false,
-                                },
-                            ],
-                            anonymous: false,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Event {
+                        name: ::std::borrow::ToOwned::to_owned("Approval"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("owner"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                indexed: true,
+                            },
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("spender"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                indexed: true,
+                            },
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("amount"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                indexed: false,
+                            },
+                        ],
+                        anonymous: false,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("Transfer"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Event {
-                            name: ::std::borrow::ToOwned::to_owned("Transfer"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("from"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    indexed: true,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("to"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    indexed: true,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("amount"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    indexed: false,
-                                },
-                            ],
-                            anonymous: false,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Event {
+                        name: ::std::borrow::ToOwned::to_owned("Transfer"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("from"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                indexed: true,
+                            },
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("to"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                indexed: true,
+                            },
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("amount"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                indexed: false,
+                            },
+                        ],
+                        anonymous: false,
+                    },],
                 ),
             ]),
             errors: ::std::collections::BTreeMap::new(),
@@ -549,22 +457,19 @@ pub mod arbiter_token {
             fallback: false,
         }
     }
-    ///The parsed JSON ABI of the contract.
-    pub static ARBITERTOKEN_ABI: ::ethers::contract::Lazy<::ethers::core::abi::Abi> = ::ethers::contract::Lazy::new(
-        __abi,
-    );
+    /// The parsed JSON ABI of the contract.
+    pub static ARBITERTOKEN_ABI: ::ethers::contract::Lazy<::ethers::core::abi::Abi> =
+        ::ethers::contract::Lazy::new(__abi);
     #[rustfmt::skip]
     const __BYTECODE: &[u8] = b"`\xE0`@\x90\x80\x82R4b\0\x04\xABWPb\0\x13T\x808\x03\x80\x83Q\x92b\0\0%\x82\x85b\0\x04\xF8V[\x839\x81\x01``\x82\x82\x03\x12b\0\x04\\W\x81Q`\x01`\x01`@\x1B\x03\x93\x90\x84\x81\x11b\0\x04VW\x82b\0\0V\x91\x85\x01b\0\x05lV[\x92` \x92\x83\x82\x01Q\x86\x81\x11b\0\x04VW\x83\x91b\0\0u\x91\x84\x01b\0\x05lV[\x91\x01Q`\xFF\x81\x16\x81\x03b\0\x04QW\x84Q\x94\x86\x86\x11b\0\x04;W`\0\x95\x80b\0\0\x9E\x88Tb\0\x06\x91V[\x92`\x1F\x93\x84\x81\x11b\0\x03\xEAW[P\x87\x90\x84\x83\x11`\x01\x14b\0\x03\x82W\x89\x92b\0\x03vW[PP\x81`\x01\x1B\x91`\0\x19\x90`\x03\x1B\x1C\x19\x16\x17\x86U[\x82Q\x90\x87\x82\x11b\0\x03bW\x81\x90`\x01\x94b\0\0\xF2\x86Tb\0\x06\x91V[\x82\x81\x11b\0\x03\rW[P\x87\x91\x83\x11`\x01\x14b\0\x02\xA9W\x88\x92b\0\x02\x9DW[PP`\0\x19`\x03\x83\x90\x1B\x1C\x19\x16\x90\x83\x1B\x17\x82U[`\x80RF`\xA0R\x81Q\x84T\x91\x81\x86b\0\x01=\x85b\0\x06\x91V[\x92\x83\x83R\x87\x83\x01\x95\x88\x82\x82\x16\x91\x82`\0\x14b\0\x02}WPP`\x01\x14b\0\x02=W[Pb\0\x01m\x92P\x03\x82b\0\x04\xF8V[Q\x90 \x92\x81Q\x92\x83\x01\x93\x7F\x8Bs\xC3\xC6\x9B\xB8\xFE=Q.\xCCL\xF7Y\xCCy#\x9F{\x17\x9B\x0F\xFA\xCA\xA9\xA7]R+9@\x0F\x85R\x82\x84\x01R\x7F\xC8\x9E\xFD\xAAT\xC0\xF2\x0Cz\xDFa(\x82\xDF\tP\xF5\xA9Qc~\x03\x07\xCD\xCBLg/)\x8B\x8B\xC6``\x84\x01RF`\x80\x84\x01R0`\xA0\x84\x01R`\xA0\x83R`\xC0\x83\x01\x94\x83\x86\x10\x90\x86\x11\x17b\0\x02)WP\x83\x90RQ\x90 `\xC0R`\x06\x80T`\x01`\x01`\xA0\x1B\x03\x19\x163\x17\x90Ua\x0C\x85\x90\x81b\0\x06\xCF\x829`\x80Q\x81a\x06\xCC\x01R`\xA0Q\x81a\n\xAE\x01R`\xC0Q\x81a\n\xD5\x01R\xF3[cNH{q`\xE0\x1B\x81R`A`\x04R`$\x90\xFD[\x87\x91P\x88\x80R\x81\x89 \x90\x89\x91[\x85\x83\x10b\0\x02dWPPb\0\x01m\x93P\x82\x01\x018b\0\x01^V[\x80T\x83\x88\x01\x85\x01R\x86\x94P\x89\x93\x90\x92\x01\x91\x81\x01b\0\x02JV[`\xFF\x19\x16\x88Rb\0\x01m\x95\x15\x15`\x05\x1B\x85\x01\x01\x92P8\x91Pb\0\x01^\x90PV[\x01Q\x90P8\x80b\0\x01\x10V[\x85\x89R\x87\x89 \x86\x94P\x91\x90`\x1F\x19\x84\x16\x8A[\x8A\x82\x82\x10b\0\x02\xF6WPP\x84\x11b\0\x02\xDCW[PPP\x81\x1B\x01\x82Ub\0\x01$V[\x01Q`\0\x19`\xF8\x84`\x03\x1B\x16\x1C\x19\x16\x90U8\x80\x80b\0\x02\xCEV[\x83\x85\x01Q\x86U\x89\x97\x90\x95\x01\x94\x93\x84\x01\x93\x01b\0\x02\xBBV[\x90\x91\x92P\x85\x89R\x87\x89 \x83\x80\x86\x01`\x05\x1C\x82\x01\x92\x8A\x87\x10b\0\x03XW[\x91\x86\x95\x89\x92\x95\x94\x93\x01`\x05\x1C\x01\x91[\x82\x81\x10b\0\x03IWPPb\0\0\xFBV[\x8B\x81U\x86\x95P\x88\x91\x01b\0\x039V[\x92P\x81\x92b\0\x03*V[cNH{q`\xE0\x1B\x87R`A`\x04R`$\x87\xFD[\x01Q\x90P8\x80b\0\0\xC1V[\x89\x80R\x88\x8A \x92P`\x1F\x19\x84\x16\x8A[\x8A\x82\x82\x10b\0\x03\xD3WPP\x90\x84`\x01\x95\x94\x93\x92\x10b\0\x03\xB9W[PPP\x81\x1B\x01\x86Ub\0\0\xD6V[\x01Q`\0\x19`\xF8\x84`\x03\x1B\x16\x1C\x19\x16\x90U8\x80\x80b\0\x03\xABV[`\x01\x85\x96\x82\x93\x96\x86\x01Q\x81U\x01\x95\x01\x93\x01b\0\x03\x91V[\x90\x91P\x88\x80R\x87\x89 \x84\x80\x85\x01`\x05\x1C\x82\x01\x92\x8A\x86\x10b\0\x041W[\x90\x85\x94\x93\x92\x91\x01`\x05\x1C\x01\x90[\x81\x81\x10b\0\x04\"WPb\0\0\xABV[\x8A\x81U\x84\x93P`\x01\x01b\0\x04\x13V[\x92P\x81\x92b\0\x04\x06V[cNH{q`\xE0\x1B`\0R`A`\x04R`$`\0\xFD[`\0\x80\xFD[b\0\x05\x1CV[\x82QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x90\xFD[bF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD[`\x1F\x90\x91\x01`\x1F\x19\x16\x81\x01\x90`\x01`\x01`@\x1B\x03\x82\x11\x90\x82\x10\x17b\0\x04;W`@RV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: invalid tuple offs`D\x82\x01Ra\x19]`\xF2\x1B`d\x82\x01R`\x84\x90\xFD[\x91\x90\x80`\x1F\x84\x01\x12\x15b\0\x068W\x82Q\x90`\x01`\x01`@\x1B\x03\x82\x11b\0\x04;W`@Q\x91` \x91b\0\x05\xA8`\x1F\x83\x01`\x1F\x19\x16\x84\x01\x85b\0\x04\xF8V[\x81\x84R\x82\x82\x87\x01\x01\x11b\0\x05\xE3W`\0[\x81\x81\x10b\0\x05\xCFWP\x82`\0\x93\x94\x95P\x01\x01R\x90V[\x85\x81\x01\x83\x01Q\x84\x82\x01\x84\x01R\x82\x01b\0\x05\xB9V[`@QbF\x1B\xCD`\xE5\x1B\x81R`\x04\x81\x01\x83\x90R`'`$\x82\x01R\x7FABI decoding: invalid byte array`D\x82\x01Rf\x04\r\x8C\xAD\xCC\xEE\x8D`\xCB\x1B`d\x82\x01R`\x84\x90\xFD[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`+`$\x82\x01R\x7FABI decoding: invalid calldata a`D\x82\x01Rj\x1C\x9C\x98^H\x1B\xD9\x99\x9C\xD9]`\xAA\x1B`d\x82\x01R`\x84\x90\xFD[\x90`\x01\x82\x81\x1C\x92\x16\x80\x15b\0\x06\xC3W[` \x83\x10\x14b\0\x06\xADWV[cNH{q`\xE0\x1B`\0R`\"`\x04R`$`\0\xFD[\x91`\x7F\x16\x91b\0\x06\xA1V\xFE`@`\x80\x81R`\x04\x806\x10\x15a\0pW[` `\x84\x92Q\x91bF\x1B\xCD`\xE5\x1B\x83R\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01Rtnor receive functions`X\x1B`d\x82\x01R\xFD[`\0\x805`\xE0\x1C\x80c\x06\xFD\xDE\x03\x14a\x08RW\x80c\t^\xA7\xB3\x14a\x07\xE2W\x80c\x18\x16\r\xDD\x14a\x07\xC4W\x80c#\xB8r\xDD\x14a\x06\xF0W\x80c1<\xE5g\x14a\x06\xB3W\x80c6D\xE5\x15\x14a\x06\x90W\x80c@\xC1\x0F\x19\x14a\x05\xA4W\x80cp\xA0\x821\x14a\x05lW\x80c~\xCE\xBE\0\x14a\x054W\x80c\x95\xD8\x9BA\x14a\x04UW\x80c\xA9\x05\x9C\xBB\x14a\x03\xD1W\x80c\xD5\x05\xAC\xCF\x14a\x01\x92W\x80c\xDDb\xED>\x14a\x01HWc\xF8Q\xA4@\x14a\x01\x16WPa\0\x10V[\x90P4a\x01CW6`\x03\x19\x01\x12a\x01>W`\x06T\x90Q`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x81R` \x90\xF3[a\tJV[a\x08\xFAV[P\x91\x904a\x01CW\x81`\x03\x196\x01\x12a\x01>W` \x92\x82\x91a\x01ha\nUV[a\x01pa\npV[`\x01`\x01`\xA0\x1B\x03\x91\x82\x16\x84R\x91\x86R\x83\x83 \x91\x16\x82R\x84R T\x90Q\x90\x81R\xF3[P\x824a\x01CW`\xE06`\x03\x19\x01\x12a\x01>Wa\x01\xADa\nUV[\x90a\x01\xB6a\npV[\x91`D5`d5\x92`\x845\x92`\xFF\x84\x16\x80\x94\x03a\x03\xCDWB\x85\x10a\x03\x8AWa\x01\xDCa\n\xA9V[\x95`\x01\x80`\xA0\x1B\x03\x80\x92\x16\x95\x86\x89R` \x95`\x05\x87R\x84\x8A \x98\x89T\x99`\x01\x8B\x01\x90U\x85Q\x92\x85\x89\x85\x01\x95\x7Fnq\xED\xAE\x12\xB1\xB9\x7FM\x1F`7\x0F\xEF\x10\x10_\xA2\xFA\xAE\x01&\x11J\x16\x9Cd\x84]a&\xC9\x87R\x8B\x89\x87\x01R\x16\x9A\x8B``\x86\x01R\x88`\x80\x86\x01R`\xA0\x85\x01R`\xC0\x84\x01R`\xC0\x83R`\xE0\x83\x01g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x94\x84\x82\x10\x86\x83\x11\x17a\x03vW\x81\x88R\x84Q\x90 a\x01\0\x85\x01\x92a\x19\x01`\xF0\x1B\x84Ra\x01\x02\x86\x01Ra\x01\"\x85\x01R`B\x81Ra\x01`\x84\x01\x94\x81\x86\x10\x90\x86\x11\x17a\x03cW\x84\x87RQ\x90 \x83Ra\x01\x80\x82\x01R`\xA45a\x01\xA0\x82\x01R`\xC45a\x01\xC0\x90\x91\x01R\x87\x80R\x84\x90\x88\x90`\x80\x90`\x01Z\xFA\x15a\x03YW\x86Q\x16\x96\x87\x15\x15\x80a\x03PW[\x15a\x03\x1EW\x86\x97\x7F\x8C[\xE1\xE5\xEB\xEC}[\xD1OqB}\x1E\x84\xF3\xDD\x03\x14\xC0\xF7\xB2)\x1E[ \n\xC8\xC7\xC3\xB9%\x95\x96\x97R\x83R\x80\x87 \x86\x88R\x83R\x81\x81\x88 UQ\x90\x81R\xA3\x80\xF3[\x83`d\x92Q\x91bF\x1B\xCD`\xE5\x1B\x83R\x82\x01R`\x0E`$\x82\x01Rm$\xA7+ \xA6$\xA2/\xA9\xA4\xA3\xA7\"\xA9`\x91\x1B`D\x82\x01R\xFD[P\x84\x88\x14a\x02\xDBV[\x81Q=\x88\x82>=\x90\xFD[cNH{q`\xE0\x1B\x8CR`A\x8DR`$\x8C\xFD[PcNH{q`\xE0\x1B\x8CR`A\x8DR`$\x8C\xFD[\x81QbF\x1B\xCD`\xE5\x1B\x81R` \x81\x8A\x01R`\x17`$\x82\x01R\x7FPERMIT_DEADLINE_EXPIRED\0\0\0\0\0\0\0\0\0`D\x82\x01R`d\x90\xFD[\x86\x80\xFD[P\x824a\x01CW\x80`\x03\x196\x01\x12a\x01>W` \x91a\x03\xEEa\nUV[\x82`$5\x913\x84R`\x03\x86R\x81\x84 a\x04\x08\x84\x82Ta\n\x86V[\x90U`\x01`\x01`\xA0\x1B\x03\x16\x80\x84R`\x03\x86R\x92 \x80T\x82\x01\x90U\x82Q\x90\x81R3\x90\x7F\xDD\xF2R\xAD\x1B\xE2\xC8\x9Bi\xC2\xB0h\xFC7\x8D\xAA\x95+\xA7\xF1c\xC4\xA1\x16(\xF5ZM\xF5#\xB3\xEF\x90\x85\x90\xA3Q`\x01\x81R\xF3[P\x824a\x01CW\x81`\x03\x196\x01\x12a\x01>W\x80Q\x90\x82`\x01\x80T\x91a\x04y\x83a\t\x9AV[\x80\x86R\x92\x82\x81\x16\x90\x81\x15a\x05\x0CWP`\x01\x14a\x04\xB0W[PPPa\x04\xA2\x82a\x04\xAC\x94\x03\x83a\t\xD4V[Q\x91\x82\x91\x82a\n\x0CV[\x03\x90\xF3[\x94P\x80\x85R\x7F\xB1\x0E-Rv\x12\x07;&\xEE\xCD\xFDq~j2\x0C\xF4KJ\xFA\xC2\xB0s-\x9F\xCB\xE2\xB7\xFA\x0C\xF6[\x82\x86\x10a\x04\xF4WPPPa\x04\xA2\x82` a\x04\xAC\x95\x82\x01\x01\x94a\x04\x90V[\x80T` \x87\x87\x01\x81\x01\x91\x90\x91R\x90\x95\x01\x94\x81\x01a\x04\xD7V[a\x04\xAC\x97P\x86\x93P` \x92Pa\x04\xA2\x94\x91P`\xFF\x19\x16\x82\x84\x01R\x15\x15`\x05\x1B\x82\x01\x01\x94a\x04\x90V[P\x824a\x01CW` 6`\x03\x19\x01\x12a\x01>W` \x91\x81\x90`\x01`\x01`\xA0\x1B\x03a\x05\\a\nUV[\x16\x81R`\x05\x84R T\x90Q\x90\x81R\xF3[P\x824a\x01CW` 6`\x03\x19\x01\x12a\x01>W` \x91\x81\x90`\x01`\x01`\xA0\x1B\x03a\x05\x94a\nUV[\x16\x81R`\x03\x84R T\x90Q\x90\x81R\xF3[P\x82\x904a\x01CW\x81`\x03\x196\x01\x12a\x01>Wa\x05\xBFa\nUV[`\x06T`$5\x92\x91`\x01`\x01`\xA0\x1B\x03\x91\x82\x163\x03a\x06CW`\x02T\x84\x81\x01\x80\x91\x11a\x060W` \x96P\x91\x86\x91\x7F\xDD\xF2R\xAD\x1B\xE2\xC8\x9Bi\xC2\xB0h\xFC7\x8D\xAA\x95+\xA7\xF1c\xC4\xA1\x16(\xF5ZM\xF5#\xB3\xEF\x93`\x02U\x16\x93\x84\x84R`\x03\x82R\x85\x84 \x81\x81T\x01\x90U\x85Q\x90\x81R\xA3Q`\x01\x81R\xF3[cNH{q`\xE0\x1B\x84R`\x11\x87R`$\x84\xFD[\x84QbF\x1B\xCD`\xE5\x1B\x81R` \x81\x88\x01R`!`$\x82\x01R\x7FOnly admin can call this functio`D\x82\x01R`7`\xF9\x1B`d\x82\x01R`\x84\x90\xFD[\x83\x824a\x01CW6`\x03\x19\x01\x12a\x01>W` \x90a\x06\xACa\n\xA9V[\x90Q\x90\x81R\xF3[\x83\x824a\x01CW6`\x03\x19\x01\x12a\x01>W` \x90Q`\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x81R\xF3[P\x82\x904a\x01CW``6`\x03\x19\x01\x12a\x01>Wa\x07\x0Ca\nUV[\x7F\xDD\xF2R\xAD\x1B\xE2\xC8\x9Bi\xC2\xB0h\xFC7\x8D\xAA\x95+\xA7\xF1c\xC4\xA1\x16(\xF5ZM\xF5#\xB3\xEFa\x075a\npV[`\x01`\x01`\xA0\x1B\x03\x92\x83\x16\x80\x85R` \x87\x81R\x86\x86 3\x87R\x81R\x86\x86 T\x90\x97\x91\x94\x88\x93`D5\x93\x89\x93\x85`\x01\x82\x01a\x07\xA1W[PPP\x86\x88R`\x03\x85R\x82\x88 a\x07\x82\x85\x82Ta\n\x86V[\x90U\x16\x95\x86\x81R`\x03\x84R \x81\x81T\x01\x90U\x85Q\x90\x81R\xA3Q`\x01\x81R\xF3[a\x07\xAA\x91a\n\x86V[\x90\x88\x8AR\x86R\x83\x89 3\x8AR\x86R\x83\x89 U\x8A\x80\x85a\x07jV[\x83\x824a\x01CW6`\x03\x19\x01\x12a\x01>W` \x90`\x02T\x90Q\x90\x81R\xF3[P\x91\x904a\x01CW\x81`\x03\x196\x01\x12a\x01>W` \x92a\x08\0a\nUV[\x91\x83`$5\x92\x83\x923\x82R\x87R\x81\x81 \x94`\x01\x80`\xA0\x1B\x03\x16\x94\x85\x82R\x87R U\x82Q\x90\x81R\x7F\x8C[\xE1\xE5\xEB\xEC}[\xD1OqB}\x1E\x84\xF3\xDD\x03\x14\xC0\xF7\xB2)\x1E[ \n\xC8\xC7\xC3\xB9%\x843\x92\xA3Q`\x01\x81R\xF3[P\x824a\x08\xFAW\x81`\x03\x196\x01\x12a\x01>W\x80Q\x90\x82\x80Ta\x08s\x81a\t\x9AV[\x80\x85R\x91`\x01\x91\x80\x83\x16\x90\x81\x15a\x05\x0CWP`\x01\x14a\x08\x9EWPPPa\x04\xA2\x82a\x04\xAC\x94\x03\x83a\t\xD4V[\x80\x80\x96PR\x7F)\r\xEC\xD9T\x8Bb\xA8\xD6\x03E\xA9\x888o\xC8K\xA6\xBC\x95H@\x08\xF66/\x93\x16\x0E\xF3\xE5c[\x82\x86\x10a\x08\xE2WPPPa\x04\xA2\x82` a\x04\xAC\x95\x82\x01\x01\x94a\x04\x90V[\x80T` \x87\x87\x01\x81\x01\x91\x90\x91R\x90\x95\x01\x94\x81\x01a\x08\xC5V[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x90\xFD[\x90`\x01\x82\x81\x1C\x92\x16\x80\x15a\t\xCAW[` \x83\x10\x14a\t\xB4WV[cNH{q`\xE0\x1B`\0R`\"`\x04R`$`\0\xFD[\x91`\x7F\x16\x91a\t\xA9V[\x90`\x1F\x80\x19\x91\x01\x16\x81\x01\x90\x81\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11\x17a\t\xF6W`@RV[cNH{q`\xE0\x1B`\0R`A`\x04R`$`\0\xFD[` \x80\x82R\x82Q\x81\x83\x01\x81\x90R\x90\x93\x92`\0[\x82\x81\x10a\nAWPP`@\x92\x93P`\0\x83\x82\x84\x01\x01R`\x1F\x80\x19\x91\x01\x16\x01\x01\x90V[\x81\x81\x01\x86\x01Q\x84\x82\x01`@\x01R\x85\x01a\n\x1FV[`\x045\x90`\x01`\x01`\xA0\x1B\x03\x82\x16\x82\x03a\nkWV[`\0\x80\xFD[`$5\x90`\x01`\x01`\xA0\x1B\x03\x82\x16\x82\x03a\nkWV[\x91\x90\x82\x03\x91\x82\x11a\n\x93WV[cNH{q`\xE0\x1B`\0R`\x11`\x04R`$`\0\xFD[`\0F\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x03a\n\xF7WP\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x90V[`@Q\x81T\x82\x91a\x0B\x07\x82a\t\x9AV[\x80\x82R\x81` \x94\x85\x82\x01\x94`\x01\x90\x87\x82\x82\x16\x91\x82`\0\x14a\x0C1WPP`\x01\x14a\x0B\xD8W[Pa\x0B9\x92P\x03\x82a\t\xD4V[Q\x90 \x91`@Q\x91\x82\x01\x92\x7F\x8Bs\xC3\xC6\x9B\xB8\xFE=Q.\xCCL\xF7Y\xCCy#\x9F{\x17\x9B\x0F\xFA\xCA\xA9\xA7]R+9@\x0F\x84R`@\x83\x01R\x7F\xC8\x9E\xFD\xAAT\xC0\xF2\x0Cz\xDFa(\x82\xDF\tP\xF5\xA9Qc~\x03\x07\xCD\xCBLg/)\x8B\x8B\xC6``\x83\x01RF`\x80\x83\x01R0`\xA0\x83\x01R`\xA0\x82R`\xC0\x82\x01\x90\x82\x82\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x83\x11\x17a\x0B\xC4WP`@RQ\x90 \x90V[cNH{q`\xE0\x1B\x81R`A`\x04R`$\x90\xFD[\x87\x80R\x86\x91P\x87\x90\x7F)\r\xEC\xD9T\x8Bb\xA8\xD6\x03E\xA9\x888o\xC8K\xA6\xBC\x95H@\x08\xF66/\x93\x16\x0E\xF3\xE5c[\x85\x83\x10a\x0C\x19WPPa\x0B9\x93P\x82\x01\x018a\x0B,V[\x80T\x83\x88\x01\x85\x01R\x86\x94P\x88\x93\x90\x92\x01\x91\x81\x01a\x0C\x02V[`\xFF\x19\x16\x88Ra\x0B9\x95\x15\x15`\x05\x1B\x85\x01\x01\x92P8\x91Pa\x0B,\x90PV\xFE\xA2dipfsX\"\x12 \xE3W;\xFC\xD8\xCC\xEE\x0E\x810\x99\x8C`\x1FF*\xCAO\xF0_\x18L\xAD=\x04U+\x03\xCE\xD1\xB5\xC9dsolcC\0\x08\x13\x003";
     /// The bytecode of the contract.
-    pub static ARBITERTOKEN_BYTECODE: ::ethers::core::types::Bytes = ::ethers::core::types::Bytes::from_static(
-        __BYTECODE,
-    );
+    pub static ARBITERTOKEN_BYTECODE: ::ethers::core::types::Bytes =
+        ::ethers::core::types::Bytes::from_static(__BYTECODE);
     #[rustfmt::skip]
     const __DEPLOYED_BYTECODE: &[u8] = b"`@`\x80\x81R`\x04\x806\x10\x15a\0pW[` `\x84\x92Q\x91bF\x1B\xCD`\xE5\x1B\x83R\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01Rtnor receive functions`X\x1B`d\x82\x01R\xFD[`\0\x805`\xE0\x1C\x80c\x06\xFD\xDE\x03\x14a\x08RW\x80c\t^\xA7\xB3\x14a\x07\xE2W\x80c\x18\x16\r\xDD\x14a\x07\xC4W\x80c#\xB8r\xDD\x14a\x06\xF0W\x80c1<\xE5g\x14a\x06\xB3W\x80c6D\xE5\x15\x14a\x06\x90W\x80c@\xC1\x0F\x19\x14a\x05\xA4W\x80cp\xA0\x821\x14a\x05lW\x80c~\xCE\xBE\0\x14a\x054W\x80c\x95\xD8\x9BA\x14a\x04UW\x80c\xA9\x05\x9C\xBB\x14a\x03\xD1W\x80c\xD5\x05\xAC\xCF\x14a\x01\x92W\x80c\xDDb\xED>\x14a\x01HWc\xF8Q\xA4@\x14a\x01\x16WPa\0\x10V[\x90P4a\x01CW6`\x03\x19\x01\x12a\x01>W`\x06T\x90Q`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x81R` \x90\xF3[a\tJV[a\x08\xFAV[P\x91\x904a\x01CW\x81`\x03\x196\x01\x12a\x01>W` \x92\x82\x91a\x01ha\nUV[a\x01pa\npV[`\x01`\x01`\xA0\x1B\x03\x91\x82\x16\x84R\x91\x86R\x83\x83 \x91\x16\x82R\x84R T\x90Q\x90\x81R\xF3[P\x824a\x01CW`\xE06`\x03\x19\x01\x12a\x01>Wa\x01\xADa\nUV[\x90a\x01\xB6a\npV[\x91`D5`d5\x92`\x845\x92`\xFF\x84\x16\x80\x94\x03a\x03\xCDWB\x85\x10a\x03\x8AWa\x01\xDCa\n\xA9V[\x95`\x01\x80`\xA0\x1B\x03\x80\x92\x16\x95\x86\x89R` \x95`\x05\x87R\x84\x8A \x98\x89T\x99`\x01\x8B\x01\x90U\x85Q\x92\x85\x89\x85\x01\x95\x7Fnq\xED\xAE\x12\xB1\xB9\x7FM\x1F`7\x0F\xEF\x10\x10_\xA2\xFA\xAE\x01&\x11J\x16\x9Cd\x84]a&\xC9\x87R\x8B\x89\x87\x01R\x16\x9A\x8B``\x86\x01R\x88`\x80\x86\x01R`\xA0\x85\x01R`\xC0\x84\x01R`\xC0\x83R`\xE0\x83\x01g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x94\x84\x82\x10\x86\x83\x11\x17a\x03vW\x81\x88R\x84Q\x90 a\x01\0\x85\x01\x92a\x19\x01`\xF0\x1B\x84Ra\x01\x02\x86\x01Ra\x01\"\x85\x01R`B\x81Ra\x01`\x84\x01\x94\x81\x86\x10\x90\x86\x11\x17a\x03cW\x84\x87RQ\x90 \x83Ra\x01\x80\x82\x01R`\xA45a\x01\xA0\x82\x01R`\xC45a\x01\xC0\x90\x91\x01R\x87\x80R\x84\x90\x88\x90`\x80\x90`\x01Z\xFA\x15a\x03YW\x86Q\x16\x96\x87\x15\x15\x80a\x03PW[\x15a\x03\x1EW\x86\x97\x7F\x8C[\xE1\xE5\xEB\xEC}[\xD1OqB}\x1E\x84\xF3\xDD\x03\x14\xC0\xF7\xB2)\x1E[ \n\xC8\xC7\xC3\xB9%\x95\x96\x97R\x83R\x80\x87 \x86\x88R\x83R\x81\x81\x88 UQ\x90\x81R\xA3\x80\xF3[\x83`d\x92Q\x91bF\x1B\xCD`\xE5\x1B\x83R\x82\x01R`\x0E`$\x82\x01Rm$\xA7+ \xA6$\xA2/\xA9\xA4\xA3\xA7\"\xA9`\x91\x1B`D\x82\x01R\xFD[P\x84\x88\x14a\x02\xDBV[\x81Q=\x88\x82>=\x90\xFD[cNH{q`\xE0\x1B\x8CR`A\x8DR`$\x8C\xFD[PcNH{q`\xE0\x1B\x8CR`A\x8DR`$\x8C\xFD[\x81QbF\x1B\xCD`\xE5\x1B\x81R` \x81\x8A\x01R`\x17`$\x82\x01R\x7FPERMIT_DEADLINE_EXPIRED\0\0\0\0\0\0\0\0\0`D\x82\x01R`d\x90\xFD[\x86\x80\xFD[P\x824a\x01CW\x80`\x03\x196\x01\x12a\x01>W` \x91a\x03\xEEa\nUV[\x82`$5\x913\x84R`\x03\x86R\x81\x84 a\x04\x08\x84\x82Ta\n\x86V[\x90U`\x01`\x01`\xA0\x1B\x03\x16\x80\x84R`\x03\x86R\x92 \x80T\x82\x01\x90U\x82Q\x90\x81R3\x90\x7F\xDD\xF2R\xAD\x1B\xE2\xC8\x9Bi\xC2\xB0h\xFC7\x8D\xAA\x95+\xA7\xF1c\xC4\xA1\x16(\xF5ZM\xF5#\xB3\xEF\x90\x85\x90\xA3Q`\x01\x81R\xF3[P\x824a\x01CW\x81`\x03\x196\x01\x12a\x01>W\x80Q\x90\x82`\x01\x80T\x91a\x04y\x83a\t\x9AV[\x80\x86R\x92\x82\x81\x16\x90\x81\x15a\x05\x0CWP`\x01\x14a\x04\xB0W[PPPa\x04\xA2\x82a\x04\xAC\x94\x03\x83a\t\xD4V[Q\x91\x82\x91\x82a\n\x0CV[\x03\x90\xF3[\x94P\x80\x85R\x7F\xB1\x0E-Rv\x12\x07;&\xEE\xCD\xFDq~j2\x0C\xF4KJ\xFA\xC2\xB0s-\x9F\xCB\xE2\xB7\xFA\x0C\xF6[\x82\x86\x10a\x04\xF4WPPPa\x04\xA2\x82` a\x04\xAC\x95\x82\x01\x01\x94a\x04\x90V[\x80T` \x87\x87\x01\x81\x01\x91\x90\x91R\x90\x95\x01\x94\x81\x01a\x04\xD7V[a\x04\xAC\x97P\x86\x93P` \x92Pa\x04\xA2\x94\x91P`\xFF\x19\x16\x82\x84\x01R\x15\x15`\x05\x1B\x82\x01\x01\x94a\x04\x90V[P\x824a\x01CW` 6`\x03\x19\x01\x12a\x01>W` \x91\x81\x90`\x01`\x01`\xA0\x1B\x03a\x05\\a\nUV[\x16\x81R`\x05\x84R T\x90Q\x90\x81R\xF3[P\x824a\x01CW` 6`\x03\x19\x01\x12a\x01>W` \x91\x81\x90`\x01`\x01`\xA0\x1B\x03a\x05\x94a\nUV[\x16\x81R`\x03\x84R T\x90Q\x90\x81R\xF3[P\x82\x904a\x01CW\x81`\x03\x196\x01\x12a\x01>Wa\x05\xBFa\nUV[`\x06T`$5\x92\x91`\x01`\x01`\xA0\x1B\x03\x91\x82\x163\x03a\x06CW`\x02T\x84\x81\x01\x80\x91\x11a\x060W` \x96P\x91\x86\x91\x7F\xDD\xF2R\xAD\x1B\xE2\xC8\x9Bi\xC2\xB0h\xFC7\x8D\xAA\x95+\xA7\xF1c\xC4\xA1\x16(\xF5ZM\xF5#\xB3\xEF\x93`\x02U\x16\x93\x84\x84R`\x03\x82R\x85\x84 \x81\x81T\x01\x90U\x85Q\x90\x81R\xA3Q`\x01\x81R\xF3[cNH{q`\xE0\x1B\x84R`\x11\x87R`$\x84\xFD[\x84QbF\x1B\xCD`\xE5\x1B\x81R` \x81\x88\x01R`!`$\x82\x01R\x7FOnly admin can call this functio`D\x82\x01R`7`\xF9\x1B`d\x82\x01R`\x84\x90\xFD[\x83\x824a\x01CW6`\x03\x19\x01\x12a\x01>W` \x90a\x06\xACa\n\xA9V[\x90Q\x90\x81R\xF3[\x83\x824a\x01CW6`\x03\x19\x01\x12a\x01>W` \x90Q`\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x81R\xF3[P\x82\x904a\x01CW``6`\x03\x19\x01\x12a\x01>Wa\x07\x0Ca\nUV[\x7F\xDD\xF2R\xAD\x1B\xE2\xC8\x9Bi\xC2\xB0h\xFC7\x8D\xAA\x95+\xA7\xF1c\xC4\xA1\x16(\xF5ZM\xF5#\xB3\xEFa\x075a\npV[`\x01`\x01`\xA0\x1B\x03\x92\x83\x16\x80\x85R` \x87\x81R\x86\x86 3\x87R\x81R\x86\x86 T\x90\x97\x91\x94\x88\x93`D5\x93\x89\x93\x85`\x01\x82\x01a\x07\xA1W[PPP\x86\x88R`\x03\x85R\x82\x88 a\x07\x82\x85\x82Ta\n\x86V[\x90U\x16\x95\x86\x81R`\x03\x84R \x81\x81T\x01\x90U\x85Q\x90\x81R\xA3Q`\x01\x81R\xF3[a\x07\xAA\x91a\n\x86V[\x90\x88\x8AR\x86R\x83\x89 3\x8AR\x86R\x83\x89 U\x8A\x80\x85a\x07jV[\x83\x824a\x01CW6`\x03\x19\x01\x12a\x01>W` \x90`\x02T\x90Q\x90\x81R\xF3[P\x91\x904a\x01CW\x81`\x03\x196\x01\x12a\x01>W` \x92a\x08\0a\nUV[\x91\x83`$5\x92\x83\x923\x82R\x87R\x81\x81 \x94`\x01\x80`\xA0\x1B\x03\x16\x94\x85\x82R\x87R U\x82Q\x90\x81R\x7F\x8C[\xE1\xE5\xEB\xEC}[\xD1OqB}\x1E\x84\xF3\xDD\x03\x14\xC0\xF7\xB2)\x1E[ \n\xC8\xC7\xC3\xB9%\x843\x92\xA3Q`\x01\x81R\xF3[P\x824a\x08\xFAW\x81`\x03\x196\x01\x12a\x01>W\x80Q\x90\x82\x80Ta\x08s\x81a\t\x9AV[\x80\x85R\x91`\x01\x91\x80\x83\x16\x90\x81\x15a\x05\x0CWP`\x01\x14a\x08\x9EWPPPa\x04\xA2\x82a\x04\xAC\x94\x03\x83a\t\xD4V[\x80\x80\x96PR\x7F)\r\xEC\xD9T\x8Bb\xA8\xD6\x03E\xA9\x888o\xC8K\xA6\xBC\x95H@\x08\xF66/\x93\x16\x0E\xF3\xE5c[\x82\x86\x10a\x08\xE2WPPPa\x04\xA2\x82` a\x04\xAC\x95\x82\x01\x01\x94a\x04\x90V[\x80T` \x87\x87\x01\x81\x01\x91\x90\x91R\x90\x95\x01\x94\x81\x01a\x08\xC5V[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x90\xFD[\x90`\x01\x82\x81\x1C\x92\x16\x80\x15a\t\xCAW[` \x83\x10\x14a\t\xB4WV[cNH{q`\xE0\x1B`\0R`\"`\x04R`$`\0\xFD[\x91`\x7F\x16\x91a\t\xA9V[\x90`\x1F\x80\x19\x91\x01\x16\x81\x01\x90\x81\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11\x17a\t\xF6W`@RV[cNH{q`\xE0\x1B`\0R`A`\x04R`$`\0\xFD[` \x80\x82R\x82Q\x81\x83\x01\x81\x90R\x90\x93\x92`\0[\x82\x81\x10a\nAWPP`@\x92\x93P`\0\x83\x82\x84\x01\x01R`\x1F\x80\x19\x91\x01\x16\x01\x01\x90V[\x81\x81\x01\x86\x01Q\x84\x82\x01`@\x01R\x85\x01a\n\x1FV[`\x045\x90`\x01`\x01`\xA0\x1B\x03\x82\x16\x82\x03a\nkWV[`\0\x80\xFD[`$5\x90`\x01`\x01`\xA0\x1B\x03\x82\x16\x82\x03a\nkWV[\x91\x90\x82\x03\x91\x82\x11a\n\x93WV[cNH{q`\xE0\x1B`\0R`\x11`\x04R`$`\0\xFD[`\0F\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x03a\n\xF7WP\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x90V[`@Q\x81T\x82\x91a\x0B\x07\x82a\t\x9AV[\x80\x82R\x81` \x94\x85\x82\x01\x94`\x01\x90\x87\x82\x82\x16\x91\x82`\0\x14a\x0C1WPP`\x01\x14a\x0B\xD8W[Pa\x0B9\x92P\x03\x82a\t\xD4V[Q\x90 \x91`@Q\x91\x82\x01\x92\x7F\x8Bs\xC3\xC6\x9B\xB8\xFE=Q.\xCCL\xF7Y\xCCy#\x9F{\x17\x9B\x0F\xFA\xCA\xA9\xA7]R+9@\x0F\x84R`@\x83\x01R\x7F\xC8\x9E\xFD\xAAT\xC0\xF2\x0Cz\xDFa(\x82\xDF\tP\xF5\xA9Qc~\x03\x07\xCD\xCBLg/)\x8B\x8B\xC6``\x83\x01RF`\x80\x83\x01R0`\xA0\x83\x01R`\xA0\x82R`\xC0\x82\x01\x90\x82\x82\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x83\x11\x17a\x0B\xC4WP`@RQ\x90 \x90V[cNH{q`\xE0\x1B\x81R`A`\x04R`$\x90\xFD[\x87\x80R\x86\x91P\x87\x90\x7F)\r\xEC\xD9T\x8Bb\xA8\xD6\x03E\xA9\x888o\xC8K\xA6\xBC\x95H@\x08\xF66/\x93\x16\x0E\xF3\xE5c[\x85\x83\x10a\x0C\x19WPPa\x0B9\x93P\x82\x01\x018a\x0B,V[\x80T\x83\x88\x01\x85\x01R\x86\x94P\x88\x93\x90\x92\x01\x91\x81\x01a\x0C\x02V[`\xFF\x19\x16\x88Ra\x0B9\x95\x15\x15`\x05\x1B\x85\x01\x01\x92P8\x91Pa\x0B,\x90PV\xFE\xA2dipfsX\"\x12 \xE3W;\xFC\xD8\xCC\xEE\x0E\x810\x99\x8C`\x1FF*\xCAO\xF0_\x18L\xAD=\x04U+\x03\xCE\xD1\xB5\xC9dsolcC\0\x08\x13\x003";
     /// The deployed bytecode of the contract.
-    pub static ARBITERTOKEN_DEPLOYED_BYTECODE: ::ethers::core::types::Bytes = ::ethers::core::types::Bytes::from_static(
-        __DEPLOYED_BYTECODE,
-    );
+    pub static ARBITERTOKEN_DEPLOYED_BYTECODE: ::ethers::core::types::Bytes =
+        ::ethers::core::types::Bytes::from_static(__DEPLOYED_BYTECODE);
     pub struct ArbiterToken<M>(::ethers::contract::Contract<M>);
     impl<M> ::core::clone::Clone for ArbiterToken<M> {
         fn clone(&self) -> Self {
@@ -590,34 +495,38 @@ pub mod arbiter_token {
         }
     }
     impl<M: ::ethers::providers::Middleware> ArbiterToken<M> {
-        /// Creates a new contract instance with the specified `ethers` client at
-        /// `address`. The contract derefs to a `ethers::Contract` object.
+        /// Creates a new contract instance with the specified `ethers` client
+        /// at `address`. The contract derefs to a `ethers::Contract`
+        /// object.
         pub fn new<T: Into<::ethers::core::types::Address>>(
             address: T,
             client: ::std::sync::Arc<M>,
         ) -> Self {
-            Self(
-                ::ethers::contract::Contract::new(
-                    address.into(),
-                    ARBITERTOKEN_ABI.clone(),
-                    client,
-                ),
-            )
+            Self(::ethers::contract::Contract::new(
+                address.into(),
+                ARBITERTOKEN_ABI.clone(),
+                client,
+            ))
         }
-        /// Constructs the general purpose `Deployer` instance based on the provided constructor arguments and sends it.
-        /// Returns a new instance of a deployer that returns an instance of this contract after sending the transaction
+        /// Constructs the general purpose `Deployer` instance based on the
+        /// provided constructor arguments and sends it. Returns a new
+        /// instance of a deployer that returns an instance of this contract
+        /// after sending the transaction
         ///
         /// Notes:
-        /// - If there are no constructor arguments, you should pass `()` as the argument.
+        /// - If there are no constructor arguments, you should pass `()` as the
+        ///   argument.
         /// - The default poll duration is 7 seconds.
         /// - The default number of confirmations is 1 block.
         ///
         ///
         /// # Example
         ///
-        /// Generate contract bindings with `abigen!` and deploy a new contract instance.
+        /// Generate contract bindings with `abigen!` and deploy a new contract
+        /// instance.
         ///
-        /// *Note*: this requires a `bytecode` and `abi` object in the `greeter.json` artifact.
+        /// *Note*: this requires a `bytecode` and `abi` object in the
+        /// `greeter.json` artifact.
         ///
         /// ```ignore
         /// # async fn deploy<M: ethers::providers::Middleware>(client: ::std::sync::Arc<M>) {
@@ -643,26 +552,21 @@ pub mod arbiter_token {
             let deployer = ::ethers::contract::ContractDeployer::new(deployer);
             Ok(deployer)
         }
-        ///Calls the contract's `DOMAIN_SEPARATOR` (0x3644e515) function
-        pub fn domain_separator(
-            &self,
-        ) -> ::ethers::contract::builders::ContractCall<M, [u8; 32]> {
+        /// Calls the contract's `DOMAIN_SEPARATOR` (0x3644e515) function
+        pub fn domain_separator(&self) -> ::ethers::contract::builders::ContractCall<M, [u8; 32]> {
             self.0
                 .method_hash([54, 68, 229, 21], ())
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `admin` (0xf851a440) function
+        /// Calls the contract's `admin` (0xf851a440) function
         pub fn admin(
             &self,
-        ) -> ::ethers::contract::builders::ContractCall<
-            M,
-            ::ethers::core::types::Address,
-        > {
+        ) -> ::ethers::contract::builders::ContractCall<M, ::ethers::core::types::Address> {
             self.0
                 .method_hash([248, 81, 164, 64], ())
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `allowance` (0xdd62ed3e) function
+        /// Calls the contract's `allowance` (0xdd62ed3e) function
         pub fn allowance(
             &self,
             p0: ::ethers::core::types::Address,
@@ -672,7 +576,7 @@ pub mod arbiter_token {
                 .method_hash([221, 98, 237, 62], (p0, p1))
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `approve` (0x095ea7b3) function
+        /// Calls the contract's `approve` (0x095ea7b3) function
         pub fn approve(
             &self,
             spender: ::ethers::core::types::Address,
@@ -682,7 +586,7 @@ pub mod arbiter_token {
                 .method_hash([9, 94, 167, 179], (spender, amount))
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `balanceOf` (0x70a08231) function
+        /// Calls the contract's `balanceOf` (0x70a08231) function
         pub fn balance_of(
             &self,
             p0: ::ethers::core::types::Address,
@@ -691,13 +595,13 @@ pub mod arbiter_token {
                 .method_hash([112, 160, 130, 49], p0)
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `decimals` (0x313ce567) function
+        /// Calls the contract's `decimals` (0x313ce567) function
         pub fn decimals(&self) -> ::ethers::contract::builders::ContractCall<M, u8> {
             self.0
                 .method_hash([49, 60, 229, 103], ())
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `mint` (0x40c10f19) function
+        /// Calls the contract's `mint` (0x40c10f19) function
         pub fn mint(
             &self,
             receiver: ::ethers::core::types::Address,
@@ -707,15 +611,13 @@ pub mod arbiter_token {
                 .method_hash([64, 193, 15, 25], (receiver, amount))
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `name` (0x06fdde03) function
-        pub fn name(
-            &self,
-        ) -> ::ethers::contract::builders::ContractCall<M, ::std::string::String> {
+        /// Calls the contract's `name` (0x06fdde03) function
+        pub fn name(&self) -> ::ethers::contract::builders::ContractCall<M, ::std::string::String> {
             self.0
                 .method_hash([6, 253, 222, 3], ())
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `nonces` (0x7ecebe00) function
+        /// Calls the contract's `nonces` (0x7ecebe00) function
         pub fn nonces(
             &self,
             p0: ::ethers::core::types::Address,
@@ -724,7 +626,7 @@ pub mod arbiter_token {
                 .method_hash([126, 206, 190, 0], p0)
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `permit` (0xd505accf) function
+        /// Calls the contract's `permit` (0xd505accf) function
         pub fn permit(
             &self,
             owner: ::ethers::core::types::Address,
@@ -742,7 +644,7 @@ pub mod arbiter_token {
                 )
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `symbol` (0x95d89b41) function
+        /// Calls the contract's `symbol` (0x95d89b41) function
         pub fn symbol(
             &self,
         ) -> ::ethers::contract::builders::ContractCall<M, ::std::string::String> {
@@ -750,7 +652,7 @@ pub mod arbiter_token {
                 .method_hash([149, 216, 155, 65], ())
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `totalSupply` (0x18160ddd) function
+        /// Calls the contract's `totalSupply` (0x18160ddd) function
         pub fn total_supply(
             &self,
         ) -> ::ethers::contract::builders::ContractCall<M, ::ethers::core::types::U256> {
@@ -758,7 +660,7 @@ pub mod arbiter_token {
                 .method_hash([24, 22, 13, 221], ())
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `transfer` (0xa9059cbb) function
+        /// Calls the contract's `transfer` (0xa9059cbb) function
         pub fn transfer(
             &self,
             to: ::ethers::core::types::Address,
@@ -768,7 +670,7 @@ pub mod arbiter_token {
                 .method_hash([169, 5, 156, 187], (to, amount))
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `transferFrom` (0x23b872dd) function
+        /// Calls the contract's `transferFrom` (0x23b872dd) function
         pub fn transfer_from(
             &self,
             from: ::ethers::core::types::Address,
@@ -779,39 +681,28 @@ pub mod arbiter_token {
                 .method_hash([35, 184, 114, 221], (from, to, amount))
                 .expect("method not found (this should never happen)")
         }
-        ///Gets the contract's `Approval` event
+        /// Gets the contract's `Approval` event
         pub fn approval_filter(
             &self,
-        ) -> ::ethers::contract::builders::Event<
-            ::std::sync::Arc<M>,
-            M,
-            ApprovalFilter,
-        > {
+        ) -> ::ethers::contract::builders::Event<::std::sync::Arc<M>, M, ApprovalFilter> {
             self.0.event()
         }
-        ///Gets the contract's `Transfer` event
+        /// Gets the contract's `Transfer` event
         pub fn transfer_filter(
             &self,
-        ) -> ::ethers::contract::builders::Event<
-            ::std::sync::Arc<M>,
-            M,
-            TransferFilter,
-        > {
+        ) -> ::ethers::contract::builders::Event<::std::sync::Arc<M>, M, TransferFilter> {
             self.0.event()
         }
         /// Returns an `Event` builder for all the events of this contract.
         pub fn events(
             &self,
-        ) -> ::ethers::contract::builders::Event<
-            ::std::sync::Arc<M>,
-            M,
-            ArbiterTokenEvents,
-        > {
-            self.0.event_with_filter(::core::default::Default::default())
+        ) -> ::ethers::contract::builders::Event<::std::sync::Arc<M>, M, ArbiterTokenEvents>
+        {
+            self.0
+                .event_with_filter(::core::default::Default::default())
         }
     }
-    impl<M: ::ethers::providers::Middleware> From<::ethers::contract::Contract<M>>
-    for ArbiterToken<M> {
+    impl<M: ::ethers::providers::Middleware> From<::ethers::contract::Contract<M>> for ArbiterToken<M> {
         fn from(contract: ::ethers::contract::Contract<M>) -> Self {
             Self::new(contract.address(), contract.client())
         }
@@ -826,7 +717,7 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethevent(name = "Approval", abi = "Approval(address,address,uint256)")]
     pub struct ApprovalFilter {
@@ -846,7 +737,7 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethevent(name = "Transfer", abi = "Transfer(address,address,uint256)")]
     pub struct TransferFilter {
@@ -856,7 +747,7 @@ pub mod arbiter_token {
         pub to: ::ethers::core::types::Address,
         pub amount: ::ethers::core::types::U256,
     }
-    ///Container type for all of the contract's events
+    /// Container type for all of the contract's events
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -865,7 +756,7 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub enum ArbiterTokenEvents {
         ApprovalFilter(ApprovalFilter),
@@ -902,7 +793,8 @@ pub mod arbiter_token {
             Self::TransferFilter(value)
         }
     }
-    ///Container type for all input parameters for the `DOMAIN_SEPARATOR` function with signature `DOMAIN_SEPARATOR()` and selector `0x3644e515`
+    /// Container type for all input parameters for the `DOMAIN_SEPARATOR`
+    /// function with signature `DOMAIN_SEPARATOR()` and selector `0x3644e515`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -913,11 +805,12 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "DOMAIN_SEPARATOR", abi = "DOMAIN_SEPARATOR()")]
     pub struct DomainSeparatorCall;
-    ///Container type for all input parameters for the `admin` function with signature `admin()` and selector `0xf851a440`
+    /// Container type for all input parameters for the `admin` function with
+    /// signature `admin()` and selector `0xf851a440`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -928,11 +821,12 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "admin", abi = "admin()")]
     pub struct AdminCall;
-    ///Container type for all input parameters for the `allowance` function with signature `allowance(address,address)` and selector `0xdd62ed3e`
+    /// Container type for all input parameters for the `allowance` function
+    /// with signature `allowance(address,address)` and selector `0xdd62ed3e`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -943,14 +837,15 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "allowance", abi = "allowance(address,address)")]
     pub struct AllowanceCall(
         pub ::ethers::core::types::Address,
         pub ::ethers::core::types::Address,
     );
-    ///Container type for all input parameters for the `approve` function with signature `approve(address,uint256)` and selector `0x095ea7b3`
+    /// Container type for all input parameters for the `approve` function with
+    /// signature `approve(address,uint256)` and selector `0x095ea7b3`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -961,14 +856,15 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "approve", abi = "approve(address,uint256)")]
     pub struct ApproveCall {
         pub spender: ::ethers::core::types::Address,
         pub amount: ::ethers::core::types::U256,
     }
-    ///Container type for all input parameters for the `balanceOf` function with signature `balanceOf(address)` and selector `0x70a08231`
+    /// Container type for all input parameters for the `balanceOf` function
+    /// with signature `balanceOf(address)` and selector `0x70a08231`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -979,11 +875,12 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "balanceOf", abi = "balanceOf(address)")]
     pub struct BalanceOfCall(pub ::ethers::core::types::Address);
-    ///Container type for all input parameters for the `decimals` function with signature `decimals()` and selector `0x313ce567`
+    /// Container type for all input parameters for the `decimals` function with
+    /// signature `decimals()` and selector `0x313ce567`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -994,11 +891,12 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "decimals", abi = "decimals()")]
     pub struct DecimalsCall;
-    ///Container type for all input parameters for the `mint` function with signature `mint(address,uint256)` and selector `0x40c10f19`
+    /// Container type for all input parameters for the `mint` function with
+    /// signature `mint(address,uint256)` and selector `0x40c10f19`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -1009,14 +907,15 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "mint", abi = "mint(address,uint256)")]
     pub struct MintCall {
         pub receiver: ::ethers::core::types::Address,
         pub amount: ::ethers::core::types::U256,
     }
-    ///Container type for all input parameters for the `name` function with signature `name()` and selector `0x06fdde03`
+    /// Container type for all input parameters for the `name` function with
+    /// signature `name()` and selector `0x06fdde03`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -1027,11 +926,12 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "name", abi = "name()")]
     pub struct NameCall;
-    ///Container type for all input parameters for the `nonces` function with signature `nonces(address)` and selector `0x7ecebe00`
+    /// Container type for all input parameters for the `nonces` function with
+    /// signature `nonces(address)` and selector `0x7ecebe00`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -1042,11 +942,13 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "nonces", abi = "nonces(address)")]
     pub struct NoncesCall(pub ::ethers::core::types::Address);
-    ///Container type for all input parameters for the `permit` function with signature `permit(address,address,uint256,uint256,uint8,bytes32,bytes32)` and selector `0xd505accf`
+    /// Container type for all input parameters for the `permit` function with
+    /// signature `permit(address,address,uint256,uint256,uint8,bytes32,
+    /// bytes32)` and selector `0xd505accf`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -1057,7 +959,7 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(
         name = "permit",
@@ -1072,7 +974,8 @@ pub mod arbiter_token {
         pub r: [u8; 32],
         pub s: [u8; 32],
     }
-    ///Container type for all input parameters for the `symbol` function with signature `symbol()` and selector `0x95d89b41`
+    /// Container type for all input parameters for the `symbol` function with
+    /// signature `symbol()` and selector `0x95d89b41`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -1083,11 +986,12 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "symbol", abi = "symbol()")]
     pub struct SymbolCall;
-    ///Container type for all input parameters for the `totalSupply` function with signature `totalSupply()` and selector `0x18160ddd`
+    /// Container type for all input parameters for the `totalSupply` function
+    /// with signature `totalSupply()` and selector `0x18160ddd`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -1098,11 +1002,12 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "totalSupply", abi = "totalSupply()")]
     pub struct TotalSupplyCall;
-    ///Container type for all input parameters for the `transfer` function with signature `transfer(address,uint256)` and selector `0xa9059cbb`
+    /// Container type for all input parameters for the `transfer` function with
+    /// signature `transfer(address,uint256)` and selector `0xa9059cbb`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -1113,14 +1018,16 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "transfer", abi = "transfer(address,uint256)")]
     pub struct TransferCall {
         pub to: ::ethers::core::types::Address,
         pub amount: ::ethers::core::types::U256,
     }
-    ///Container type for all input parameters for the `transferFrom` function with signature `transferFrom(address,address,uint256)` and selector `0x23b872dd`
+    /// Container type for all input parameters for the `transferFrom` function
+    /// with signature `transferFrom(address,address,uint256)` and selector
+    /// `0x23b872dd`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -1131,7 +1038,7 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "transferFrom", abi = "transferFrom(address,address,uint256)")]
     pub struct TransferFromCall {
@@ -1139,7 +1046,7 @@ pub mod arbiter_token {
         pub to: ::ethers::core::types::Address,
         pub amount: ::ethers::core::types::U256,
     }
-    ///Container type for all of the contract's call
+    /// Container type for all of the contract's call
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1148,7 +1055,7 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub enum ArbiterTokenCalls {
         DomainSeparator(DomainSeparatorCall),
@@ -1171,74 +1078,49 @@ pub mod arbiter_token {
             data: impl AsRef<[u8]>,
         ) -> ::core::result::Result<Self, ::ethers::core::abi::AbiError> {
             let data = data.as_ref();
-            if let Ok(decoded) = <DomainSeparatorCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) =
+                <DomainSeparatorCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::DomainSeparator(decoded));
             }
-            if let Ok(decoded) = <AdminCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <AdminCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Admin(decoded));
             }
-            if let Ok(decoded) = <AllowanceCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <AllowanceCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Allowance(decoded));
             }
-            if let Ok(decoded) = <ApproveCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <ApproveCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Approve(decoded));
             }
-            if let Ok(decoded) = <BalanceOfCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <BalanceOfCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::BalanceOf(decoded));
             }
-            if let Ok(decoded) = <DecimalsCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <DecimalsCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Decimals(decoded));
             }
-            if let Ok(decoded) = <MintCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <MintCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Mint(decoded));
             }
-            if let Ok(decoded) = <NameCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <NameCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Name(decoded));
             }
-            if let Ok(decoded) = <NoncesCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <NoncesCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Nonces(decoded));
             }
-            if let Ok(decoded) = <PermitCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <PermitCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Permit(decoded));
             }
-            if let Ok(decoded) = <SymbolCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <SymbolCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Symbol(decoded));
             }
-            if let Ok(decoded) = <TotalSupplyCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <TotalSupplyCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::TotalSupply(decoded));
             }
-            if let Ok(decoded) = <TransferCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <TransferCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Transfer(decoded));
             }
-            if let Ok(decoded) = <TransferFromCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <TransferFromCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::TransferFrom(decoded));
             }
             Err(::ethers::core::abi::Error::InvalidData.into())
@@ -1247,34 +1129,20 @@ pub mod arbiter_token {
     impl ::ethers::core::abi::AbiEncode for ArbiterTokenCalls {
         fn encode(self) -> Vec<u8> {
             match self {
-                Self::DomainSeparator(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                Self::DomainSeparator(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Admin(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::Allowance(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                Self::Allowance(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Approve(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::BalanceOf(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::Decimals(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                Self::BalanceOf(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::Decimals(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Mint(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Name(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Nonces(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Permit(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Symbol(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::TotalSupply(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::Transfer(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::TransferFrom(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                Self::TotalSupply(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::Transfer(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::TransferFrom(element) => ::ethers::core::abi::AbiEncode::encode(element),
             }
         }
     }
@@ -1368,7 +1236,8 @@ pub mod arbiter_token {
             Self::TransferFrom(value)
         }
     }
-    ///Container type for all return fields from the `DOMAIN_SEPARATOR` function with signature `DOMAIN_SEPARATOR()` and selector `0x3644e515`
+    /// Container type for all return fields from the `DOMAIN_SEPARATOR`
+    /// function with signature `DOMAIN_SEPARATOR()` and selector `0x3644e515`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1379,10 +1248,11 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct DomainSeparatorReturn(pub [u8; 32]);
-    ///Container type for all return fields from the `admin` function with signature `admin()` and selector `0xf851a440`
+    /// Container type for all return fields from the `admin` function with
+    /// signature `admin()` and selector `0xf851a440`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1393,10 +1263,11 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct AdminReturn(pub ::ethers::core::types::Address);
-    ///Container type for all return fields from the `allowance` function with signature `allowance(address,address)` and selector `0xdd62ed3e`
+    /// Container type for all return fields from the `allowance` function with
+    /// signature `allowance(address,address)` and selector `0xdd62ed3e`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1407,10 +1278,11 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct AllowanceReturn(pub ::ethers::core::types::U256);
-    ///Container type for all return fields from the `approve` function with signature `approve(address,uint256)` and selector `0x095ea7b3`
+    /// Container type for all return fields from the `approve` function with
+    /// signature `approve(address,uint256)` and selector `0x095ea7b3`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1421,10 +1293,11 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct ApproveReturn(pub bool);
-    ///Container type for all return fields from the `balanceOf` function with signature `balanceOf(address)` and selector `0x70a08231`
+    /// Container type for all return fields from the `balanceOf` function with
+    /// signature `balanceOf(address)` and selector `0x70a08231`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1435,10 +1308,11 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct BalanceOfReturn(pub ::ethers::core::types::U256);
-    ///Container type for all return fields from the `decimals` function with signature `decimals()` and selector `0x313ce567`
+    /// Container type for all return fields from the `decimals` function with
+    /// signature `decimals()` and selector `0x313ce567`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1449,10 +1323,11 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct DecimalsReturn(pub u8);
-    ///Container type for all return fields from the `mint` function with signature `mint(address,uint256)` and selector `0x40c10f19`
+    /// Container type for all return fields from the `mint` function with
+    /// signature `mint(address,uint256)` and selector `0x40c10f19`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1463,10 +1338,11 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct MintReturn(pub bool);
-    ///Container type for all return fields from the `name` function with signature `name()` and selector `0x06fdde03`
+    /// Container type for all return fields from the `name` function with
+    /// signature `name()` and selector `0x06fdde03`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1477,10 +1353,11 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct NameReturn(pub ::std::string::String);
-    ///Container type for all return fields from the `nonces` function with signature `nonces(address)` and selector `0x7ecebe00`
+    /// Container type for all return fields from the `nonces` function with
+    /// signature `nonces(address)` and selector `0x7ecebe00`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1491,10 +1368,11 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct NoncesReturn(pub ::ethers::core::types::U256);
-    ///Container type for all return fields from the `symbol` function with signature `symbol()` and selector `0x95d89b41`
+    /// Container type for all return fields from the `symbol` function with
+    /// signature `symbol()` and selector `0x95d89b41`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1505,10 +1383,11 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct SymbolReturn(pub ::std::string::String);
-    ///Container type for all return fields from the `totalSupply` function with signature `totalSupply()` and selector `0x18160ddd`
+    /// Container type for all return fields from the `totalSupply` function
+    /// with signature `totalSupply()` and selector `0x18160ddd`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1519,10 +1398,11 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct TotalSupplyReturn(pub ::ethers::core::types::U256);
-    ///Container type for all return fields from the `transfer` function with signature `transfer(address,uint256)` and selector `0xa9059cbb`
+    /// Container type for all return fields from the `transfer` function with
+    /// signature `transfer(address,uint256)` and selector `0xa9059cbb`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1533,10 +1413,12 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct TransferReturn(pub bool);
-    ///Container type for all return fields from the `transferFrom` function with signature `transferFrom(address,address,uint256)` and selector `0x23b872dd`
+    /// Container type for all return fields from the `transferFrom` function
+    /// with signature `transferFrom(address,address,uint256)` and selector
+    /// `0x23b872dd`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -1547,7 +1429,7 @@ pub mod arbiter_token {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct TransferFromReturn(pub bool);
 }

--- a/arbiter-core/src/bindings/liquid_exchange.rs
+++ b/arbiter-core/src/bindings/liquid_exchange.rs
@@ -7,7 +7,7 @@ pub use liquid_exchange::*;
     clippy::upper_case_acronyms,
     clippy::type_complexity,
     dead_code,
-    non_camel_case_types
+    non_camel_case_types,
 )]
 pub mod liquid_exchange {
     #[allow(deprecated)]
@@ -41,156 +41,196 @@ pub mod liquid_exchange {
             functions: ::core::convert::From::from([
                 (
                     ::std::borrow::ToOwned::to_owned("admin"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("admin"),
-                        inputs: ::std::vec![],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::string::String::new(),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("address"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("admin"),
+                            inputs: ::std::vec![],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("address"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("arbiterTokenX"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("arbiterTokenX"),
-                        inputs: ::std::vec![],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::string::String::new(),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("address"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("arbiterTokenX"),
+                            inputs: ::std::vec![],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("address"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("arbiterTokenY"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("arbiterTokenY"),
-                        inputs: ::std::vec![],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::string::String::new(),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("address"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("arbiterTokenY"),
+                            inputs: ::std::vec![],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("address"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("price"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("price"),
-                        inputs: ::std::vec![],
-                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::string::String::new(),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("uint256"),
-                            ),
-                        },],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("price"),
+                            inputs: ::std::vec![],
+                            outputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("setPrice"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("setPrice"),
-                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
-                            name: ::std::borrow::ToOwned::to_owned("_price"),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                            internal_type: ::core::option::Option::Some(
-                                ::std::borrow::ToOwned::to_owned("uint256"),
-                            ),
-                        },],
-                        outputs: ::std::vec![],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("setPrice"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("_price"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            outputs: ::std::vec![],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("swap"),
-                    ::std::vec![::ethers::core::abi::ethabi::Function {
-                        name: ::std::borrow::ToOwned::to_owned("swap"),
-                        inputs: ::std::vec![
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("tokenIn"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("address"),
-                                ),
-                            },
-                            ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("amountIn"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                internal_type: ::core::option::Option::Some(
-                                    ::std::borrow::ToOwned::to_owned("uint256"),
-                                ),
-                            },
-                        ],
-                        outputs: ::std::vec![],
-                        constant: ::core::option::Option::None,
-                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("swap"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("tokenIn"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("address"),
+                                    ),
+                                },
+                                ::ethers::core::abi::ethabi::Param {
+                                    name: ::std::borrow::ToOwned::to_owned("amountIn"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    internal_type: ::core::option::Option::Some(
+                                        ::std::borrow::ToOwned::to_owned("uint256"),
+                                    ),
+                                },
+                            ],
+                            outputs: ::std::vec![],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                        },
+                    ],
                 ),
             ]),
             events: ::core::convert::From::from([
                 (
                     ::std::borrow::ToOwned::to_owned("PriceChange"),
-                    ::std::vec![::ethers::core::abi::ethabi::Event {
-                        name: ::std::borrow::ToOwned::to_owned("PriceChange"),
-                        inputs: ::std::vec![::ethers::core::abi::ethabi::EventParam {
-                            name: ::std::borrow::ToOwned::to_owned("price"),
-                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                            indexed: false,
-                        },],
-                        anonymous: false,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Event {
+                            name: ::std::borrow::ToOwned::to_owned("PriceChange"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::EventParam {
+                                    name: ::std::borrow::ToOwned::to_owned("price"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    indexed: false,
+                                },
+                            ],
+                            anonymous: false,
+                        },
+                    ],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("Swap"),
-                    ::std::vec![::ethers::core::abi::ethabi::Event {
-                        name: ::std::borrow::ToOwned::to_owned("Swap"),
-                        inputs: ::std::vec![
-                            ::ethers::core::abi::ethabi::EventParam {
-                                name: ::std::borrow::ToOwned::to_owned("tokenIn"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                indexed: false,
-                            },
-                            ::ethers::core::abi::ethabi::EventParam {
-                                name: ::std::borrow::ToOwned::to_owned("tokenOut"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                indexed: false,
-                            },
-                            ::ethers::core::abi::ethabi::EventParam {
-                                name: ::std::borrow::ToOwned::to_owned("amountIn"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                indexed: false,
-                            },
-                            ::ethers::core::abi::ethabi::EventParam {
-                                name: ::std::borrow::ToOwned::to_owned("amountOut"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
-                                indexed: false,
-                            },
-                            ::ethers::core::abi::ethabi::EventParam {
-                                name: ::std::borrow::ToOwned::to_owned("to"),
-                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                indexed: false,
-                            },
-                        ],
-                        anonymous: false,
-                    },],
+                    ::std::vec![
+                        ::ethers::core::abi::ethabi::Event {
+                            name: ::std::borrow::ToOwned::to_owned("Swap"),
+                            inputs: ::std::vec![
+                                ::ethers::core::abi::ethabi::EventParam {
+                                    name: ::std::borrow::ToOwned::to_owned("tokenIn"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    indexed: false,
+                                },
+                                ::ethers::core::abi::ethabi::EventParam {
+                                    name: ::std::borrow::ToOwned::to_owned("tokenOut"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    indexed: false,
+                                },
+                                ::ethers::core::abi::ethabi::EventParam {
+                                    name: ::std::borrow::ToOwned::to_owned("amountIn"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    indexed: false,
+                                },
+                                ::ethers::core::abi::ethabi::EventParam {
+                                    name: ::std::borrow::ToOwned::to_owned("amountOut"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
+                                        256usize,
+                                    ),
+                                    indexed: false,
+                                },
+                                ::ethers::core::abi::ethabi::EventParam {
+                                    name: ::std::borrow::ToOwned::to_owned("to"),
+                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                    indexed: false,
+                                },
+                            ],
+                            anonymous: false,
+                        },
+                    ],
                 ),
             ]),
             errors: ::std::collections::BTreeMap::new(),
@@ -198,19 +238,22 @@ pub mod liquid_exchange {
             fallback: false,
         }
     }
-    /// The parsed JSON ABI of the contract.
-    pub static LIQUIDEXCHANGE_ABI: ::ethers::contract::Lazy<::ethers::core::abi::Abi> =
-        ::ethers::contract::Lazy::new(__abi);
+    ///The parsed JSON ABI of the contract.
+    pub static LIQUIDEXCHANGE_ABI: ::ethers::contract::Lazy<::ethers::core::abi::Abi> = ::ethers::contract::Lazy::new(
+        __abi,
+    );
     #[rustfmt::skip]
-    const __BYTECODE: &[u8] = b"`\x80`@R4\x80\x15a\0]W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01\x90\x81Ra7\xB7`\xF1\x1B`d\x83\x01R`\x84\x82\xFD[P`@Qa\x0888\x03\x80a\x088\x839\x81\x01`@\x81\x90Ra\0|\x91a\0\xDBV[`\0\x80T`\x01`\x01`\xA0\x1B\x03\x19\x90\x81\x163\x17\x90\x91U`\x01\x80T`\x01`\x01`\xA0\x1B\x03\x95\x86\x16\x90\x83\x16\x17\x90U`\x02\x80T\x93\x90\x94\x16\x92\x16\x91\x90\x91\x17\x90\x91U`\x03Ua\x01bV[\x80Q`\x01`\x01`\xA0\x1B\x03\x81\x16\x81\x14a\0\xD6W`\0\x80\xFD[\x91\x90PV[`\0\x80`\0``\x84\x86\x03\x12\x15a\x01;W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x81\xFD[a\x01D\x84a\0\xBFV[\x92Pa\x01R` \x85\x01a\0\xBFV[\x91P`@\x84\x01Q\x90P\x92P\x92P\x92V[a\x06\xC7\x80a\x01q`\09`\0\xF3\xFE`\x80`@R4\x80\x15a\0]W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01\x90\x81Ra7\xB7`\xF1\x1B`d\x83\x01R`\x84\x82\xFD[P`\x046\x10a\0\xAFW`\x005`\xE0\x1C\x80c; IH\x14a\x01\x14W\x80c\x91\xB7\xF5\xED\x14a\x01DW\x80c\xA05\xB1\xFE\x14a\x01YW\x80c\xD0\x04\xF0\xF7\x14a\x01pW\x80c\xD0\xC4r\xEC\x14a\x01\x83W\x80c\xF8Q\xA4@\x14a\x01\x96W[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01\x90\x81Rtnor receive functions`X\x1B`d\x83\x01R`\x84\x82\xFD[`\x01Ta\x01'\x90`\x01`\x01`\xA0\x1B\x03\x16\x81V[`@Q`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x81R` \x01[`@Q\x80\x91\x03\x90\xF3[a\x01Wa\x01R6`\x04a\x06\x15V[a\x01\xA9V[\0[a\x01b`\x03T\x81V[`@Q\x90\x81R` \x01a\x01;V[a\x01Wa\x01~6`\x04a\x061V[a\x02MV[`\x02Ta\x01'\x90`\x01`\x01`\xA0\x1B\x03\x16\x81V[`\0Ta\x01'\x90`\x01`\x01`\xA0\x1B\x03\x16\x81V[`\0T`\x01`\x01`\xA0\x1B\x03\x163\x14a\x02\x12W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`!`$\x82\x01R\x7FOnly admin can call this functio`D\x82\x01R`7`\xF9\x1B`d\x82\x01R`\x84\x01[`@Q\x80\x91\x03\x90\xFD[`\x03\x81\x90U`@Q\x81\x81R\x7F\xF3G\xEE\x99P;\xF1\x9C\x02\x8B\xD6\xB1\x8F<gn\x82\xA9\xBB[+\xB5\"Z\xEB\xE0\xFDb\xFDj\r\x19\x90` \x01`@Q\x80\x91\x03\x90\xA1PV[`\x01T`\0\x90\x81\x90`\x01`\x01`\xA0\x1B\x03\x90\x81\x16\x90\x85\x16\x03a\x02\x8DWP`\x02T`\x03T`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x90a\x02\x86\x90\x84\x90a\x05yV[\x91Pa\x02\xF9V[`\x02T`\x01`\x01`\xA0\x1B\x03\x90\x81\x16\x90\x85\x16\x03a\x02\xC1WP`\x01T`\x03T`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x90a\x02\x86\x90\x84\x90a\x05\x95V[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\r`$\x82\x01Rl$\xB7;0\xB64\xB2\x10:7\xB5\xB2\xB7`\x99\x1B`D\x82\x01R`d\x01a\x02\tV[`@Qc#\xB8r\xDD`\xE0\x1B\x81R3`\x04\x82\x01R0`$\x82\x01R`D\x81\x01\x84\x90R`\x01`\x01`\xA0\x1B\x03\x85\x16\x90c#\xB8r\xDD\x90`d\x01` `@Q\x80\x83\x03\x81`\0\x87\x80;\x15\x80\x15a\x03\x97W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`%`$\x82\x01R\x7FTarget contract does not contain`D\x82\x01\x90\x81Rd code`\xD8\x1B`d\x83\x01R`\x84\x82\xFD[PZ\xF1\x15\x80\x15a\x03\xABW=`\0\x80>=`\0\xFD[PPPP`@Q=`\x1F\x19`\x1F\x82\x01\x16\x82\x01\x80`@RP\x81\x01\x90a\x03\xCF\x91\x90a\x06lV[a\x04\rW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x0F`$\x82\x01Rn\x15\x1C\x98[\x9C\xD9\x99\\\x88\x19\x98Z[\x19Y`\x8A\x1B`D\x82\x01R`d\x01a\x02\tV[`@Qc\xA9\x05\x9C\xBB`\xE0\x1B\x81R3`\x04\x82\x01R`$\x81\x01\x83\x90R`\x01`\x01`\xA0\x1B\x03\x82\x16\x90c\xA9\x05\x9C\xBB\x90`D\x01` `@Q\x80\x83\x03\x81`\0\x87\x80;\x15\x80\x15a\x04\xA5W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`%`$\x82\x01R\x7FTarget contract does not contain`D\x82\x01\x90\x81Rd code`\xD8\x1B`d\x83\x01R`\x84\x82\xFD[PZ\xF1\x15\x80\x15a\x04\xB9W=`\0\x80>=`\0\xFD[PPPP`@Q=`\x1F\x19`\x1F\x82\x01\x16\x82\x01\x80`@RP\x81\x01\x90a\x04\xDD\x91\x90a\x06lV[a\x05\x1BW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x0F`$\x82\x01Rn\x15\x1C\x98[\x9C\xD9\x99\\\x88\x19\x98Z[\x19Y`\x8A\x1B`D\x82\x01R`d\x01a\x02\tV[`@\x80Q`\x01`\x01`\xA0\x1B\x03\x80\x87\x16\x82R\x83\x16` \x82\x01R\x90\x81\x01\x84\x90R``\x81\x01\x83\x90R3`\x80\x82\x01R\x7F\xB3\x9C\x9B\xC4?\x81\x1E\x1A|\xE1Y\xC5\xF1GE\x8F\xDB\x80&k\xF2<\x172 \x131n'\xE0\x86\xD0\x90`\xA0\x01`@Q\x80\x91\x03\x90\xA1PPPPV[`\0a\x05\x8E\x83\x83g\r\xE0\xB6\xB3\xA7d\0\0a\x05\xA6V[\x93\x92PPPV[`\0a\x05\x8E\x83g\r\xE0\xB6\xB3\xA7d\0\0\x84[\x82\x82\x02\x81\x15\x15\x84\x15\x85\x83\x04\x85\x14\x17\x16a\x05\xBEW`\0\x80\xFD[\x04\x92\x91PPV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x81\xFD[`\0` \x82\x84\x03\x12\x15a\x06*Wa\x06*a\x05\xC5V[P5\x91\x90PV[`\0\x80`@\x83\x85\x03\x12\x15a\x06GWa\x06Ga\x05\xC5V[\x825`\x01`\x01`\xA0\x1B\x03\x81\x16\x81\x14a\x06^W`\0\x80\xFD[\x94` \x93\x90\x93\x015\x93PPPV[`\0` \x82\x84\x03\x12\x15a\x06\x81Wa\x06\x81a\x05\xC5V[\x81Q\x80\x15\x15\x81\x14a\x05\x8EW`\0\x80\xFD\xFE\xA2dipfsX\"\x12 \x80\xCA\x15\x1F\xCD\xD7\t;x\x89\xB1G\xD07\xEE\x15\xF8\xE4\xFAcJ\x1B[]\xB9\xD7\xEDR\xEB\xE5!\xBBdsolcC\0\x08\x13\x003";
+    const __BYTECODE: &[u8] = b"`\x80`@\x90\x80\x82R4a\x01\x06WP\x80Q`\x1Fa\x07\x9C8\x81\x90\x03\x91\x82\x01`\x1F\x19\x16\x83\x01\x91`\x01`\x01`@\x1B\x03\x83\x11\x84\x84\x10\x17a\0\xF0W\x80\x84\x92``\x94\x87R\x839\x81\x01\x03\x12a\0\xA1Wa\0O\x81a\x01SV[\x90\x82a\0]` \x83\x01a\x01SV[\x91\x01Q\x91`\x01\x80`\xA0\x1B\x03\x19\x913\x83`\0T\x16\x17`\0U`\x01\x80`\xA0\x1B\x03\x80\x92\x16\x83`\x01T\x16\x17`\x01U\x16\x90`\x02T\x16\x17`\x02U`\x03UQa\x06/\x90\x81a\x01m\x829\xF3[\x81QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x90\xFD[cNH{q`\xE0\x1B`\0R`A`\x04R`$`\0\xFD[bF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD[Q\x90`\x01`\x01`\xA0\x1B\x03\x82\x16\x82\x03a\x01gWV[`\0\x80\xFD\xFE`\x80`@R`\x046\x10a\x04fW`\x005`\xE0\x1C\x80c; IH\x14a\0lW\x80c\x91\xB7\xF5\xED\x14a\0gW\x80c\xA05\xB1\xFE\x14a\0bW\x80c\xD0\x04\xF0\xF7\x14a\0]W\x80c\xD0\xC4r\xEC\x14a\0XWc\xF8Q\xA4@\x03a\x04fWa\x04=V[a\x04\x14V[a\x02\x04V[a\x01\xE6V[a\x01:V[4a\0\x9AW`\x006`\x03\x19\x01\x12a\0\x95W`\x01T`@Q`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x81R` \x90\xF3[a\0\xEAV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x90\xFD[4a\x01\xE1W` 6`\x03\x19\x01\x12a\0\x95W`\0T`\x045\x90`\x01`\x01`\xA0\x1B\x03\x163\x03a\x01\x92W` \x81\x7F\xF3G\xEE\x99P;\xF1\x9C\x02\x8B\xD6\xB1\x8F<gn\x82\xA9\xBB[+\xB5\"Z\xEB\xE0\xFDb\xFDj\r\x19\x92`\x03U`@Q\x90\x81R\xA1\0[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`!`$\x82\x01R\x7FOnly admin can call this functio`D\x82\x01R`7`\xF9\x1B`d\x82\x01R`\x84\x90\xFD[a\0\x9AV[4a\x01\xE1W`\x006`\x03\x19\x01\x12a\0\x95W` `\x03T`@Q\x90\x81R\xF3[4a\x01\xE1W`@6`\x03\x19\x01\x12a\0\x95W`\x045`\x01`\x01`\xA0\x1B\x03\x81\x81\x16\x91\x82\x81\x03a\x04\x0FW`\x01T`$5\x92\x90`\x01`\x01`\xA0\x1B\x03\x16\x80\x82\x16\x85\x03a\x03\xB5WP`\x02T`\x01`\x01`\xA0\x1B\x03\x16\x91a\x02_`\x03T\x85a\x05\xB6V[\x91[\x85;\x15a\x03\x93W`@Qc#\xB8r\xDD`\xE0\x1B\x81R3`\x04\x82\x01R0`$\x82\x01R`D\x81\x01\x86\x90R` \x96\x87\x90\x82\x90`d\x90\x82\x90`\0\x90Z\xF1\x80\x15a\x03\x8EWa\x02\xB1\x91`\0\x91a\x03\x98W[Pa\x05xV[\x83\x16\x91\x82;\x15a\x03\x93W`@Qc\xA9\x05\x9C\xBB`\xE0\x1B\x81R3`\x04\x82\x01R`$\x81\x01\x82\x90R\x92\x86\x90\x84\x90`D\x90\x82\x90`\0\x90Z\xF1\x95\x86\x15a\x03\x8EW\x7F\xB3\x9C\x9B\xC4?\x81\x1E\x1A|\xE1Y\xC5\xF1GE\x8F\xDB\x80&k\xF2<\x172 \x131n'\xE0\x86\xD0\x96a\x03\\\x94a\x03$\x92`\0\x92a\x03aW[PPa\x05xV[`@\x80Q`\x01`\x01`\xA0\x1B\x03\x93\x84\x16\x81R\x92\x90\x94\x16` \x83\x01R\x92\x81\x01\x93\x90\x93R``\x83\x01\x91\x90\x91R3`\x80\x83\x01R\x81\x90`\xA0\x82\x01\x90V[\x03\x90\xA1\0[a\x03\x80\x92P\x80=\x10a\x03\x87W[a\x03x\x81\x83a\x05\x1CV[\x81\x01\x90a\x05TV[8\x80a\x03\x1DV[P=a\x03nV[a\x05lV[a\x04\xC9V[a\x03\xAF\x91P\x88=\x8A\x11a\x03\x87Wa\x03x\x81\x83a\x05\x1CV[8a\x02\xABV[`\x02T`\x01`\x01`\xA0\x1B\x03\x16\x85\x03a\x03\xDAW\x91a\x03\xD4`\x03T\x85a\x05\xD7V[\x91a\x02aV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\r`$\x82\x01Rl$\xB7;0\xB64\xB2\x10:7\xB5\xB2\xB7`\x99\x1B`D\x82\x01R`d\x90\xFD[`\0\x80\xFD[4a\x01\xE1W`\x006`\x03\x19\x01\x12a\0\x95W`\x02T`@Q`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x81R` \x90\xF3[4a\x01\xE1W`\x006`\x03\x19\x01\x12a\0\x95W`\0T`@Q`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x81R` \x90\xF3[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01Rtnor receive functions`X\x1B`d\x82\x01R`\x84\x90\xFD[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`%`$\x82\x01R\x7FTarget contract does not contain`D\x82\x01Rd code`\xD8\x1B`d\x82\x01R`\x84\x90\xFD[\x90`\x1F\x80\x19\x91\x01\x16\x81\x01\x90\x81\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11\x17a\x05>W`@RV[cNH{q`\xE0\x1B`\0R`A`\x04R`$`\0\xFD[\x90\x81` \x91\x03\x12a\0\x95WQ\x80\x15\x15\x81\x03a\x04\x0FW\x90V[`@Q=`\0\x82>=\x90\xFD[\x15a\x05\x7FWV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x0F`$\x82\x01Rn\x15\x1C\x98[\x9C\xD9\x99\\\x88\x19\x98Z[\x19Y`\x8A\x1B`D\x82\x01R`d\x90\xFD[\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17`\x01\x16\x15a\x04\x0FWg\r\xE0\xB6\xB3\xA7d\0\0\x90\x04\x90V[g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17\x82\x15\x15\x16\x15a\x04\x0FW\x04\x90V\xFE\xA2dipfsX\"\x12 \x7FZa7\xA3\n\xFC\x17\xC46Q\xAA\xF0s\x8B\xCB|c0\x04\xA2_k\xF2k\xBD\xB8n*\xDC\xD7\xFFdsolcC\0\x08\x13\x003";
     /// The bytecode of the contract.
-    pub static LIQUIDEXCHANGE_BYTECODE: ::ethers::core::types::Bytes =
-        ::ethers::core::types::Bytes::from_static(__BYTECODE);
+    pub static LIQUIDEXCHANGE_BYTECODE: ::ethers::core::types::Bytes = ::ethers::core::types::Bytes::from_static(
+        __BYTECODE,
+    );
     #[rustfmt::skip]
-    const __DEPLOYED_BYTECODE: &[u8] = b"`\x80`@R4\x80\x15a\0]W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01\x90\x81Ra7\xB7`\xF1\x1B`d\x83\x01R`\x84\x82\xFD[P`\x046\x10a\0\xAFW`\x005`\xE0\x1C\x80c; IH\x14a\x01\x14W\x80c\x91\xB7\xF5\xED\x14a\x01DW\x80c\xA05\xB1\xFE\x14a\x01YW\x80c\xD0\x04\xF0\xF7\x14a\x01pW\x80c\xD0\xC4r\xEC\x14a\x01\x83W\x80c\xF8Q\xA4@\x14a\x01\x96W[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01\x90\x81Rtnor receive functions`X\x1B`d\x83\x01R`\x84\x82\xFD[`\x01Ta\x01'\x90`\x01`\x01`\xA0\x1B\x03\x16\x81V[`@Q`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x81R` \x01[`@Q\x80\x91\x03\x90\xF3[a\x01Wa\x01R6`\x04a\x06\x15V[a\x01\xA9V[\0[a\x01b`\x03T\x81V[`@Q\x90\x81R` \x01a\x01;V[a\x01Wa\x01~6`\x04a\x061V[a\x02MV[`\x02Ta\x01'\x90`\x01`\x01`\xA0\x1B\x03\x16\x81V[`\0Ta\x01'\x90`\x01`\x01`\xA0\x1B\x03\x16\x81V[`\0T`\x01`\x01`\xA0\x1B\x03\x163\x14a\x02\x12W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`!`$\x82\x01R\x7FOnly admin can call this functio`D\x82\x01R`7`\xF9\x1B`d\x82\x01R`\x84\x01[`@Q\x80\x91\x03\x90\xFD[`\x03\x81\x90U`@Q\x81\x81R\x7F\xF3G\xEE\x99P;\xF1\x9C\x02\x8B\xD6\xB1\x8F<gn\x82\xA9\xBB[+\xB5\"Z\xEB\xE0\xFDb\xFDj\r\x19\x90` \x01`@Q\x80\x91\x03\x90\xA1PV[`\x01T`\0\x90\x81\x90`\x01`\x01`\xA0\x1B\x03\x90\x81\x16\x90\x85\x16\x03a\x02\x8DWP`\x02T`\x03T`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x90a\x02\x86\x90\x84\x90a\x05yV[\x91Pa\x02\xF9V[`\x02T`\x01`\x01`\xA0\x1B\x03\x90\x81\x16\x90\x85\x16\x03a\x02\xC1WP`\x01T`\x03T`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x90a\x02\x86\x90\x84\x90a\x05\x95V[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\r`$\x82\x01Rl$\xB7;0\xB64\xB2\x10:7\xB5\xB2\xB7`\x99\x1B`D\x82\x01R`d\x01a\x02\tV[`@Qc#\xB8r\xDD`\xE0\x1B\x81R3`\x04\x82\x01R0`$\x82\x01R`D\x81\x01\x84\x90R`\x01`\x01`\xA0\x1B\x03\x85\x16\x90c#\xB8r\xDD\x90`d\x01` `@Q\x80\x83\x03\x81`\0\x87\x80;\x15\x80\x15a\x03\x97W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`%`$\x82\x01R\x7FTarget contract does not contain`D\x82\x01\x90\x81Rd code`\xD8\x1B`d\x83\x01R`\x84\x82\xFD[PZ\xF1\x15\x80\x15a\x03\xABW=`\0\x80>=`\0\xFD[PPPP`@Q=`\x1F\x19`\x1F\x82\x01\x16\x82\x01\x80`@RP\x81\x01\x90a\x03\xCF\x91\x90a\x06lV[a\x04\rW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x0F`$\x82\x01Rn\x15\x1C\x98[\x9C\xD9\x99\\\x88\x19\x98Z[\x19Y`\x8A\x1B`D\x82\x01R`d\x01a\x02\tV[`@Qc\xA9\x05\x9C\xBB`\xE0\x1B\x81R3`\x04\x82\x01R`$\x81\x01\x83\x90R`\x01`\x01`\xA0\x1B\x03\x82\x16\x90c\xA9\x05\x9C\xBB\x90`D\x01` `@Q\x80\x83\x03\x81`\0\x87\x80;\x15\x80\x15a\x04\xA5W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`%`$\x82\x01R\x7FTarget contract does not contain`D\x82\x01\x90\x81Rd code`\xD8\x1B`d\x83\x01R`\x84\x82\xFD[PZ\xF1\x15\x80\x15a\x04\xB9W=`\0\x80>=`\0\xFD[PPPP`@Q=`\x1F\x19`\x1F\x82\x01\x16\x82\x01\x80`@RP\x81\x01\x90a\x04\xDD\x91\x90a\x06lV[a\x05\x1BW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x0F`$\x82\x01Rn\x15\x1C\x98[\x9C\xD9\x99\\\x88\x19\x98Z[\x19Y`\x8A\x1B`D\x82\x01R`d\x01a\x02\tV[`@\x80Q`\x01`\x01`\xA0\x1B\x03\x80\x87\x16\x82R\x83\x16` \x82\x01R\x90\x81\x01\x84\x90R``\x81\x01\x83\x90R3`\x80\x82\x01R\x7F\xB3\x9C\x9B\xC4?\x81\x1E\x1A|\xE1Y\xC5\xF1GE\x8F\xDB\x80&k\xF2<\x172 \x131n'\xE0\x86\xD0\x90`\xA0\x01`@Q\x80\x91\x03\x90\xA1PPPPV[`\0a\x05\x8E\x83\x83g\r\xE0\xB6\xB3\xA7d\0\0a\x05\xA6V[\x93\x92PPPV[`\0a\x05\x8E\x83g\r\xE0\xB6\xB3\xA7d\0\0\x84[\x82\x82\x02\x81\x15\x15\x84\x15\x85\x83\x04\x85\x14\x17\x16a\x05\xBEW`\0\x80\xFD[\x04\x92\x91PPV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x81\xFD[`\0` \x82\x84\x03\x12\x15a\x06*Wa\x06*a\x05\xC5V[P5\x91\x90PV[`\0\x80`@\x83\x85\x03\x12\x15a\x06GWa\x06Ga\x05\xC5V[\x825`\x01`\x01`\xA0\x1B\x03\x81\x16\x81\x14a\x06^W`\0\x80\xFD[\x94` \x93\x90\x93\x015\x93PPPV[`\0` \x82\x84\x03\x12\x15a\x06\x81Wa\x06\x81a\x05\xC5V[\x81Q\x80\x15\x15\x81\x14a\x05\x8EW`\0\x80\xFD\xFE\xA2dipfsX\"\x12 \x80\xCA\x15\x1F\xCD\xD7\t;x\x89\xB1G\xD07\xEE\x15\xF8\xE4\xFAcJ\x1B[]\xB9\xD7\xEDR\xEB\xE5!\xBBdsolcC\0\x08\x13\x003";
+    const __DEPLOYED_BYTECODE: &[u8] = b"`\x80`@R`\x046\x10a\x04fW`\x005`\xE0\x1C\x80c; IH\x14a\0lW\x80c\x91\xB7\xF5\xED\x14a\0gW\x80c\xA05\xB1\xFE\x14a\0bW\x80c\xD0\x04\xF0\xF7\x14a\0]W\x80c\xD0\xC4r\xEC\x14a\0XWc\xF8Q\xA4@\x03a\x04fWa\x04=V[a\x04\x14V[a\x02\x04V[a\x01\xE6V[a\x01:V[4a\0\x9AW`\x006`\x03\x19\x01\x12a\0\x95W`\x01T`@Q`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x81R` \x90\xF3[a\0\xEAV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x90\xFD[4a\x01\xE1W` 6`\x03\x19\x01\x12a\0\x95W`\0T`\x045\x90`\x01`\x01`\xA0\x1B\x03\x163\x03a\x01\x92W` \x81\x7F\xF3G\xEE\x99P;\xF1\x9C\x02\x8B\xD6\xB1\x8F<gn\x82\xA9\xBB[+\xB5\"Z\xEB\xE0\xFDb\xFDj\r\x19\x92`\x03U`@Q\x90\x81R\xA1\0[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`!`$\x82\x01R\x7FOnly admin can call this functio`D\x82\x01R`7`\xF9\x1B`d\x82\x01R`\x84\x90\xFD[a\0\x9AV[4a\x01\xE1W`\x006`\x03\x19\x01\x12a\0\x95W` `\x03T`@Q\x90\x81R\xF3[4a\x01\xE1W`@6`\x03\x19\x01\x12a\0\x95W`\x045`\x01`\x01`\xA0\x1B\x03\x81\x81\x16\x91\x82\x81\x03a\x04\x0FW`\x01T`$5\x92\x90`\x01`\x01`\xA0\x1B\x03\x16\x80\x82\x16\x85\x03a\x03\xB5WP`\x02T`\x01`\x01`\xA0\x1B\x03\x16\x91a\x02_`\x03T\x85a\x05\xB6V[\x91[\x85;\x15a\x03\x93W`@Qc#\xB8r\xDD`\xE0\x1B\x81R3`\x04\x82\x01R0`$\x82\x01R`D\x81\x01\x86\x90R` \x96\x87\x90\x82\x90`d\x90\x82\x90`\0\x90Z\xF1\x80\x15a\x03\x8EWa\x02\xB1\x91`\0\x91a\x03\x98W[Pa\x05xV[\x83\x16\x91\x82;\x15a\x03\x93W`@Qc\xA9\x05\x9C\xBB`\xE0\x1B\x81R3`\x04\x82\x01R`$\x81\x01\x82\x90R\x92\x86\x90\x84\x90`D\x90\x82\x90`\0\x90Z\xF1\x95\x86\x15a\x03\x8EW\x7F\xB3\x9C\x9B\xC4?\x81\x1E\x1A|\xE1Y\xC5\xF1GE\x8F\xDB\x80&k\xF2<\x172 \x131n'\xE0\x86\xD0\x96a\x03\\\x94a\x03$\x92`\0\x92a\x03aW[PPa\x05xV[`@\x80Q`\x01`\x01`\xA0\x1B\x03\x93\x84\x16\x81R\x92\x90\x94\x16` \x83\x01R\x92\x81\x01\x93\x90\x93R``\x83\x01\x91\x90\x91R3`\x80\x83\x01R\x81\x90`\xA0\x82\x01\x90V[\x03\x90\xA1\0[a\x03\x80\x92P\x80=\x10a\x03\x87W[a\x03x\x81\x83a\x05\x1CV[\x81\x01\x90a\x05TV[8\x80a\x03\x1DV[P=a\x03nV[a\x05lV[a\x04\xC9V[a\x03\xAF\x91P\x88=\x8A\x11a\x03\x87Wa\x03x\x81\x83a\x05\x1CV[8a\x02\xABV[`\x02T`\x01`\x01`\xA0\x1B\x03\x16\x85\x03a\x03\xDAW\x91a\x03\xD4`\x03T\x85a\x05\xD7V[\x91a\x02aV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\r`$\x82\x01Rl$\xB7;0\xB64\xB2\x10:7\xB5\xB2\xB7`\x99\x1B`D\x82\x01R`d\x90\xFD[`\0\x80\xFD[4a\x01\xE1W`\x006`\x03\x19\x01\x12a\0\x95W`\x02T`@Q`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x81R` \x90\xF3[4a\x01\xE1W`\x006`\x03\x19\x01\x12a\0\x95W`\0T`@Q`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x81R` \x90\xF3[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01Rtnor receive functions`X\x1B`d\x82\x01R`\x84\x90\xFD[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`%`$\x82\x01R\x7FTarget contract does not contain`D\x82\x01Rd code`\xD8\x1B`d\x82\x01R`\x84\x90\xFD[\x90`\x1F\x80\x19\x91\x01\x16\x81\x01\x90\x81\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11\x17a\x05>W`@RV[cNH{q`\xE0\x1B`\0R`A`\x04R`$`\0\xFD[\x90\x81` \x91\x03\x12a\0\x95WQ\x80\x15\x15\x81\x03a\x04\x0FW\x90V[`@Q=`\0\x82>=\x90\xFD[\x15a\x05\x7FWV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x0F`$\x82\x01Rn\x15\x1C\x98[\x9C\xD9\x99\\\x88\x19\x98Z[\x19Y`\x8A\x1B`D\x82\x01R`d\x90\xFD[\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17`\x01\x16\x15a\x04\x0FWg\r\xE0\xB6\xB3\xA7d\0\0\x90\x04\x90V[g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17\x82\x15\x15\x16\x15a\x04\x0FW\x04\x90V\xFE\xA2dipfsX\"\x12 \x7FZa7\xA3\n\xFC\x17\xC46Q\xAA\xF0s\x8B\xCB|c0\x04\xA2_k\xF2k\xBD\xB8n*\xDC\xD7\xFFdsolcC\0\x08\x13\x003";
     /// The deployed bytecode of the contract.
-    pub static LIQUIDEXCHANGE_DEPLOYED_BYTECODE: ::ethers::core::types::Bytes =
-        ::ethers::core::types::Bytes::from_static(__DEPLOYED_BYTECODE);
+    pub static LIQUIDEXCHANGE_DEPLOYED_BYTECODE: ::ethers::core::types::Bytes = ::ethers::core::types::Bytes::from_static(
+        __DEPLOYED_BYTECODE,
+    );
     pub struct LiquidExchange<M>(::ethers::contract::Contract<M>);
     impl<M> ::core::clone::Clone for LiquidExchange<M> {
         fn clone(&self) -> Self {
@@ -236,38 +279,34 @@ pub mod liquid_exchange {
         }
     }
     impl<M: ::ethers::providers::Middleware> LiquidExchange<M> {
-        /// Creates a new contract instance with the specified `ethers` client
-        /// at `address`. The contract derefs to a `ethers::Contract`
-        /// object.
+        /// Creates a new contract instance with the specified `ethers` client at
+        /// `address`. The contract derefs to a `ethers::Contract` object.
         pub fn new<T: Into<::ethers::core::types::Address>>(
             address: T,
             client: ::std::sync::Arc<M>,
         ) -> Self {
-            Self(::ethers::contract::Contract::new(
-                address.into(),
-                LIQUIDEXCHANGE_ABI.clone(),
-                client,
-            ))
+            Self(
+                ::ethers::contract::Contract::new(
+                    address.into(),
+                    LIQUIDEXCHANGE_ABI.clone(),
+                    client,
+                ),
+            )
         }
-        /// Constructs the general purpose `Deployer` instance based on the
-        /// provided constructor arguments and sends it. Returns a new
-        /// instance of a deployer that returns an instance of this contract
-        /// after sending the transaction
+        /// Constructs the general purpose `Deployer` instance based on the provided constructor arguments and sends it.
+        /// Returns a new instance of a deployer that returns an instance of this contract after sending the transaction
         ///
         /// Notes:
-        /// - If there are no constructor arguments, you should pass `()` as the
-        ///   argument.
+        /// - If there are no constructor arguments, you should pass `()` as the argument.
         /// - The default poll duration is 7 seconds.
         /// - The default number of confirmations is 1 block.
         ///
         ///
         /// # Example
         ///
-        /// Generate contract bindings with `abigen!` and deploy a new contract
-        /// instance.
+        /// Generate contract bindings with `abigen!` and deploy a new contract instance.
         ///
-        /// *Note*: this requires a `bytecode` and `abi` object in the
-        /// `greeter.json` artifact.
+        /// *Note*: this requires a `bytecode` and `abi` object in the `greeter.json` artifact.
         ///
         /// ```ignore
         /// # async fn deploy<M: ethers::providers::Middleware>(client: ::std::sync::Arc<M>) {
@@ -293,31 +332,40 @@ pub mod liquid_exchange {
             let deployer = ::ethers::contract::ContractDeployer::new(deployer);
             Ok(deployer)
         }
-        /// Calls the contract's `admin` (0xf851a440) function
+        ///Calls the contract's `admin` (0xf851a440) function
         pub fn admin(
             &self,
-        ) -> ::ethers::contract::builders::ContractCall<M, ::ethers::core::types::Address> {
+        ) -> ::ethers::contract::builders::ContractCall<
+            M,
+            ::ethers::core::types::Address,
+        > {
             self.0
                 .method_hash([248, 81, 164, 64], ())
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `arbiterTokenX` (0x3b204948) function
+        ///Calls the contract's `arbiterTokenX` (0x3b204948) function
         pub fn arbiter_token_x(
             &self,
-        ) -> ::ethers::contract::builders::ContractCall<M, ::ethers::core::types::Address> {
+        ) -> ::ethers::contract::builders::ContractCall<
+            M,
+            ::ethers::core::types::Address,
+        > {
             self.0
                 .method_hash([59, 32, 73, 72], ())
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `arbiterTokenY` (0xd0c472ec) function
+        ///Calls the contract's `arbiterTokenY` (0xd0c472ec) function
         pub fn arbiter_token_y(
             &self,
-        ) -> ::ethers::contract::builders::ContractCall<M, ::ethers::core::types::Address> {
+        ) -> ::ethers::contract::builders::ContractCall<
+            M,
+            ::ethers::core::types::Address,
+        > {
             self.0
                 .method_hash([208, 196, 114, 236], ())
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `price` (0xa035b1fe) function
+        ///Calls the contract's `price` (0xa035b1fe) function
         pub fn price(
             &self,
         ) -> ::ethers::contract::builders::ContractCall<M, ::ethers::core::types::U256> {
@@ -325,7 +373,7 @@ pub mod liquid_exchange {
                 .method_hash([160, 53, 177, 254], ())
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `setPrice` (0x91b7f5ed) function
+        ///Calls the contract's `setPrice` (0x91b7f5ed) function
         pub fn set_price(
             &self,
             price: ::ethers::core::types::U256,
@@ -334,7 +382,7 @@ pub mod liquid_exchange {
                 .method_hash([145, 183, 245, 237], price)
                 .expect("method not found (this should never happen)")
         }
-        /// Calls the contract's `swap` (0xd004f0f7) function
+        ///Calls the contract's `swap` (0xd004f0f7) function
         pub fn swap(
             &self,
             token_in: ::ethers::core::types::Address,
@@ -344,14 +392,17 @@ pub mod liquid_exchange {
                 .method_hash([208, 4, 240, 247], (token_in, amount_in))
                 .expect("method not found (this should never happen)")
         }
-        /// Gets the contract's `PriceChange` event
+        ///Gets the contract's `PriceChange` event
         pub fn price_change_filter(
             &self,
-        ) -> ::ethers::contract::builders::Event<::std::sync::Arc<M>, M, PriceChangeFilter>
-        {
+        ) -> ::ethers::contract::builders::Event<
+            ::std::sync::Arc<M>,
+            M,
+            PriceChangeFilter,
+        > {
             self.0.event()
         }
-        /// Gets the contract's `Swap` event
+        ///Gets the contract's `Swap` event
         pub fn swap_filter(
             &self,
         ) -> ::ethers::contract::builders::Event<::std::sync::Arc<M>, M, SwapFilter> {
@@ -360,15 +411,16 @@ pub mod liquid_exchange {
         /// Returns an `Event` builder for all the events of this contract.
         pub fn events(
             &self,
-        ) -> ::ethers::contract::builders::Event<::std::sync::Arc<M>, M, LiquidExchangeEvents>
-        {
-            self.0
-                .event_with_filter(::core::default::Default::default())
+        ) -> ::ethers::contract::builders::Event<
+            ::std::sync::Arc<M>,
+            M,
+            LiquidExchangeEvents,
+        > {
+            self.0.event_with_filter(::core::default::Default::default())
         }
     }
     impl<M: ::ethers::providers::Middleware> From<::ethers::contract::Contract<M>>
-        for LiquidExchange<M>
-    {
+    for LiquidExchange<M> {
         fn from(contract: ::ethers::contract::Contract<M>) -> Self {
             Self::new(contract.address(), contract.client())
         }
@@ -377,11 +429,13 @@ pub mod liquid_exchange {
         Clone,
         ::ethers::contract::EthEvent,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethevent(name = "PriceChange", abi = "PriceChange(uint256)")]
     pub struct PriceChangeFilter {
@@ -391,11 +445,13 @@ pub mod liquid_exchange {
         Clone,
         ::ethers::contract::EthEvent,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethevent(name = "Swap", abi = "Swap(address,address,uint256,uint256,address)")]
     pub struct SwapFilter {
@@ -405,8 +461,17 @@ pub mod liquid_exchange {
         pub amount_out: ::ethers::core::types::U256,
         pub to: ::ethers::core::types::Address,
     }
-    /// Container type for all of the contract's events
-    #[derive(Clone, ::ethers::contract::EthAbiType, Debug, PartialEq, Eq, Hash)]
+    ///Container type for all of the contract's events
+    #[derive(
+        Clone,
+        ::ethers::contract::EthAbiType,
+        serde::Serialize,
+        serde::Deserialize,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
     pub enum LiquidExchangeEvents {
         PriceChangeFilter(PriceChangeFilter),
         SwapFilter(SwapFilter),
@@ -442,97 +507,112 @@ pub mod liquid_exchange {
             Self::SwapFilter(value)
         }
     }
-    /// Container type for all input parameters for the `admin` function with
-    /// signature `admin()` and selector `0xf851a440`
+    ///Container type for all input parameters for the `admin` function with signature `admin()` and selector `0xf851a440`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "admin", abi = "admin()")]
     pub struct AdminCall;
-    /// Container type for all input parameters for the `arbiterTokenX` function
-    /// with signature `arbiterTokenX()` and selector `0x3b204948`
+    ///Container type for all input parameters for the `arbiterTokenX` function with signature `arbiterTokenX()` and selector `0x3b204948`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "arbiterTokenX", abi = "arbiterTokenX()")]
     pub struct ArbiterTokenXCall;
-    /// Container type for all input parameters for the `arbiterTokenY` function
-    /// with signature `arbiterTokenY()` and selector `0xd0c472ec`
+    ///Container type for all input parameters for the `arbiterTokenY` function with signature `arbiterTokenY()` and selector `0xd0c472ec`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "arbiterTokenY", abi = "arbiterTokenY()")]
     pub struct ArbiterTokenYCall;
-    /// Container type for all input parameters for the `price` function with
-    /// signature `price()` and selector `0xa035b1fe`
+    ///Container type for all input parameters for the `price` function with signature `price()` and selector `0xa035b1fe`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "price", abi = "price()")]
     pub struct PriceCall;
-    /// Container type for all input parameters for the `setPrice` function with
-    /// signature `setPrice(uint256)` and selector `0x91b7f5ed`
+    ///Container type for all input parameters for the `setPrice` function with signature `setPrice(uint256)` and selector `0x91b7f5ed`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "setPrice", abi = "setPrice(uint256)")]
     pub struct SetPriceCall {
         pub price: ::ethers::core::types::U256,
     }
-    /// Container type for all input parameters for the `swap` function with
-    /// signature `swap(address,uint256)` and selector `0xd004f0f7`
+    ///Container type for all input parameters for the `swap` function with signature `swap(address,uint256)` and selector `0xd004f0f7`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
         ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     #[ethcall(name = "swap", abi = "swap(address,uint256)")]
     pub struct SwapCall {
         pub token_in: ::ethers::core::types::Address,
         pub amount_in: ::ethers::core::types::U256,
     }
-    /// Container type for all of the contract's call
-    #[derive(Clone, ::ethers::contract::EthAbiType, Debug, PartialEq, Eq, Hash)]
+    ///Container type for all of the contract's call
+    #[derive(
+        Clone,
+        ::ethers::contract::EthAbiType,
+        serde::Serialize,
+        serde::Deserialize,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
     pub enum LiquidExchangeCalls {
         Admin(AdminCall),
         ArbiterTokenX(ArbiterTokenXCall),
@@ -546,24 +626,34 @@ pub mod liquid_exchange {
             data: impl AsRef<[u8]>,
         ) -> ::core::result::Result<Self, ::ethers::core::abi::AbiError> {
             let data = data.as_ref();
-            if let Ok(decoded) = <AdminCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <AdminCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::Admin(decoded));
             }
-            if let Ok(decoded) = <ArbiterTokenXCall as ::ethers::core::abi::AbiDecode>::decode(data)
-            {
+            if let Ok(decoded) = <ArbiterTokenXCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::ArbiterTokenX(decoded));
             }
-            if let Ok(decoded) = <ArbiterTokenYCall as ::ethers::core::abi::AbiDecode>::decode(data)
-            {
+            if let Ok(decoded) = <ArbiterTokenYCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::ArbiterTokenY(decoded));
             }
-            if let Ok(decoded) = <PriceCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <PriceCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::Price(decoded));
             }
-            if let Ok(decoded) = <SetPriceCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <SetPriceCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::SetPrice(decoded));
             }
-            if let Ok(decoded) = <SwapCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <SwapCall as ::ethers::core::abi::AbiDecode>::decode(
+                data,
+            ) {
                 return Ok(Self::Swap(decoded));
             }
             Err(::ethers::core::abi::Error::InvalidData.into())
@@ -573,10 +663,16 @@ pub mod liquid_exchange {
         fn encode(self) -> Vec<u8> {
             match self {
                 Self::Admin(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::ArbiterTokenX(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::ArbiterTokenY(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::ArbiterTokenX(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
+                Self::ArbiterTokenY(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
                 Self::Price(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::SetPrice(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::SetPrice(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
                 Self::Swap(element) => ::ethers::core::abi::AbiEncode::encode(element),
             }
         }
@@ -623,56 +719,60 @@ pub mod liquid_exchange {
             Self::Swap(value)
         }
     }
-    /// Container type for all return fields from the `admin` function with
-    /// signature `admin()` and selector `0xf851a440`
+    ///Container type for all return fields from the `admin` function with signature `admin()` and selector `0xf851a440`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct AdminReturn(pub ::ethers::core::types::Address);
-    /// Container type for all return fields from the `arbiterTokenX` function
-    /// with signature `arbiterTokenX()` and selector `0x3b204948`
+    ///Container type for all return fields from the `arbiterTokenX` function with signature `arbiterTokenX()` and selector `0x3b204948`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct ArbiterTokenXReturn(pub ::ethers::core::types::Address);
-    /// Container type for all return fields from the `arbiterTokenY` function
-    /// with signature `arbiterTokenY()` and selector `0xd0c472ec`
+    ///Container type for all return fields from the `arbiterTokenY` function with signature `arbiterTokenY()` and selector `0xd0c472ec`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct ArbiterTokenYReturn(pub ::ethers::core::types::Address);
-    /// Container type for all return fields from the `price` function with
-    /// signature `price()` and selector `0xa035b1fe`
+    ///Container type for all return fields from the `price` function with signature `price()` and selector `0xa035b1fe`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
         ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
         Default,
         Debug,
         PartialEq,
         Eq,
-        Hash,
+        Hash
     )]
     pub struct PriceReturn(pub ::ethers::core::types::U256);
 }

--- a/arbiter-core/src/bindings/liquid_exchange.rs
+++ b/arbiter-core/src/bindings/liquid_exchange.rs
@@ -7,7 +7,7 @@ pub use liquid_exchange::*;
     clippy::upper_case_acronyms,
     clippy::type_complexity,
     dead_code,
-    non_camel_case_types,
+    non_camel_case_types
 )]
 pub mod liquid_exchange {
     #[allow(deprecated)]
@@ -41,196 +41,156 @@ pub mod liquid_exchange {
             functions: ::core::convert::From::from([
                 (
                     ::std::borrow::ToOwned::to_owned("admin"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("admin"),
-                            inputs: ::std::vec![],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("admin"),
+                        inputs: ::std::vec![],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("address"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("arbiterTokenX"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("arbiterTokenX"),
-                            inputs: ::std::vec![],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("arbiterTokenX"),
+                        inputs: ::std::vec![],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("address"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("arbiterTokenY"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("arbiterTokenY"),
-                            inputs: ::std::vec![],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("arbiterTokenY"),
+                        inputs: ::std::vec![],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("address"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("price"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("price"),
-                            inputs: ::std::vec![],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("price"),
+                        inputs: ::std::vec![],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint256"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("setPrice"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("setPrice"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("_price"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("setPrice"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("_price"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint256"),
+                            ),
+                        },],
+                        outputs: ::std::vec![],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("swap"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("swap"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("tokenIn"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("amountIn"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("swap"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("tokenIn"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("address"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("amountIn"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                    },],
                 ),
             ]),
             events: ::core::convert::From::from([
                 (
                     ::std::borrow::ToOwned::to_owned("PriceChange"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Event {
-                            name: ::std::borrow::ToOwned::to_owned("PriceChange"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("price"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    indexed: false,
-                                },
-                            ],
-                            anonymous: false,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Event {
+                        name: ::std::borrow::ToOwned::to_owned("PriceChange"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::EventParam {
+                            name: ::std::borrow::ToOwned::to_owned("price"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                            indexed: false,
+                        },],
+                        anonymous: false,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("Swap"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Event {
-                            name: ::std::borrow::ToOwned::to_owned("Swap"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("tokenIn"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    indexed: false,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("tokenOut"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    indexed: false,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("amountIn"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    indexed: false,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("amountOut"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    indexed: false,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("to"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    indexed: false,
-                                },
-                            ],
-                            anonymous: false,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Event {
+                        name: ::std::borrow::ToOwned::to_owned("Swap"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("tokenIn"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                indexed: false,
+                            },
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("tokenOut"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                indexed: false,
+                            },
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("amountIn"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                indexed: false,
+                            },
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("amountOut"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                indexed: false,
+                            },
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("to"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                indexed: false,
+                            },
+                        ],
+                        anonymous: false,
+                    },],
                 ),
             ]),
             errors: ::std::collections::BTreeMap::new(),
@@ -238,22 +198,19 @@ pub mod liquid_exchange {
             fallback: false,
         }
     }
-    ///The parsed JSON ABI of the contract.
-    pub static LIQUIDEXCHANGE_ABI: ::ethers::contract::Lazy<::ethers::core::abi::Abi> = ::ethers::contract::Lazy::new(
-        __abi,
-    );
+    /// The parsed JSON ABI of the contract.
+    pub static LIQUIDEXCHANGE_ABI: ::ethers::contract::Lazy<::ethers::core::abi::Abi> =
+        ::ethers::contract::Lazy::new(__abi);
     #[rustfmt::skip]
     const __BYTECODE: &[u8] = b"`\x80`@\x90\x80\x82R4a\x01\x06WP\x80Q`\x1Fa\x07\x9C8\x81\x90\x03\x91\x82\x01`\x1F\x19\x16\x83\x01\x91`\x01`\x01`@\x1B\x03\x83\x11\x84\x84\x10\x17a\0\xF0W\x80\x84\x92``\x94\x87R\x839\x81\x01\x03\x12a\0\xA1Wa\0O\x81a\x01SV[\x90\x82a\0]` \x83\x01a\x01SV[\x91\x01Q\x91`\x01\x80`\xA0\x1B\x03\x19\x913\x83`\0T\x16\x17`\0U`\x01\x80`\xA0\x1B\x03\x80\x92\x16\x83`\x01T\x16\x17`\x01U\x16\x90`\x02T\x16\x17`\x02U`\x03UQa\x06/\x90\x81a\x01m\x829\xF3[\x81QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x90\xFD[cNH{q`\xE0\x1B`\0R`A`\x04R`$`\0\xFD[bF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD[Q\x90`\x01`\x01`\xA0\x1B\x03\x82\x16\x82\x03a\x01gWV[`\0\x80\xFD\xFE`\x80`@R`\x046\x10a\x04fW`\x005`\xE0\x1C\x80c; IH\x14a\0lW\x80c\x91\xB7\xF5\xED\x14a\0gW\x80c\xA05\xB1\xFE\x14a\0bW\x80c\xD0\x04\xF0\xF7\x14a\0]W\x80c\xD0\xC4r\xEC\x14a\0XWc\xF8Q\xA4@\x03a\x04fWa\x04=V[a\x04\x14V[a\x02\x04V[a\x01\xE6V[a\x01:V[4a\0\x9AW`\x006`\x03\x19\x01\x12a\0\x95W`\x01T`@Q`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x81R` \x90\xF3[a\0\xEAV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x90\xFD[4a\x01\xE1W` 6`\x03\x19\x01\x12a\0\x95W`\0T`\x045\x90`\x01`\x01`\xA0\x1B\x03\x163\x03a\x01\x92W` \x81\x7F\xF3G\xEE\x99P;\xF1\x9C\x02\x8B\xD6\xB1\x8F<gn\x82\xA9\xBB[+\xB5\"Z\xEB\xE0\xFDb\xFDj\r\x19\x92`\x03U`@Q\x90\x81R\xA1\0[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`!`$\x82\x01R\x7FOnly admin can call this functio`D\x82\x01R`7`\xF9\x1B`d\x82\x01R`\x84\x90\xFD[a\0\x9AV[4a\x01\xE1W`\x006`\x03\x19\x01\x12a\0\x95W` `\x03T`@Q\x90\x81R\xF3[4a\x01\xE1W`@6`\x03\x19\x01\x12a\0\x95W`\x045`\x01`\x01`\xA0\x1B\x03\x81\x81\x16\x91\x82\x81\x03a\x04\x0FW`\x01T`$5\x92\x90`\x01`\x01`\xA0\x1B\x03\x16\x80\x82\x16\x85\x03a\x03\xB5WP`\x02T`\x01`\x01`\xA0\x1B\x03\x16\x91a\x02_`\x03T\x85a\x05\xB6V[\x91[\x85;\x15a\x03\x93W`@Qc#\xB8r\xDD`\xE0\x1B\x81R3`\x04\x82\x01R0`$\x82\x01R`D\x81\x01\x86\x90R` \x96\x87\x90\x82\x90`d\x90\x82\x90`\0\x90Z\xF1\x80\x15a\x03\x8EWa\x02\xB1\x91`\0\x91a\x03\x98W[Pa\x05xV[\x83\x16\x91\x82;\x15a\x03\x93W`@Qc\xA9\x05\x9C\xBB`\xE0\x1B\x81R3`\x04\x82\x01R`$\x81\x01\x82\x90R\x92\x86\x90\x84\x90`D\x90\x82\x90`\0\x90Z\xF1\x95\x86\x15a\x03\x8EW\x7F\xB3\x9C\x9B\xC4?\x81\x1E\x1A|\xE1Y\xC5\xF1GE\x8F\xDB\x80&k\xF2<\x172 \x131n'\xE0\x86\xD0\x96a\x03\\\x94a\x03$\x92`\0\x92a\x03aW[PPa\x05xV[`@\x80Q`\x01`\x01`\xA0\x1B\x03\x93\x84\x16\x81R\x92\x90\x94\x16` \x83\x01R\x92\x81\x01\x93\x90\x93R``\x83\x01\x91\x90\x91R3`\x80\x83\x01R\x81\x90`\xA0\x82\x01\x90V[\x03\x90\xA1\0[a\x03\x80\x92P\x80=\x10a\x03\x87W[a\x03x\x81\x83a\x05\x1CV[\x81\x01\x90a\x05TV[8\x80a\x03\x1DV[P=a\x03nV[a\x05lV[a\x04\xC9V[a\x03\xAF\x91P\x88=\x8A\x11a\x03\x87Wa\x03x\x81\x83a\x05\x1CV[8a\x02\xABV[`\x02T`\x01`\x01`\xA0\x1B\x03\x16\x85\x03a\x03\xDAW\x91a\x03\xD4`\x03T\x85a\x05\xD7V[\x91a\x02aV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\r`$\x82\x01Rl$\xB7;0\xB64\xB2\x10:7\xB5\xB2\xB7`\x99\x1B`D\x82\x01R`d\x90\xFD[`\0\x80\xFD[4a\x01\xE1W`\x006`\x03\x19\x01\x12a\0\x95W`\x02T`@Q`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x81R` \x90\xF3[4a\x01\xE1W`\x006`\x03\x19\x01\x12a\0\x95W`\0T`@Q`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x81R` \x90\xF3[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01Rtnor receive functions`X\x1B`d\x82\x01R`\x84\x90\xFD[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`%`$\x82\x01R\x7FTarget contract does not contain`D\x82\x01Rd code`\xD8\x1B`d\x82\x01R`\x84\x90\xFD[\x90`\x1F\x80\x19\x91\x01\x16\x81\x01\x90\x81\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11\x17a\x05>W`@RV[cNH{q`\xE0\x1B`\0R`A`\x04R`$`\0\xFD[\x90\x81` \x91\x03\x12a\0\x95WQ\x80\x15\x15\x81\x03a\x04\x0FW\x90V[`@Q=`\0\x82>=\x90\xFD[\x15a\x05\x7FWV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x0F`$\x82\x01Rn\x15\x1C\x98[\x9C\xD9\x99\\\x88\x19\x98Z[\x19Y`\x8A\x1B`D\x82\x01R`d\x90\xFD[\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17`\x01\x16\x15a\x04\x0FWg\r\xE0\xB6\xB3\xA7d\0\0\x90\x04\x90V[g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17\x82\x15\x15\x16\x15a\x04\x0FW\x04\x90V\xFE\xA2dipfsX\"\x12 \x7FZa7\xA3\n\xFC\x17\xC46Q\xAA\xF0s\x8B\xCB|c0\x04\xA2_k\xF2k\xBD\xB8n*\xDC\xD7\xFFdsolcC\0\x08\x13\x003";
     /// The bytecode of the contract.
-    pub static LIQUIDEXCHANGE_BYTECODE: ::ethers::core::types::Bytes = ::ethers::core::types::Bytes::from_static(
-        __BYTECODE,
-    );
+    pub static LIQUIDEXCHANGE_BYTECODE: ::ethers::core::types::Bytes =
+        ::ethers::core::types::Bytes::from_static(__BYTECODE);
     #[rustfmt::skip]
     const __DEPLOYED_BYTECODE: &[u8] = b"`\x80`@R`\x046\x10a\x04fW`\x005`\xE0\x1C\x80c; IH\x14a\0lW\x80c\x91\xB7\xF5\xED\x14a\0gW\x80c\xA05\xB1\xFE\x14a\0bW\x80c\xD0\x04\xF0\xF7\x14a\0]W\x80c\xD0\xC4r\xEC\x14a\0XWc\xF8Q\xA4@\x03a\x04fWa\x04=V[a\x04\x14V[a\x02\x04V[a\x01\xE6V[a\x01:V[4a\0\x9AW`\x006`\x03\x19\x01\x12a\0\x95W`\x01T`@Q`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x81R` \x90\xF3[a\0\xEAV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FEther sent to non-payable functi`D\x82\x01Ra7\xB7`\xF1\x1B`d\x82\x01R`\x84\x90\xFD[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\"`$\x82\x01R\x7FABI decoding: tuple data too sho`D\x82\x01Ra\x1C\x9D`\xF2\x1B`d\x82\x01R`\x84\x90\xFD[4a\x01\xE1W` 6`\x03\x19\x01\x12a\0\x95W`\0T`\x045\x90`\x01`\x01`\xA0\x1B\x03\x163\x03a\x01\x92W` \x81\x7F\xF3G\xEE\x99P;\xF1\x9C\x02\x8B\xD6\xB1\x8F<gn\x82\xA9\xBB[+\xB5\"Z\xEB\xE0\xFDb\xFDj\r\x19\x92`\x03U`@Q\x90\x81R\xA1\0[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`!`$\x82\x01R\x7FOnly admin can call this functio`D\x82\x01R`7`\xF9\x1B`d\x82\x01R`\x84\x90\xFD[a\0\x9AV[4a\x01\xE1W`\x006`\x03\x19\x01\x12a\0\x95W` `\x03T`@Q\x90\x81R\xF3[4a\x01\xE1W`@6`\x03\x19\x01\x12a\0\x95W`\x045`\x01`\x01`\xA0\x1B\x03\x81\x81\x16\x91\x82\x81\x03a\x04\x0FW`\x01T`$5\x92\x90`\x01`\x01`\xA0\x1B\x03\x16\x80\x82\x16\x85\x03a\x03\xB5WP`\x02T`\x01`\x01`\xA0\x1B\x03\x16\x91a\x02_`\x03T\x85a\x05\xB6V[\x91[\x85;\x15a\x03\x93W`@Qc#\xB8r\xDD`\xE0\x1B\x81R3`\x04\x82\x01R0`$\x82\x01R`D\x81\x01\x86\x90R` \x96\x87\x90\x82\x90`d\x90\x82\x90`\0\x90Z\xF1\x80\x15a\x03\x8EWa\x02\xB1\x91`\0\x91a\x03\x98W[Pa\x05xV[\x83\x16\x91\x82;\x15a\x03\x93W`@Qc\xA9\x05\x9C\xBB`\xE0\x1B\x81R3`\x04\x82\x01R`$\x81\x01\x82\x90R\x92\x86\x90\x84\x90`D\x90\x82\x90`\0\x90Z\xF1\x95\x86\x15a\x03\x8EW\x7F\xB3\x9C\x9B\xC4?\x81\x1E\x1A|\xE1Y\xC5\xF1GE\x8F\xDB\x80&k\xF2<\x172 \x131n'\xE0\x86\xD0\x96a\x03\\\x94a\x03$\x92`\0\x92a\x03aW[PPa\x05xV[`@\x80Q`\x01`\x01`\xA0\x1B\x03\x93\x84\x16\x81R\x92\x90\x94\x16` \x83\x01R\x92\x81\x01\x93\x90\x93R``\x83\x01\x91\x90\x91R3`\x80\x83\x01R\x81\x90`\xA0\x82\x01\x90V[\x03\x90\xA1\0[a\x03\x80\x92P\x80=\x10a\x03\x87W[a\x03x\x81\x83a\x05\x1CV[\x81\x01\x90a\x05TV[8\x80a\x03\x1DV[P=a\x03nV[a\x05lV[a\x04\xC9V[a\x03\xAF\x91P\x88=\x8A\x11a\x03\x87Wa\x03x\x81\x83a\x05\x1CV[8a\x02\xABV[`\x02T`\x01`\x01`\xA0\x1B\x03\x16\x85\x03a\x03\xDAW\x91a\x03\xD4`\x03T\x85a\x05\xD7V[\x91a\x02aV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\r`$\x82\x01Rl$\xB7;0\xB64\xB2\x10:7\xB5\xB2\xB7`\x99\x1B`D\x82\x01R`d\x90\xFD[`\0\x80\xFD[4a\x01\xE1W`\x006`\x03\x19\x01\x12a\0\x95W`\x02T`@Q`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x81R` \x90\xF3[4a\x01\xE1W`\x006`\x03\x19\x01\x12a\0\x95W`\0T`@Q`\x01`\x01`\xA0\x1B\x03\x90\x91\x16\x81R` \x90\xF3[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7FContract does not have fallback `D\x82\x01Rtnor receive functions`X\x1B`d\x82\x01R`\x84\x90\xFD[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`%`$\x82\x01R\x7FTarget contract does not contain`D\x82\x01Rd code`\xD8\x1B`d\x82\x01R`\x84\x90\xFD[\x90`\x1F\x80\x19\x91\x01\x16\x81\x01\x90\x81\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11\x17a\x05>W`@RV[cNH{q`\xE0\x1B`\0R`A`\x04R`$`\0\xFD[\x90\x81` \x91\x03\x12a\0\x95WQ\x80\x15\x15\x81\x03a\x04\x0FW\x90V[`@Q=`\0\x82>=\x90\xFD[\x15a\x05\x7FWV[`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x0F`$\x82\x01Rn\x15\x1C\x98[\x9C\xD9\x99\\\x88\x19\x98Z[\x19Y`\x8A\x1B`D\x82\x01R`d\x90\xFD[\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17`\x01\x16\x15a\x04\x0FWg\r\xE0\xB6\xB3\xA7d\0\0\x90\x04\x90V[g\r\xE0\xB6\xB3\xA7d\0\0\x90\x81\x81\x02\x91\x81\x83\x04\x14\x90\x15\x17\x82\x15\x15\x16\x15a\x04\x0FW\x04\x90V\xFE\xA2dipfsX\"\x12 \x7FZa7\xA3\n\xFC\x17\xC46Q\xAA\xF0s\x8B\xCB|c0\x04\xA2_k\xF2k\xBD\xB8n*\xDC\xD7\xFFdsolcC\0\x08\x13\x003";
     /// The deployed bytecode of the contract.
-    pub static LIQUIDEXCHANGE_DEPLOYED_BYTECODE: ::ethers::core::types::Bytes = ::ethers::core::types::Bytes::from_static(
-        __DEPLOYED_BYTECODE,
-    );
+    pub static LIQUIDEXCHANGE_DEPLOYED_BYTECODE: ::ethers::core::types::Bytes =
+        ::ethers::core::types::Bytes::from_static(__DEPLOYED_BYTECODE);
     pub struct LiquidExchange<M>(::ethers::contract::Contract<M>);
     impl<M> ::core::clone::Clone for LiquidExchange<M> {
         fn clone(&self) -> Self {
@@ -279,34 +236,38 @@ pub mod liquid_exchange {
         }
     }
     impl<M: ::ethers::providers::Middleware> LiquidExchange<M> {
-        /// Creates a new contract instance with the specified `ethers` client at
-        /// `address`. The contract derefs to a `ethers::Contract` object.
+        /// Creates a new contract instance with the specified `ethers` client
+        /// at `address`. The contract derefs to a `ethers::Contract`
+        /// object.
         pub fn new<T: Into<::ethers::core::types::Address>>(
             address: T,
             client: ::std::sync::Arc<M>,
         ) -> Self {
-            Self(
-                ::ethers::contract::Contract::new(
-                    address.into(),
-                    LIQUIDEXCHANGE_ABI.clone(),
-                    client,
-                ),
-            )
+            Self(::ethers::contract::Contract::new(
+                address.into(),
+                LIQUIDEXCHANGE_ABI.clone(),
+                client,
+            ))
         }
-        /// Constructs the general purpose `Deployer` instance based on the provided constructor arguments and sends it.
-        /// Returns a new instance of a deployer that returns an instance of this contract after sending the transaction
+        /// Constructs the general purpose `Deployer` instance based on the
+        /// provided constructor arguments and sends it. Returns a new
+        /// instance of a deployer that returns an instance of this contract
+        /// after sending the transaction
         ///
         /// Notes:
-        /// - If there are no constructor arguments, you should pass `()` as the argument.
+        /// - If there are no constructor arguments, you should pass `()` as the
+        ///   argument.
         /// - The default poll duration is 7 seconds.
         /// - The default number of confirmations is 1 block.
         ///
         ///
         /// # Example
         ///
-        /// Generate contract bindings with `abigen!` and deploy a new contract instance.
+        /// Generate contract bindings with `abigen!` and deploy a new contract
+        /// instance.
         ///
-        /// *Note*: this requires a `bytecode` and `abi` object in the `greeter.json` artifact.
+        /// *Note*: this requires a `bytecode` and `abi` object in the
+        /// `greeter.json` artifact.
         ///
         /// ```ignore
         /// # async fn deploy<M: ethers::providers::Middleware>(client: ::std::sync::Arc<M>) {
@@ -332,40 +293,31 @@ pub mod liquid_exchange {
             let deployer = ::ethers::contract::ContractDeployer::new(deployer);
             Ok(deployer)
         }
-        ///Calls the contract's `admin` (0xf851a440) function
+        /// Calls the contract's `admin` (0xf851a440) function
         pub fn admin(
             &self,
-        ) -> ::ethers::contract::builders::ContractCall<
-            M,
-            ::ethers::core::types::Address,
-        > {
+        ) -> ::ethers::contract::builders::ContractCall<M, ::ethers::core::types::Address> {
             self.0
                 .method_hash([248, 81, 164, 64], ())
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `arbiterTokenX` (0x3b204948) function
+        /// Calls the contract's `arbiterTokenX` (0x3b204948) function
         pub fn arbiter_token_x(
             &self,
-        ) -> ::ethers::contract::builders::ContractCall<
-            M,
-            ::ethers::core::types::Address,
-        > {
+        ) -> ::ethers::contract::builders::ContractCall<M, ::ethers::core::types::Address> {
             self.0
                 .method_hash([59, 32, 73, 72], ())
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `arbiterTokenY` (0xd0c472ec) function
+        /// Calls the contract's `arbiterTokenY` (0xd0c472ec) function
         pub fn arbiter_token_y(
             &self,
-        ) -> ::ethers::contract::builders::ContractCall<
-            M,
-            ::ethers::core::types::Address,
-        > {
+        ) -> ::ethers::contract::builders::ContractCall<M, ::ethers::core::types::Address> {
             self.0
                 .method_hash([208, 196, 114, 236], ())
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `price` (0xa035b1fe) function
+        /// Calls the contract's `price` (0xa035b1fe) function
         pub fn price(
             &self,
         ) -> ::ethers::contract::builders::ContractCall<M, ::ethers::core::types::U256> {
@@ -373,7 +325,7 @@ pub mod liquid_exchange {
                 .method_hash([160, 53, 177, 254], ())
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `setPrice` (0x91b7f5ed) function
+        /// Calls the contract's `setPrice` (0x91b7f5ed) function
         pub fn set_price(
             &self,
             price: ::ethers::core::types::U256,
@@ -382,7 +334,7 @@ pub mod liquid_exchange {
                 .method_hash([145, 183, 245, 237], price)
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `swap` (0xd004f0f7) function
+        /// Calls the contract's `swap` (0xd004f0f7) function
         pub fn swap(
             &self,
             token_in: ::ethers::core::types::Address,
@@ -392,17 +344,14 @@ pub mod liquid_exchange {
                 .method_hash([208, 4, 240, 247], (token_in, amount_in))
                 .expect("method not found (this should never happen)")
         }
-        ///Gets the contract's `PriceChange` event
+        /// Gets the contract's `PriceChange` event
         pub fn price_change_filter(
             &self,
-        ) -> ::ethers::contract::builders::Event<
-            ::std::sync::Arc<M>,
-            M,
-            PriceChangeFilter,
-        > {
+        ) -> ::ethers::contract::builders::Event<::std::sync::Arc<M>, M, PriceChangeFilter>
+        {
             self.0.event()
         }
-        ///Gets the contract's `Swap` event
+        /// Gets the contract's `Swap` event
         pub fn swap_filter(
             &self,
         ) -> ::ethers::contract::builders::Event<::std::sync::Arc<M>, M, SwapFilter> {
@@ -411,16 +360,15 @@ pub mod liquid_exchange {
         /// Returns an `Event` builder for all the events of this contract.
         pub fn events(
             &self,
-        ) -> ::ethers::contract::builders::Event<
-            ::std::sync::Arc<M>,
-            M,
-            LiquidExchangeEvents,
-        > {
-            self.0.event_with_filter(::core::default::Default::default())
+        ) -> ::ethers::contract::builders::Event<::std::sync::Arc<M>, M, LiquidExchangeEvents>
+        {
+            self.0
+                .event_with_filter(::core::default::Default::default())
         }
     }
     impl<M: ::ethers::providers::Middleware> From<::ethers::contract::Contract<M>>
-    for LiquidExchange<M> {
+        for LiquidExchange<M>
+    {
         fn from(contract: ::ethers::contract::Contract<M>) -> Self {
             Self::new(contract.address(), contract.client())
         }
@@ -435,7 +383,7 @@ pub mod liquid_exchange {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethevent(name = "PriceChange", abi = "PriceChange(uint256)")]
     pub struct PriceChangeFilter {
@@ -451,7 +399,7 @@ pub mod liquid_exchange {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethevent(name = "Swap", abi = "Swap(address,address,uint256,uint256,address)")]
     pub struct SwapFilter {
@@ -461,7 +409,7 @@ pub mod liquid_exchange {
         pub amount_out: ::ethers::core::types::U256,
         pub to: ::ethers::core::types::Address,
     }
-    ///Container type for all of the contract's events
+    /// Container type for all of the contract's events
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -470,7 +418,7 @@ pub mod liquid_exchange {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub enum LiquidExchangeEvents {
         PriceChangeFilter(PriceChangeFilter),
@@ -507,7 +455,8 @@ pub mod liquid_exchange {
             Self::SwapFilter(value)
         }
     }
-    ///Container type for all input parameters for the `admin` function with signature `admin()` and selector `0xf851a440`
+    /// Container type for all input parameters for the `admin` function with
+    /// signature `admin()` and selector `0xf851a440`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -518,11 +467,12 @@ pub mod liquid_exchange {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "admin", abi = "admin()")]
     pub struct AdminCall;
-    ///Container type for all input parameters for the `arbiterTokenX` function with signature `arbiterTokenX()` and selector `0x3b204948`
+    /// Container type for all input parameters for the `arbiterTokenX` function
+    /// with signature `arbiterTokenX()` and selector `0x3b204948`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -533,11 +483,12 @@ pub mod liquid_exchange {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "arbiterTokenX", abi = "arbiterTokenX()")]
     pub struct ArbiterTokenXCall;
-    ///Container type for all input parameters for the `arbiterTokenY` function with signature `arbiterTokenY()` and selector `0xd0c472ec`
+    /// Container type for all input parameters for the `arbiterTokenY` function
+    /// with signature `arbiterTokenY()` and selector `0xd0c472ec`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -548,11 +499,12 @@ pub mod liquid_exchange {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "arbiterTokenY", abi = "arbiterTokenY()")]
     pub struct ArbiterTokenYCall;
-    ///Container type for all input parameters for the `price` function with signature `price()` and selector `0xa035b1fe`
+    /// Container type for all input parameters for the `price` function with
+    /// signature `price()` and selector `0xa035b1fe`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -563,11 +515,12 @@ pub mod liquid_exchange {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "price", abi = "price()")]
     pub struct PriceCall;
-    ///Container type for all input parameters for the `setPrice` function with signature `setPrice(uint256)` and selector `0x91b7f5ed`
+    /// Container type for all input parameters for the `setPrice` function with
+    /// signature `setPrice(uint256)` and selector `0x91b7f5ed`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -578,13 +531,14 @@ pub mod liquid_exchange {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "setPrice", abi = "setPrice(uint256)")]
     pub struct SetPriceCall {
         pub price: ::ethers::core::types::U256,
     }
-    ///Container type for all input parameters for the `swap` function with signature `swap(address,uint256)` and selector `0xd004f0f7`
+    /// Container type for all input parameters for the `swap` function with
+    /// signature `swap(address,uint256)` and selector `0xd004f0f7`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -595,14 +549,14 @@ pub mod liquid_exchange {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "swap", abi = "swap(address,uint256)")]
     pub struct SwapCall {
         pub token_in: ::ethers::core::types::Address,
         pub amount_in: ::ethers::core::types::U256,
     }
-    ///Container type for all of the contract's call
+    /// Container type for all of the contract's call
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -611,7 +565,7 @@ pub mod liquid_exchange {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub enum LiquidExchangeCalls {
         Admin(AdminCall),
@@ -626,34 +580,24 @@ pub mod liquid_exchange {
             data: impl AsRef<[u8]>,
         ) -> ::core::result::Result<Self, ::ethers::core::abi::AbiError> {
             let data = data.as_ref();
-            if let Ok(decoded) = <AdminCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <AdminCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Admin(decoded));
             }
-            if let Ok(decoded) = <ArbiterTokenXCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <ArbiterTokenXCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::ArbiterTokenX(decoded));
             }
-            if let Ok(decoded) = <ArbiterTokenYCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <ArbiterTokenYCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::ArbiterTokenY(decoded));
             }
-            if let Ok(decoded) = <PriceCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <PriceCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Price(decoded));
             }
-            if let Ok(decoded) = <SetPriceCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <SetPriceCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::SetPrice(decoded));
             }
-            if let Ok(decoded) = <SwapCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded) = <SwapCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Swap(decoded));
             }
             Err(::ethers::core::abi::Error::InvalidData.into())
@@ -663,16 +607,10 @@ pub mod liquid_exchange {
         fn encode(self) -> Vec<u8> {
             match self {
                 Self::Admin(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::ArbiterTokenX(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::ArbiterTokenY(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                Self::ArbiterTokenX(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::ArbiterTokenY(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Price(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::SetPrice(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                Self::SetPrice(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Swap(element) => ::ethers::core::abi::AbiEncode::encode(element),
             }
         }
@@ -719,7 +657,8 @@ pub mod liquid_exchange {
             Self::Swap(value)
         }
     }
-    ///Container type for all return fields from the `admin` function with signature `admin()` and selector `0xf851a440`
+    /// Container type for all return fields from the `admin` function with
+    /// signature `admin()` and selector `0xf851a440`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -730,10 +669,11 @@ pub mod liquid_exchange {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct AdminReturn(pub ::ethers::core::types::Address);
-    ///Container type for all return fields from the `arbiterTokenX` function with signature `arbiterTokenX()` and selector `0x3b204948`
+    /// Container type for all return fields from the `arbiterTokenX` function
+    /// with signature `arbiterTokenX()` and selector `0x3b204948`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -744,10 +684,11 @@ pub mod liquid_exchange {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct ArbiterTokenXReturn(pub ::ethers::core::types::Address);
-    ///Container type for all return fields from the `arbiterTokenY` function with signature `arbiterTokenY()` and selector `0xd0c472ec`
+    /// Container type for all return fields from the `arbiterTokenY` function
+    /// with signature `arbiterTokenY()` and selector `0xd0c472ec`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -758,10 +699,11 @@ pub mod liquid_exchange {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct ArbiterTokenYReturn(pub ::ethers::core::types::Address);
-    ///Container type for all return fields from the `price` function with signature `price()` and selector `0xa035b1fe`
+    /// Container type for all return fields from the `price` function with
+    /// signature `price()` and selector `0xa035b1fe`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -772,7 +714,7 @@ pub mod liquid_exchange {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct PriceReturn(pub ::ethers::core::types::U256);
 }


### PR DESCRIPTION
**Give an overview of the tasks completed**
Places the `serde::Serialize` and `serde:Deserialize` traits on all structs/enums in Arbiter's native contract bindings.

**Link to issue(s) that this PR closes**
Closes #503 