### PR TITLE
auto run + contructor return arc

### DIFF
--- a/arbiter-core/Cargo.toml
+++ b/arbiter-core/Cargo.toml
@@ -17,8 +17,8 @@ revm = { version = "=3.4.0", features = ["serde"] }
 
 # Serialization
 bytes = { version = "=1.5.0" }
-serde = { version = "1.0.163", features = ["derive"] }
-serde_json = { version = "1.0.96" }
+serde = { version = "=1.0.163", features = ["derive"] }
+serde_json = { version = "=1.0.96" }
 
 # Concurrency/async
 tokio = { version = "=1.32.0", features = ["macros", "full"] }
@@ -26,7 +26,7 @@ async-trait =  { version = "=0.1.73" }
 crossbeam-channel =  { version = "=0.5.8" }
 atomic_enum = { version = "=0.2.0" }
 futures-timer = { version = "=3.0.2" }
-futures-locks = { version = "0.7.1" }
+futures-locks = { version = "=0.7.1" }
 
 # Randomness
 rand =  { version = "=0.8.5" }

--- a/arbiter-core/Cargo.toml
+++ b/arbiter-core/Cargo.toml
@@ -26,6 +26,7 @@ async-trait =  { version = "=0.1.73" }
 crossbeam-channel =  { version = "=0.5.8" }
 atomic_enum = { version = "=0.2.0" }
 futures-timer = { version = "=3.0.2" }
+futures-locks = { version = "0.7.1" }
 
 # Randomness
 rand =  { version = "=0.8.5" }

--- a/arbiter-core/benches/bench.rs
+++ b/arbiter-core/benches/bench.rs
@@ -155,7 +155,7 @@ fn arbiter_startup() -> Result<(Environment, Arc<RevmMiddleware>)> {
     let mut environment = EnvironmentBuilder::new().build();
     environment.run();
 
-    let client = Arc::new(RevmMiddleware::new(&environment, Some("name"))?);
+    let client = RevmMiddleware::new(&environment, Some("name"))?;
     Ok((environment, client))
 }
 

--- a/arbiter-core/src/environment/builder.rs
+++ b/arbiter-core/src/environment/builder.rs
@@ -129,7 +129,9 @@ impl EnvironmentBuilder {
     /// This consumes the `EnvironmentBuilder` and returns an [`Environment`].
     pub fn build(self) -> Environment {
         let parameters = self.into_environment_parameters();
-        Environment::new(parameters)
+        let mut env = Environment::new(parameters);
+        env.run();
+        env
     }
 }
 

--- a/arbiter-core/src/environment/mod.rs
+++ b/arbiter-core/src/environment/mod.rs
@@ -171,7 +171,7 @@ impl Environment {
     pub(crate) fn new(environment_parameters: EnvironmentParameters) -> Self {
         // Initialize the EVM used
         let mut evm = EVM::new();
-        let db = CacheDB::new(EmptyDB {});
+        let db = CacheDB::new(EmptyDB::new());
         evm.database(db);
 
         // Choose extra large code size and gas limit

--- a/arbiter-core/src/environment/tests.rs
+++ b/arbiter-core/src/environment/tests.rs
@@ -1,6 +1,13 @@
 use super::*;
+use crate::middleware::RevmMiddleware;
 
 pub(crate) const TEST_ENV_LABEL: &str = "test";
+
+#[test]
+fn auto_start_on_build() {
+    let environment = EnvironmentBuilder::new().build();
+    let _client = RevmMiddleware::new(&environment, Some(TEST_ENV_LABEL)).unwrap();
+}
 
 #[test]
 fn new_with_builder() {
@@ -54,8 +61,7 @@ fn run() {
         block_settings: BlockSettings::UserControlled,
         gas_settings: GasSettings::UserControlled,
     };
-    let mut environment = Environment::new(params);
-    environment.run();
+    Environment::new(params);
 }
 
 #[test]

--- a/arbiter-core/src/middleware/mod.rs
+++ b/arbiter-core/src/middleware/mod.rs
@@ -121,7 +121,7 @@ impl RevmMiddleware {
     pub fn new(
         environment: &Environment,
         seed_and_label: Option<&str>,
-    ) -> Result<Self, RevmMiddlewareError> {
+    ) -> Result<Arc<Self>, RevmMiddlewareError> {
         let instruction_sender = &Arc::clone(&environment.socket.instruction_sender);
         let (outcome_sender, outcome_receiver) = crossbeam_channel::unbounded();
         let wallet = if let Some(seed) = seed_and_label {
@@ -150,7 +150,7 @@ impl RevmMiddleware {
             filter_receivers: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         };
         let provider = Provider::new(connection);
-        Ok(Self { wallet, provider })
+        Ok(Arc::new(Self { wallet, provider }))
     }
 
     /// Allows the user to update the block number and timestamp of the

--- a/arbiter-core/src/tests/clients.rs
+++ b/arbiter-core/src/tests/clients.rs
@@ -21,8 +21,7 @@ fn multiple_signer_addresses() {
 
 #[test]
 fn signer_collision() {
-    let mut environment = builder::EnvironmentBuilder::new().build();
-    environment.run();
+    let environment = builder::EnvironmentBuilder::new().build();
     RevmMiddleware::new(&environment, Some("0")).unwrap();
     assert!(RevmMiddleware::new(&environment, Some("0")).is_err());
 }

--- a/arbiter-core/src/tests/middleware_instructions.rs
+++ b/arbiter-core/src/tests/middleware_instructions.rs
@@ -430,7 +430,7 @@ async fn test_cheatcodes_store() {
         .apply_cheatcode(Cheatcodes::Store {
             account: client.address(),
             key: ethers::types::H256::zero(),
-            value: random_value.clone(),
+            value: random_value,
         })
         .await
         .unwrap();

--- a/arbiter-core/src/tests/mod.rs
+++ b/arbiter-core/src/tests/mod.rs
@@ -55,7 +55,7 @@ pub const ARBITER_TOKEN_Y_DECIMALS: u8 = 18;
 pub const LIQUID_EXCHANGE_PRICE: f64 = 420.69;
 
 fn startup_randomly_sampled() -> Result<(Environment, Arc<RevmMiddleware>)> {
-    let mut env = builder::EnvironmentBuilder::new()
+    let env = builder::EnvironmentBuilder::new()
         .block_settings(builder::BlockSettings::RandomlySampled {
             block_rate: TEST_BLOCK_RATE,
             block_time: TEST_BLOCK_TIME,
@@ -65,24 +65,21 @@ fn startup_randomly_sampled() -> Result<(Environment, Arc<RevmMiddleware>)> {
             multiplier: TEST_GAS_MULTIPLIER,
         })
         .build();
-    env.run();
-    let client = Arc::new(RevmMiddleware::new(&env, Some(TEST_SIGNER_SEED_AND_LABEL))?);
+    let client = RevmMiddleware::new(&env, Some(TEST_SIGNER_SEED_AND_LABEL))?;
     Ok((env, client))
 }
 
 fn startup_user_controlled() -> Result<(Environment, Arc<RevmMiddleware>)> {
-    let mut env = builder::EnvironmentBuilder::new().build();
-    env.run();
-    let client = Arc::new(RevmMiddleware::new(&env, Some(TEST_SIGNER_SEED_AND_LABEL))?);
+    let env = builder::EnvironmentBuilder::new().build();
+    let client = RevmMiddleware::new(&env, Some(TEST_SIGNER_SEED_AND_LABEL))?;
     Ok((env, client))
 }
 
 fn startup_constant_gas() -> Result<(Environment, Arc<RevmMiddleware>)> {
-    let mut env = builder::EnvironmentBuilder::new()
+    let env = builder::EnvironmentBuilder::new()
         .gas_settings(builder::GasSettings::Constant(TEST_GAS_PRICE))
         .build();
-    env.run();
-    let client = Arc::new(RevmMiddleware::new(&env, Some(TEST_SIGNER_SEED_AND_LABEL))?);
+    let client = RevmMiddleware::new(&env, Some(TEST_SIGNER_SEED_AND_LABEL))?;
     Ok((env, client))
 }
 


### PR DESCRIPTION
This PR Closes #560 

It also modifies the `RevmMiddleware` Constructor to return an `Arc<RevmMiddleware>` To improve the ease of use a bit since i don't believe there is a time in which we don't do this.

This does also have passing tests, clippy, and fmt
