### PR TITLE
Test workflow on macos-latest

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: test
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
- Runs tests on 3 core macos-latest deployment rather than 2 core ubuntu-latest, see [docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners)

edit: running the tests on macos makes data_capture pass