### PR TITLE
manifest for publishing derive

### DIFF
--- a/arbiter-derive/Cargo.toml
+++ b/arbiter-derive/Cargo.toml
@@ -2,6 +2,11 @@
 name = "arbiter-derive"
 version = "0.1.0"
 edition = "2021"
+authors = ["Waylon Jepsen <waylonjepsen1@gmail.com>", "Colin Roberts <colin@autoparallel.xyz>"]
+description = "proc-macro for arbiter"
+license = "Apache-2.0"
+keywords = ["ethereum", "evm", "emulator", "testing", "smart-contracts"]
+readme = "../README.md"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
This changes the manifest for our proc-macros to be published to crates.io