### PR TITLE
bug fix: use rustc version 1.71 rather than latest stable version for tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,15 +10,14 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
-    env:
-      ETH_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/Lc7oIGYeL_QvInzI0Wiu_pOZZDEKBrdf
     steps:
       - uses: actions/checkout@v3
 
       - name: install rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.71.0
+          override: true
 
       - name: test
         run: cargo test --all --all-features

--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ We hope to improve our API to allow the end user to be able to interface with th
 
 Please let us know if you find any issues with these benchmarks or if you have any suggestions on how to improve them!
 
+## Testing
+
+If you contribute please write tests for any new code you write, To run the tests, you can run:
+
+```bash
+cargo test --all --all-features
+```
 
 ## Contributing
 

--- a/arbiter-core/src/tests/middleware_instructions.rs
+++ b/arbiter-core/src/tests/middleware_instructions.rs
@@ -166,8 +166,6 @@ async fn filter_address() {
     assert!(!event_two.data.is_empty());
 
     // check that the address_watcher has not received any events
-
-    // Set a timeout for waiting for an event from the address_watcher
     let mut ctx = Context::from_waker(futures::task::noop_waker_ref());
     let poll_result = Pin::new(&mut address_watcher).poll_next(&mut ctx);
     match poll_result {

--- a/arbiter-core/src/tests/middleware_instructions.rs
+++ b/arbiter-core/src/tests/middleware_instructions.rs
@@ -166,6 +166,8 @@ async fn filter_address() {
     assert!(!event_two.data.is_empty());
 
     // check that the address_watcher has not received any events
+
+    // Set a timeout for waiting for an event from the address_watcher
     let mut ctx = Context::from_waker(futures::task::noop_waker_ref());
     let poll_result = Pin::new(&mut address_watcher).poll_next(&mut ctx);
     match poll_result {


### PR DESCRIPTION
Closes #498 by running tests with rust version 1.71 
