### PR TITLE
fix(#521): filterwatcher `recv`

### DIFF
--- a/arbiter-core/Cargo.toml
+++ b/arbiter-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arbiter-core"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 authors = ["Waylon Jepsen <waylonjepsen1@gmail.com>", "Colin Roberts <colin@autoparallel.xyz>"]
 description = "Allowing smart contract developers to do simulation driven development via an EVM emulator"

--- a/arbiter-core/src/middleware.rs
+++ b/arbiter-core/src/middleware.rs
@@ -863,7 +863,7 @@ impl JsonRpcClient for Connection {
                         ))?;
                 let mut logs = vec![];
                 let filtered_params = FilteredParams::new(Some(filter_receiver.filter.clone()));
-                if let Ok(received_logs) = filter_receiver.receiver.recv() {
+                if let Ok(received_logs) = filter_receiver.receiver.try_recv() {
                     let ethers_logs = revm_logs_to_ethers_logs(received_logs);
                     for log in ethers_logs {
                         if filtered_params.filter_address(&log)

--- a/arbiter-core/src/tests/mod.rs
+++ b/arbiter-core/src/tests/mod.rs
@@ -8,15 +8,9 @@ mod environment_control;
 mod management;
 mod middleware_instructions;
 
-use std::{
-    pin::Pin,
-    str::FromStr,
-    sync::Arc,
-    task::{Context, Poll},
-};
+use std::{str::FromStr, sync::Arc};
 
 use anyhow::Result;
-use assert_matches::assert_matches;
 use ethers::{
     prelude::{
         k256::sha2::{Digest, Sha256},
@@ -24,7 +18,7 @@ use ethers::{
     },
     types::{Address, Filter, ValueOrArray, U256},
 };
-use futures::{Stream, StreamExt};
+use futures::StreamExt;
 
 use crate::{
     bindings::{arbiter_math::*, arbiter_token::*, liquid_exchange::LiquidExchange},


### PR DESCRIPTION
**Give an overview of the tasks completed**
Replace the `recv()` with `try_recv()` in the `FilterWatcher` implementation in `RevmMiddleware`. This creates a non-blocking future. As a bonus, this allows for a timeout in the filter watcher tests so we can remove the odd way we checked it now.

**Link to issue(s) that this PR closes**
Closes #521
