### PR TITLE
Feat/alt event capture

### DIFF
--- a/arbiter-core/src/data_collection.rs
+++ b/arbiter-core/src/data_collection.rs
@@ -1,3 +1,15 @@
+//! The `data_collection` module provides the `EventLogger` struct for logging events from the Ethereum network.
+//!
+//! The `EventLogger` struct contains a BTreeMap of events, where each event is represented by a string key and a vector of `Event` instances.
+//! It also optionally contains a path where the event logs will be stored.
+//!
+//! This module also provides the implementation of the `EventLogger` struct, including methods for constructing a new `EventLogger`, adding an event to the `EventLogger`, and writing the event logs to a file.
+//!
+//! # Type Parameters
+//!
+//! * `M` - Middleware that implements the `Middleware` trait, `std::borrow::Borrow<D>`, and has a static lifetime.
+//! * `D` - Middleware that implements the `Middleware` trait, `Debug`, `Send`, `Sync`, and has a static lifetime.
+//! * `E` - Type that implements the `EthLogDecode`, `Debug`, `Serialize` traits, and has a static lifetime.
 use std::{collections::BTreeMap, fmt::Debug};
 
 use ethers::{
@@ -9,8 +21,16 @@ use serde_json::Value;
 use tokio::io::AsyncWriteExt;
 use tracing::info;
 
-use crate::middleware::errors::RevmMiddlewareError;
-
+/// `EventLogger` is a struct that logs events from the Ethereum network.
+///
+/// It contains a BTreeMap of events, where each event is represented by a string key and a vector of `Event` instances.
+/// It also optionally contains a path where the event logs will be stored.
+///
+/// # Type Parameters
+///
+/// * `M` - Middleware that implements the `Middleware` trait, `std::borrow::Borrow<D>`, and has a static lifetime.
+/// * `D` - Middleware that implements the `Middleware` trait, `Debug`, `Send`, `Sync`, and has a static lifetime.
+/// * `E` - Type that implements the `EthLogDecode`, `Debug`, `Serialize` traits, and has a static lifetime.
 pub struct EventLogger<
     M: Middleware + std::borrow::Borrow<D> + 'static,
     D: Middleware + Debug + Send + Sync + 'static,
@@ -26,6 +46,11 @@ impl<
         E: EthLogDecode + Debug + Serialize + 'static,
     > EventLogger<M, D, E>
 {
+    /// Constructs a new `EventLogger`.
+    ///
+    /// # Returns
+    ///
+    /// A fresh `EventLogger` instance with an uninitialized events BTreeMap and no specified path.
     pub fn builder() -> Self {
         Self {
             events: BTreeMap::new(),
@@ -33,17 +58,53 @@ impl<
         }
     }
 
+    /// Adds an event to the `EventLogger`.
+    ///
+    /// # Arguments
+    ///
+    /// * `event` - The event to be added.
+    /// * `name` - The name of the event.
+    ///
+    /// # Returns
+    ///
+    /// The `EventLogger` instance with the added event.
     pub fn add<S: Into<String>>(mut self, event: Event<M, D, E>, name: S) -> Self {
         let name = name.into();
         self.events.entry(name).or_insert_with(Vec::new).push(event);
         self
     }
 
+    /// Sets the path for the `EventLogger`.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path where the event logs will be stored.
+    ///
+    /// # Returns
+    ///
+    /// The `EventLogger` instance with the specified path.
     pub fn path<S: Into<String>>(mut self, path: S) -> Self {
         self.path = Some(path.into());
         self
     }
 
+    /// Executes the `EventLogger`.
+    ///
+    /// This function starts the event logging process. It first deletes the existing events directory,
+    /// then creates a new directory for each event. For each event, it creates a new CSV file and writes
+    /// the event data into the file. If the file already exists, it appends the new data to the file.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` which is:
+    ///
+    /// * `Ok(())` if the `EventLogger` ran successfully.
+    /// * `Err(RevmMiddlewareError)` if there was an error running the `EventLogger`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if there is a problem creating the directories or files,
+    /// or writing to the files.
     pub async fn run(self) -> Result<(), RevmMiddlewareError> {
         // Delete the ./events path before kicking off the run loop
         let path = self.path.unwrap_or("./events".to_string());

--- a/arbiter-core/src/data_collection.rs
+++ b/arbiter-core/src/data_collection.rs
@@ -14,10 +14,15 @@ use std::{collections::BTreeMap, fmt::Debug};
 
 use ethers::{
     contract::{builders::Event, EthLogDecode},
-    providers::{Middleware, StreamExt as ProviderStreamExt},
+    providers::StreamExt as ProviderStreamExt,
 };
 use serde::Serialize;
+use std::sync::Arc;
+
+use crate::middleware::errors::RevmMiddlewareError;
+use crate::middleware::RevmMiddleware;
 use serde_json::Value;
+use std::env::current_dir;
 use tokio::io::AsyncWriteExt;
 use tracing::info;
 
@@ -31,21 +36,12 @@ use tracing::info;
 /// * `M` - Middleware that implements the `Middleware` trait, `std::borrow::Borrow<D>`, and has a static lifetime.
 /// * `D` - Middleware that implements the `Middleware` trait, `Debug`, `Send`, `Sync`, and has a static lifetime.
 /// * `E` - Type that implements the `EthLogDecode`, `Debug`, `Serialize` traits, and has a static lifetime.
-pub struct EventLogger<
-    M: Middleware + std::borrow::Borrow<D> + 'static,
-    D: Middleware + Debug + Send + Sync + 'static,
-    E: EthLogDecode + Debug + Serialize + 'static,
-> {
-    events: BTreeMap<String, Vec<Event<M, D, E>>>,
+pub struct EventLogger {
+    events: tokio::task::JoinSet<()>,
     path: Option<String>,
 }
 
-impl<
-        M: Middleware + std::borrow::Borrow<D>,
-        D: Middleware + Debug + Send + Sync,
-        E: EthLogDecode + Debug + Serialize + 'static,
-    > EventLogger<M, D, E>
-{
+impl EventLogger {
     /// Constructs a new `EventLogger`.
     ///
     /// # Returns
@@ -53,7 +49,7 @@ impl<
     /// A fresh `EventLogger` instance with an uninitialized events BTreeMap and no specified path.
     pub fn builder() -> Self {
         Self {
-            events: BTreeMap::new(),
+            events: tokio::task::JoinSet::new(),
             path: None,
         }
     }
@@ -68,9 +64,71 @@ impl<
     /// # Returns
     ///
     /// The `EventLogger` instance with the added event.
-    pub fn add<S: Into<String>>(mut self, event: Event<M, D, E>, name: S) -> Self {
+    pub fn add<S: Into<String>, E: EthLogDecode + Debug + Serialize + 'static>(
+        mut self,
+        event: Event<Arc<RevmMiddleware>, RevmMiddleware, E>,
+        name: S,
+    ) -> Self {
         let name = name.into();
-        self.events.entry(name).or_insert_with(Vec::new).push(event);
+        let event_dir = current_dir().unwrap().join(&self.path.clone().unwrap_or("events".into())).join(&name);
+        std::fs::create_dir_all(&event_dir).unwrap();
+        self.events.spawn(async move {
+            let mut stream = event.stream().await.unwrap();
+            let mut toggle_written_columns = false;
+            let mut files: BTreeMap<String, tokio::fs::File> = BTreeMap::new();
+            while let Some(Ok(log)) = stream.next().await {
+                let serialized = serde_json::to_string(&log).unwrap();
+                let deserialized: BTreeMap<String, Value> =
+                    serde_json::from_str(&serialized).unwrap();
+                let (key, value) = deserialized.iter().next().unwrap();
+                let file_name = event_dir.join(format!("{}.csv", key));
+                let file_key = file_name.to_str().unwrap();
+                let file_value = files.get(file_key); 
+                let file: &mut tokio::fs::File;
+                if file_value.is_none() {
+                    files.insert(file_key.into(), tokio::fs::OpenOptions::new()
+                        .write(true)
+                        .create(true)
+                        .truncate(true)
+                        .open(&file_name)
+                        .await
+                        .unwrap());
+                } 
+                file = files.get_mut(file_key).unwrap();
+
+                if toggle_written_columns {
+                    let values = value
+                        .as_object()
+                        .unwrap()
+                        .values()
+                        .map(|x| x.to_string())
+                        .collect::<Vec<String>>()
+                        .join(",");
+                    file.write_all(values.as_bytes()).await.unwrap();
+                    file.write_all("\n".as_bytes()).await.unwrap();
+                } else {
+                    toggle_written_columns = true;
+                    let columns = value
+                        .as_object()
+                        .unwrap()
+                        .keys()
+                        .map(|x| x.to_string())
+                        .collect::<Vec<String>>()
+                        .join(",");
+                    file.write_all(columns.as_bytes()).await.unwrap();
+                    file.write_all("\n".as_bytes()).await.unwrap();
+                    let values = value
+                        .as_object()
+                        .unwrap()
+                        .values()
+                        .map(|x| x.to_string())
+                        .collect::<Vec<String>>()
+                        .join(",");
+                    file.write_all(values.as_bytes()).await.unwrap();
+                }
+                continue;
+            }
+        });
         self
     }
 
@@ -105,77 +163,9 @@ impl<
     ///
     /// This function will return an error if there is a problem creating the directories or files,
     /// or writing to the files.
-    pub async fn run(self) -> Result<(), RevmMiddlewareError> {
-        // Delete the ./events path before kicking off the run loop
-        let path = self.path.unwrap_or("./events".to_string());
-        tokio::fs::remove_dir_all(&path).await.unwrap_or_default();
-
+    pub fn run(self) -> Result<(), RevmMiddlewareError> {
         tokio::spawn(async move {
-            let mut set = tokio::task::JoinSet::new();
-            for (name, events) in self.events {
-                let dir_path = format!("{}/{}", path, name);
-                tokio::fs::create_dir_all(&dir_path).await.unwrap();
-                for event in events {
-                    let dir_path = dir_path.clone();
-                    set.spawn(async move {
-                        let mut stream = event.stream().await.unwrap();
-                        while let Some(Ok(log)) = stream.next().await {
-                            let serialized = serde_json::to_string(&log).unwrap();
-                            let deserialized: BTreeMap<String, Value> =
-                                serde_json::from_str(&serialized).unwrap();
-                            let (key, value) = deserialized.iter().next().unwrap();
-                            let file_name = format!("{}/{}.csv", dir_path, key);
-                            match tokio::fs::metadata(&file_name).await {
-                                Ok(_) => {
-                                    let mut file = tokio::fs::OpenOptions::new()
-                                        .write(true)
-                                        .append(true)
-                                        .open(&file_name)
-                                        .await
-                                        .unwrap();
-                                    let values = value
-                                        .as_object()
-                                        .unwrap()
-                                        .values()
-                                        .map(|x| x.to_string())
-                                        .collect::<Vec<String>>()
-                                        .join(",");
-                                    file.write_all(values.as_bytes()).await.unwrap();
-                                    file.write_all("\n".as_bytes()).await.unwrap();
-                                }
-                                Err(_) => {
-                                    let mut file = tokio::fs::OpenOptions::new()
-                                        .write(true)
-                                        .create(true)
-                                        .append(true)
-                                        .open(&file_name)
-                                        .await
-                                        .unwrap();
-                                    let columns = value
-                                        .as_object()
-                                        .unwrap()
-                                        .keys()
-                                        .map(|x| x.to_string())
-                                        .collect::<Vec<String>>()
-                                        .join(",");
-                                    file.write_all(columns.as_bytes()).await.unwrap();
-                                    file.write_all("\n".as_bytes()).await.unwrap();
-                                    let values = value
-                                        .as_object()
-                                        .unwrap()
-                                        .values()
-                                        .map(|x| x.to_string())
-                                        .collect::<Vec<String>>()
-                                        .join(",");
-                                    file.write_all(values.as_bytes()).await.unwrap();
-                                    file.write_all("\n".as_bytes()).await.unwrap();
-                                    continue;
-                                }
-                            }
-                        }
-                    });
-                }
-            }
+            let mut set = self.events;
             while let Some(res) = set.join_next().await {
                 info!("task completed: {:?}", res);
             }

--- a/arbiter-core/src/tests/data_output.rs
+++ b/arbiter-core/src/tests/data_output.rs
@@ -7,76 +7,91 @@ use crate::data_collection::EventLogger;
 #[traced_test]
 #[tokio::test(flavor = "multi_thread")]
 async fn data_capture() {
-    let (mut _env, client) = startup_user_controlled().unwrap();
-    let arbx = deploy_arbx(client.clone()).await.unwrap();
-    let arby = deploy_arbx(client.clone()).await.unwrap();
-    let listener = EventLogger::builder()
-        .add(arbx.events(), "arbx")
-        .add(arby.events(), "arby");
+    for _ in 0..10 {
+        let (mut _env, client) = startup_user_controlled().unwrap();
+        let (arbx, arby, lex) = deploy_liquid_exchange(client.clone()).await.unwrap();
 
-    listener.run().await.unwrap();
+        let listener = EventLogger::builder()
+            .path("./test_output1")
+            .add(arbx.events(), "arbx")
+            .add(arby.events(), "arby")
+            .add(lex.events(), "lex");
 
-    for _ in 0..5 {
-        arbx.approve(client.address(), U256::from(1))
-            .send()
-            .await
-            .unwrap()
-            .await
-            .unwrap();
-        arby.approve(client.address(), U256::from(1))
-            .send()
-            .await
-            .unwrap()
-            .await
-            .unwrap();
+        listener.run().unwrap();
+
+        for _ in 0..5 {
+            arbx.approve(client.address(), U256::from(1))
+                .send()
+                .await
+                .unwrap()
+                .await
+                .unwrap();
+            arby.approve(client.address(), U256::from(1))
+                .send()
+                .await
+                .unwrap()
+                .await
+                .unwrap();
+            lex.set_price(U256::from(10u128.pow(18)))
+                .send()
+                .await
+                .unwrap()
+                .await
+                .unwrap();
+        }
     }
-    // check if dir exists
-    tokio::fs::remove_dir_all("./events").await.unwrap();
 }
 
 #[traced_test]
 #[tokio::test(flavor = "multi_thread")]
 async fn data_capture_output_validation() {
-    let (mut _env, client) = startup_user_controlled().unwrap();
-    let arbx = deploy_arbx(client.clone()).await.unwrap();
-    let arby = deploy_arbx(client.clone()).await.unwrap();
-    let listener = EventLogger::builder()
-        .add(arbx.events(), "arbx")
-        .add(arby.events(), "arby")
-        .path("./test_output/");
+    for i in 0..10 {
+        println!("Test iteration {}", i);
+        let (mut _env, client) = startup_user_controlled().unwrap();
+        let (arbx, arby, lex) = deploy_liquid_exchange(client.clone()).await.unwrap();
+        let listener = EventLogger::builder()
+            .path("./test_output2/")
+            .add(arbx.events(), "arbx")
+            .add(arby.events(), "arby")
+            .add(lex.events(), "lex");
 
-    listener.run().await.unwrap();
+        listener.run().unwrap();
 
-    for _ in 0..5 {
-        arbx.approve(client.address(), U256::from(1))
-            .send()
-            .await
-            .unwrap()
+        for _ in 0..5 {
+            arbx.approve(client.address(), U256::from(1))
+                .send()
+                .await
+                .unwrap()
+                .await
+                .unwrap();
+            arby.approve(client.address(), U256::from(1))
+                .send()
+                .await
+                .unwrap()
+                .await
+                .unwrap();
+            lex.set_price(U256::from(10u128.pow(18)))
+                .send()
+                .await
+                .unwrap()
+                .await
+                .unwrap();
+        }
+
+        let mut file0 = tokio::fs::File::open("./test_output2/arbx/ApprovalFilter.csv")
             .await
             .unwrap();
-        arby.approve(client.address(), U256::from(1))
-            .send()
-            .await
-            .unwrap()
+        let mut contents0 = vec![];
+        file0.read_to_end(&mut contents0).await.unwrap();
+        let contents0 = String::from_utf8(contents0).unwrap();
+
+        let mut file1 = tokio::fs::File::open("./test_output2/arby/ApprovalFilter.csv")
             .await
             .unwrap();
+        let mut contents1 = vec![];
+        file1.read_to_end(&mut contents1).await.unwrap();
+        let contents1 = String::from_utf8(contents1).unwrap();
+
+        assert_eq!(contents0, contents1);
     }
-
-    let mut file0 = tokio::fs::File::open("./test_output/arbx/ApprovalFilter.csv")
-        .await
-        .unwrap();
-    let mut contents0 = vec![];
-    file0.read_to_end(&mut contents0).await.unwrap();
-    let contents0 = String::from_utf8(contents0).unwrap();
-
-    let mut file1 = tokio::fs::File::open("./test_output/arby/ApprovalFilter.csv")
-        .await
-        .unwrap();
-    let mut contents1 = vec![];
-    file1.read_to_end(&mut contents1).await.unwrap();
-    let contents1 = String::from_utf8(contents1).unwrap();
-
-    assert_eq!(contents0, contents1);
-
-    tokio::fs::remove_dir_all("./test_output").await.unwrap();
 }

--- a/arbiter-core/src/tests/data_output.rs
+++ b/arbiter-core/src/tests/data_output.rs
@@ -7,7 +7,6 @@ use crate::data_collection::EventLogger;
 #[traced_test]
 #[tokio::test(flavor = "multi_thread")]
 async fn data_capture() {
-    for _ in 0..10 {
         let (mut _env, client) = startup_user_controlled().unwrap();
         let (arbx, arby, lex) = deploy_liquid_exchange(client.clone()).await.unwrap();
 
@@ -39,14 +38,11 @@ async fn data_capture() {
                 .await
                 .unwrap();
         }
-    }
 }
 
 #[traced_test]
 #[tokio::test(flavor = "multi_thread")]
 async fn data_capture_output_validation() {
-    for i in 0..10 {
-        println!("Test iteration {}", i);
         let (mut _env, client) = startup_user_controlled().unwrap();
         let (arbx, arby, lex) = deploy_liquid_exchange(client.clone()).await.unwrap();
         let listener = EventLogger::builder()
@@ -93,5 +89,4 @@ async fn data_capture_output_validation() {
         let contents1 = String::from_utf8(contents1).unwrap();
 
         assert_eq!(contents0, contents1);
-    }
 }

--- a/arbiter-core/src/tests/data_output.rs
+++ b/arbiter-core/src/tests/data_output.rs
@@ -1,5 +1,4 @@
 use tokio::io::AsyncReadExt;
-use tracing::info;
 use tracing_test::traced_test;
 
 use super::*;

--- a/arbiter-core/src/tests/data_output.rs
+++ b/arbiter-core/src/tests/data_output.rs
@@ -38,7 +38,7 @@ async fn data_capture() {
                 .await
                 .unwrap();
         }
-        tokio::fs::remove_dir_all("./test_output2").await.unwrap();
+        tokio::fs::remove_dir_all("./test_output1").await.unwrap();
 }
 
 #[traced_test]

--- a/arbiter-core/src/tests/data_output.rs
+++ b/arbiter-core/src/tests/data_output.rs
@@ -38,6 +38,7 @@ async fn data_capture() {
                 .await
                 .unwrap();
         }
+        tokio::fs::remove_dir_all("./test_output2").await.unwrap();
 }
 
 #[traced_test]
@@ -89,4 +90,5 @@ async fn data_capture_output_validation() {
         let contents1 = String::from_utf8(contents1).unwrap();
 
         assert_eq!(contents0, contents1);
+        tokio::fs::remove_dir_all("./test_output2").await.unwrap();
 }


### PR DESCRIPTION
- Improved version of the event capture
- `.add` now accepts events from arbitrary contracts rather than enforcing that all events are from a `ContractInstance` of the same type
- Files are tracked in a BTreeMap to avoid re-opening when new events are received in the to the stream