### PR TITLE
docs: setup and cli installation details

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ cargo run
 
 You can load or write your own smart contracts in the templates `contracts/` directory and begin writing your own simulations. 
 Arbiter treats Rust smart-contract bindings as first-class citizens. The contract bindings are generated via Foundry's `forge` command. 
-`arbiter bind` wraps `forge` with some convenience features that will generate all your bindings to src/biindings as a rust module. 
+`arbiter bind` wraps `forge` with some convenience features that will generate all your bindings to src/bindings as a rust module. 
 [Foundry](https://github.com/foundry-rs/foundry) power-users are welcome to use `forge` directly.
 
 ## Documentation

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -3,7 +3,7 @@
 - [Introduction](./introduction/introduction.md)
   - [Anomaly Detection](./introduction/anomaly_detection.md)
 - [Getting Started / Installation](./getting_started/getting_started.md)
-  - [CLI installation with cargo](./getting_started/cargo_install.md)
+  - [CLI Installation with Cargo](./getting_started/cargo_install.md)
   - [Setting up Simulations](./getting_started/simulation.md)
   - [Configuring Agents](./getting_started/agents.md)
   - [Examples](./getting_started/examples.md)

--- a/docs/src/getting_started/cargo_install.md
+++ b/docs/src/getting_started/cargo_install.md
@@ -1,1 +1,43 @@
-# CLI installation with cargo
+# CLI Installation with Cargo
+
+## Prerequisites
+The best way to build Arbiter today is from source. 
+
+Install Git, if you haven't already. There are many online guides on how to install Git on different devices, including one from [Github](https://github.com/git-guides/install-git).
+
+Before installing Arbiter, ensure that you have Rust installed. You can install and verify your Rust installation from the [official website](https://www.rust-lang.org/tools/install).
+
+The Arbiter CLI works alongside [Foundry](https://github.com/foundry-rs/foundry) and aims to provide a similar CLI interface of setting up and interacting with Arbiter projects. Install Foundry from the [official website](https://getfoundry.sh/).
+
+## Installing the Arbiter CLI
+Once you're done with the above, you can install Arbiter by cloning the repository. The local crate can then be used to install the Arbiter binary on your machine.
+
+```bash
+git clone https://github.com/primitivefinance/arbiter.git
+cargo install --path ./arbiter
+```
+
+Once this is complete, you can run `arbiter --help` to verify your installation and view the help menu.
+
+## Interacting with the Arbiter CLI
+Arbiter provides a Foundry-like CLI experience. You can initialize new projects, generate bindings and execute simulations using the CLI.
+
+To create a new Arbiter project:
+```bash
+arbiter init your-new-project
+cd your-new-project
+```
+
+This initializes a new Arbiter project with a template. You can generate the bindings again by running:
+
+```bash
+arbiter bind
+```
+
+The template is executable at this point and you can run it by running:
+
+```bash
+cargo run
+```
+
+You can load or write your own smart contracts in the templates `contracts/` directory and begin writing your own simulations. Arbiter treats Rust smart-contract bindings as first-class citizens. The contract bindings are generated via Foundry's forge command. arbiter bind wraps forge with some convenience features that will generate all your bindings to `src/bindings` as a rust module. Foundry power-users are welcome to use forge directly. You can also manage project dependencies using git submodules via `forge install`. The [Foundry book](https://book.getfoundry.sh/reference/forge/forge-install) provides further details on managing project dependencies and other features.

--- a/docs/src/getting_started/cargo_install.md
+++ b/docs/src/getting_started/cargo_install.md
@@ -1,15 +1,25 @@
 # CLI Installation with Cargo
 
 ## Prerequisites
-The best way to build Arbiter today is from source. 
-
-Install Git, if you haven't already. There are many online guides on how to install Git on different devices, including one from [Github](https://github.com/git-guides/install-git).
 
 Before installing Arbiter, ensure that you have Rust installed. You can install and verify your Rust installation from the [official website](https://www.rust-lang.org/tools/install).
 
 The Arbiter CLI works alongside [Foundry](https://github.com/foundry-rs/foundry) and aims to provide a similar CLI interface of setting up and interacting with Arbiter projects. Install Foundry from the [official website](https://getfoundry.sh/).
 
 ## Installing the Arbiter CLI
+
+### Install using Cargo
+
+Once Rust is installed, you can install Arbiter from the package registry using Cargo. To do this, just run:
+```bash
+cargo install arbiter
+```
+
+You can now run `arbiter --help` to verify your installation and view the help menu.
+
+### Building From Source
+Install Git, if you haven't already. There are many online guides on how to install Git on different devices, including one from [Github](https://github.com/git-guides/install-git).
+
 Once you're done with the above, you can install Arbiter by cloning the repository. The local crate can then be used to install the Arbiter binary on your machine.
 
 ```bash
@@ -17,7 +27,7 @@ git clone https://github.com/primitivefinance/arbiter.git
 cargo install --path ./arbiter
 ```
 
-Once this is complete, you can run `arbiter --help` to verify your installation and view the help menu.
+You can now run `arbiter --help` to verify your installation and view the help menu.
 
 ## Interacting with the Arbiter CLI
 Arbiter provides a Foundry-like CLI experience. You can initialize new projects, generate bindings and execute simulations using the CLI.


### PR DESCRIPTION
**Give an overview of the tasks completed**
* Adds docs to setup and install Arbiter CLI, building from source
* README typo fix

**Link to issue(s) that this PR closes**
Resolves #557 
