### PR TITLE
Arbiter bind

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,9 @@ config = { version = "=0.13.3" }
 ethers = { version = "=2.0.10" }
 revm = { version = "=3.5.0", features = [ "ethersdb", "std" ] }
 toml = { version = "0.8.2" }
-
+proc-macro2 = { version = "1.0.69" }
+syn = { version = "2.0.38" }
+Inflector = { version = "0.11.4" }
 # Building files
 quote = { version = "=1.0.33" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,17 +28,17 @@ arbiter-core = { version = "0.6.0", path = "arbiter-core" }
 # Command line and config
 clap = { version = "=4.4.6", features = ["derive"] }
 serde = { version = "=1.0.188", features = ["derive"] }
-serde_json = { version = "1.0.107" }
+serde_json = { version = "=1.0.107" }
 config = { version = "=0.13.3" }
 ethers = { version = "=2.0.10" }
 revm = { version = "=3.5.0", features = [ "ethersdb", "std" ] }
-toml = { version = "0.8.2" }
-proc-macro2 = { version = "1.0.69" }
-syn = { version = "2.0.38" }
-Inflector = { version = "0.11.4" }
+toml = { version = "=0.8.2" }
+proc-macro2 = { version = "=1.0.69" }
+syn = { version = "=2.0.38" }
+Inflector = { version = "=0.11.4" }
 # Building files
 quote = { version = "=1.0.33" }
-
+foundry-config = { version = "=0.2.0" }
 # Errors
 thiserror = { version = "=1.0.49" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["benches"]
 # Package configuration
 [package]
 name = "arbiter"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Waylon Jepsen <waylonjepsen1@gmail.com>", "Colin Roberts <colin@autoparallel.xyz>"]
 description = "Allowing smart contract developers to do simulation driven development via an EVM emulator"


### PR DESCRIPTION
closes #609 by using the abigen heuristics for filenames

Also utilizes foundry's foundry.toml as well as adds the ability to read from config.toml for some arbiter settings. Currently it supports two fields 
```toml
[arbiter]
bindings_workspace = "simulation" # must be a valid workspace member
submodules = false # change to true if you want the submodule bindings to be generated
```
the bindings_workspace will tell the bind command which crate to output the bindings to as a module
the submodules will indicate wether or not we want the bindings for any gitsubmodule contract dependancies
