### PR TITLE
Feat bind for chosen contracts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["benches"]
 # Package configuration
 [package]
 name = "arbiter"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 authors = ["Waylon Jepsen <waylonjepsen1@gmail.com>", "Colin Roberts <colin@autoparallel.xyz>"]
 description = "Allowing smart contract developers to do simulation driven development via an EVM emulator"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ thiserror = "1.0.40"
 # Dependencies for the test build and development
 [dev-dependencies]
 assert_cmd = "2.0.11"
+tempfile = "3.8.0"
 
 # Release profile
 [profile.release]
@@ -45,3 +46,5 @@ lto = true
 # The Rust compiler splits your crate into multiple codegen units to parallelize (and thus speed up) compilation but at the cost of optimization. 
 # This setting tells the compiler to use only one codegen unit, which will slow down compilation but improve optimization.
 codegen-units = 1
+
+

--- a/bin/bind.rs
+++ b/bin/bind.rs
@@ -34,7 +34,7 @@ pub(crate) fn forge_bind() -> std::io::Result<()> {
         .arg("--module")
         .arg("--overwrite")
         .output()?;
-    let mut contracts = collect_contract_list(Path::new("contracts"))?;
+    let project_contracts = collect_contract_list(Path::new("contracts"))?;
     if output.status.success() {
         let output_str = String::from_utf8_lossy(&output.stdout);
         println!("Command output: {}", output_str);
@@ -48,19 +48,20 @@ pub(crate) fn forge_bind() -> std::io::Result<()> {
         ));
     }
 
-    // Define path to `lib` directory
+    let src_binding_dir = Path::new("src/bindings");
+    remove_unneeded_contracts(src_binding_dir, project_contracts)?;
+
     let lib_dir = Path::new("lib");
-    let mut list2 = bindings_for_submodules(lib_dir)?;
-    contracts.append(&mut list2);
-    println!("Contract List: {:?}", contracts);
-    remove_unneeded_contracts(contracts)?;
+    let (output_path, sub_module_contracts) = bindings_for_submodules(lib_dir)?;
+    println!("submodule contracts: {:?}", sub_module_contracts);
+    remove_unneeded_contracts(Path::new(&output_path), sub_module_contracts)?;
 
     Ok(())
 }
 
-fn bindings_for_submodules(dir: &Path) -> io::Result<Vec<String>> {
+fn bindings_for_submodules(dir: &Path) -> io::Result<(String, Vec<String>)> {
     let mut contracts_to_generate = Vec::new(); // to keep track of contracts we're generating bindings for
-
+    let mut output_path = String::new();
     if dir.is_dir() {
         // Iterate through entries in the directory
         for entry in fs::read_dir(dir)? {
@@ -75,7 +76,7 @@ fn bindings_for_submodules(dir: &Path) -> io::Result<Vec<String>> {
                 env::set_current_dir(&path)?;
 
                 let submodule_name = path.file_name().unwrap().to_str().unwrap(); // Assuming file_name() is not None and is valid UTF-8
-                let output_path = format!("../../src/{}_bindings/", submodule_name);
+                output_path = format!("../../src/{}_bindings/", submodule_name);
 
                 let output = Command::new("forge")
                     .arg("bind")
@@ -102,14 +103,31 @@ fn bindings_for_submodules(dir: &Path) -> io::Result<Vec<String>> {
             }
         }
     }
-    Ok(contracts_to_generate)
+    Ok((output_path, contracts_to_generate))
 }
 
 fn collect_contract_list(dir: &Path) -> io::Result<Vec<String>> {
     let mut contract_list = Vec::new();
-
+    contract_list.push("shared_types".to_string());
     if dir.is_dir() {
-        for entry in fs::read_dir(dir)? {
+        let dir_name = dir.file_name().unwrap().to_str().unwrap(); // Assuming file_name() is not None and is valid UTF-8
+
+        let target_dir = if dir_name == "src" || dir_name == "contracts" {
+            dir.to_path_buf()
+        } else {
+            // Look inside the directory for a directory named "src" or "contracts"
+            let potential_src = dir.join("src");
+            let potential_contracts = dir.join("contracts");
+            if potential_src.is_dir() {
+                potential_src
+            } else if potential_contracts.is_dir() {
+                potential_contracts
+            } else {
+                return Ok(Vec::new()); // No valid contract directory found
+            }
+        };
+
+        for entry in fs::read_dir(target_dir)? {
             let entry = entry?;
             let path = entry.path();
 
@@ -117,7 +135,8 @@ fn collect_contract_list(dir: &Path) -> io::Result<Vec<String>> {
                 let filename = path.file_stem().unwrap().to_str().unwrap();
 
                 if !filename.starts_with('I') {
-                    contract_list.push(filename.to_string().to_lowercase());
+                    let snake_case_name = camel_to_snake_case(filename);
+                    contract_list.push(snake_case_name);
                 }
             }
         }
@@ -126,11 +145,12 @@ fn collect_contract_list(dir: &Path) -> io::Result<Vec<String>> {
     Ok(contract_list)
 }
 
-fn remove_unneeded_contracts(needed_contracts: Vec<String>) -> io::Result<()> {
-    let binding_dir = Path::new("src/bindings");
-
-    if binding_dir.is_dir() {
-        for entry in fs::read_dir(binding_dir)? {
+fn remove_unneeded_contracts(
+    bindings_path: &Path,
+    needed_contracts: Vec<String>,
+) -> io::Result<()> {
+    if bindings_path.is_dir() {
+        for entry in fs::read_dir(bindings_path)? {
             let entry = entry?;
             let path = entry.path();
 
@@ -149,16 +169,17 @@ fn remove_unneeded_contracts(needed_contracts: Vec<String>) -> io::Result<()> {
             }
         }
     }
-    update_mod_file(needed_contracts)?;
+
+    update_mod_file(bindings_path, needed_contracts)?;
 
     Ok(())
 }
 
-fn update_mod_file(contracts_to_keep: Vec<String>) -> io::Result<()> {
-    let mod_path = "src/bindings/mod.rs";
+fn update_mod_file(bindings_path: &Path, contracts_to_keep: Vec<String>) -> io::Result<()> {
+    let mod_path = bindings_path.join("mod.rs");
 
     // Open the file and read its contents
-    let file = File::open(mod_path)?;
+    let file = File::open(&mod_path)?;
     let reader = BufReader::new(file);
 
     let lines: Vec<String> = reader
@@ -185,7 +206,112 @@ fn update_mod_file(contracts_to_keep: Vec<String>) -> io::Result<()> {
         .collect();
 
     // Write the new lines back to the mod.rs
-    write(mod_path, lines.join("\n"))?;
+    write(&mod_path, lines.join("\n"))?;
 
     Ok(())
+}
+
+fn camel_to_snake_case(s: &str) -> String {
+    let mut snake_case = String::new();
+    let chars: Vec<char> = s.chars().collect();
+
+    for (i, ch) in chars.iter().enumerate() {
+        if ch.is_uppercase() && i != 0 {
+            snake_case.push('_');
+        }
+        snake_case.extend(ch.to_lowercase());
+    }
+
+    snake_case
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn test_camel_to_snake_case() {
+        assert_eq!(camel_to_snake_case("PositionRenderer"), "position_renderer");
+        assert_eq!(camel_to_snake_case("Test"), "test");
+        assert_eq!(
+            camel_to_snake_case("AnotherTestExample"),
+            "another_test_example"
+        );
+    }
+
+    #[test]
+    fn test_collect_contract_list_from_contracts() {
+        // Create a temporary directory
+        let dir = tempdir().expect("Failed to create temporary directory");
+
+        // Create nested directories "src" and "contracts"
+        let contracts_dir = dir.path().join("contracts");
+        fs::create_dir(&contracts_dir).expect("Failed to create contracts directory");
+
+        // Create files in the contracts directory
+        fs::write(contracts_dir.join("ExampleContract.rs"), "").expect("Failed to write file");
+        fs::write(contracts_dir.join("AnotherTest.rs"), "").expect("Failed to write file");
+        fs::write(contracts_dir.join("ITestInterface.rs"), "").expect("Failed to write file"); // This should be ignored
+
+        // Call the function
+        let contracts = collect_contract_list(dir.path()).expect("Failed to collect contracts");
+
+        // Assert the results
+        let expected = vec!["shared_types", "example_contract", "another_test"];
+        assert_eq!(contracts, expected);
+
+        // Temp dir will be automatically cleaned up after going out of scope.
+    }
+
+    #[test]
+    fn test_collect_contract_list_from_src() {
+        // Create a temporary directory
+        let dir = tempdir().expect("Failed to create temporary directory");
+
+        // Create a nested directory "src"
+        let src_dir = dir.path().join("src");
+        fs::create_dir(&src_dir).expect("Failed to create src directory");
+
+        // Create files in the src directory
+        fs::write(src_dir.join("ExampleOne.rs"), "").expect("Failed to write file");
+        fs::write(src_dir.join("TestTwo.rs"), "").expect("Failed to write file");
+
+        // Call the function
+        let contracts = collect_contract_list(dir.path()).expect("Failed to collect contracts");
+
+        // Assert the results
+        let expected = vec!["shared_types", "test_two", "example_one"];
+        assert_eq!(contracts, expected);
+
+        // Temp dir will be automatically cleaned up after going out of scope.
+    }
+    #[test]
+    fn test_update_mod_file() {
+        // Create a temporary directory
+        let dir = tempdir().expect("Failed to create temporary directory");
+
+        // Mock a mod.rs file with some content
+        let mocked_mod_path = dir.path().join("mod.rs");
+        let content = "
+        // Some comments
+        pub mod example_contract;
+        pub mod test_contract;
+        ";
+        fs::write(&mocked_mod_path, content).expect("Failed to write mock mod.rs file");
+
+        // Call the function
+        let contracts_to_keep = vec!["example_contract".to_owned()];
+        update_mod_file(mocked_mod_path.parent().unwrap(), contracts_to_keep)
+            .expect("Failed to update mod file");
+
+        // Open the mocked mod.rs file and check its content
+        let updated_content = fs::read_to_string(&mocked_mod_path).unwrap();
+        assert!(updated_content.contains("pub mod example_contract;"));
+        assert!(!updated_content.contains("pub mod test_contract;"));
+
+        // Temp dir (and the mock mod.rs file inside it) will be automatically
+        // cleaned up after going out of scope.
+    }
 }

--- a/bin/bind.rs
+++ b/bin/bind.rs
@@ -1,5 +1,12 @@
 #![warn(missing_docs)]
-use std::{env, fs, io, path::Path, process::Command};
+use std::{
+    env, fs,
+    fs::{write, File},
+    io,
+    io::{BufRead, BufReader},
+    path::Path,
+    process::Command,
+};
 
 /// Runs the `forge` command-line tool to generate bindings.
 ///
@@ -27,7 +34,7 @@ pub(crate) fn forge_bind() -> std::io::Result<()> {
         .arg("--module")
         .arg("--overwrite")
         .output()?;
-
+    let mut contracts = collect_contract_list(Path::new("contracts"))?;
     if output.status.success() {
         let output_str = String::from_utf8_lossy(&output.stdout);
         println!("Command output: {}", output_str);
@@ -43,12 +50,17 @@ pub(crate) fn forge_bind() -> std::io::Result<()> {
 
     // Define path to `lib` directory
     let lib_dir = Path::new("lib");
-    bindings_for_submodules(lib_dir)?;
+    let mut list2 = bindings_for_submodules(lib_dir)?;
+    contracts.append(&mut list2);
+    println!("Contract List: {:?}", contracts);
+    remove_unneeded_contracts(contracts)?;
 
     Ok(())
 }
 
-fn bindings_for_submodules(dir: &Path) -> io::Result<()> {
+fn bindings_for_submodules(dir: &Path) -> io::Result<Vec<String>> {
+    let mut contracts_to_generate = Vec::new(); // to keep track of contracts we're generating bindings for
+
     if dir.is_dir() {
         // Iterate through entries in the directory
         for entry in fs::read_dir(dir)? {
@@ -57,6 +69,7 @@ fn bindings_for_submodules(dir: &Path) -> io::Result<()> {
 
             // If the entry is a directory, run command inside it
             if path.is_dir() && path.file_name().unwrap_or_default() != "forge-std" {
+                contracts_to_generate = collect_contract_list(&path)?;
                 println!("Generating bindings for submodule: {:?}...", path);
 
                 env::set_current_dir(&path)?;
@@ -89,5 +102,90 @@ fn bindings_for_submodules(dir: &Path) -> io::Result<()> {
             }
         }
     }
+    Ok(contracts_to_generate)
+}
+
+fn collect_contract_list(dir: &Path) -> io::Result<Vec<String>> {
+    let mut contract_list = Vec::new();
+
+    if dir.is_dir() {
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            if path.is_file() {
+                let filename = path.file_stem().unwrap().to_str().unwrap();
+
+                if !filename.starts_with('I') {
+                    contract_list.push(filename.to_string().to_lowercase());
+                }
+            }
+        }
+    }
+
+    Ok(contract_list)
+}
+
+fn remove_unneeded_contracts(needed_contracts: Vec<String>) -> io::Result<()> {
+    let binding_dir = Path::new("src/bindings");
+
+    if binding_dir.is_dir() {
+        for entry in fs::read_dir(binding_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            if path.is_file() {
+                let filename = path.file_stem().unwrap().to_str().unwrap().to_lowercase();
+
+                // Skip if the file is `mod.rs`
+                if filename == "mod" {
+                    continue;
+                }
+
+                if !needed_contracts.contains(&filename) {
+                    println!("Removing contract binding: {}", path.display());
+                    fs::remove_file(path)?;
+                }
+            }
+        }
+    }
+    update_mod_file(needed_contracts)?;
+
+    Ok(())
+}
+
+fn update_mod_file(contracts_to_keep: Vec<String>) -> io::Result<()> {
+    let mod_path = "src/bindings/mod.rs";
+
+    // Open the file and read its contents
+    let file = File::open(mod_path)?;
+    let reader = BufReader::new(file);
+
+    let lines: Vec<String> = reader
+        .lines()
+        .map_while(Result::ok)
+        .filter(|line| {
+            // Keep the line if it's a comment
+            if line.trim().starts_with("//") || line.trim().starts_with('#') {
+                return true;
+            }
+
+            // Check if the line is a module declaration and if it's one of the contracts we
+            // want to keep
+            if let Some(contract_name) = line
+                .trim()
+                .strip_prefix("pub mod ")
+                .and_then(|s| s.strip_suffix(';'))
+            {
+                return contracts_to_keep.contains(&contract_name.to_string());
+            }
+
+            true
+        })
+        .collect();
+
+    // Write the new lines back to the mod.rs
+    write(mod_path, lines.join("\n"))?;
+
     Ok(())
 }


### PR DESCRIPTION
Closes #465 

This PR filters out bindings for any interface, test, or other ancillary contracts while ensuring the shared types are still generated. 

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request updates the version of the "arbiter" package to 0.3.4 and adds a new dependency "tempfile" with version 3.8.0 to the dev-dependencies section in the Cargo.toml file. It also modifies the code to use only one codegen unit, collect a list of contracts from a specific directory, remove unnecessary contracts, and generate bindings for submodules.
> 
> ## What changed
> - Updated the version of the "arbiter" package to 0.3.4 in the Cargo.toml file.
> - Added a new dependency "tempfile" with version 3.8.0 to the dev-dependencies section in the Cargo.toml file.
> - Modified the code to use only one codegen unit.
> - Modified the code to collect a list of contracts from a specific directory.
> - Modified the code to remove unnecessary contracts.
> - Modified the code to generate bindings for submodules.
> 
> ## How to test
> 1. Execute the code snippet that checks if the output of a command is successful and prints the output if it is.
> 2. Execute the code snippet that removes unnecessary contracts and generates bindings for submodules.
> 3. Execute the code snippet that generates bindings for submodules in a given directory.
> 4. Execute the code snippet that sets the current directory to a given path and generates an output path based on the file name of the path.
> 5. Execute the code snippet that checks if the directory name is "src" or "contracts" and sets the target directory accordingly.
> 6. Execute the code snippet that checks if a filename does not start with 'I', converts the filename from camel case to snake case, and adds it to a list of contracts.
> 7. Execute the code snippet that removes any contracts that are not needed from a given directory.
> 8. Execute the code snippet that checks if certain contracts are needed and removes any contract bindings that are not needed.
> 9. Execute the code snippet that modifies a mod.rs file by removing certain lines based on specific conditions.
> 10. Execute the code snippet that converts a string from camel case to snake case.
> 11. Execute the code snippet that creates a temporary directory and nested directories within it.
> 12. Execute the code snippet that creates a temporary directory, creates files within the "src" directory, and collects a list of contracts from the directory.
> 13. Execute the code snippet that creates a temporary directory, creates files within the "src" directory, and updates the mod.rs file based on a list of contracts to keep.
> 14. Execute the code snippet that updates a mod file by removing certain contracts and adding others.
> 15. Check the content of the updated mod file to ensure that the removed contracts are no longer present and the added contracts are included.
> 
> ## Why make this change
> - Using only one codegen unit will slow down compilation but improve optimization.
> - Collecting a list of contracts from a specific directory allows for more flexibility in generating bindings.
> - Removing unnecessary contracts improves code cleanliness and reduces unnecessary overhead.
> - Generating bindings for submodules ensures that all necessary bindings are available for use.
</details>