### PR TITLE
Update codecov.yaml

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -9,4 +9,8 @@ coverage:
         target: 50%
         threshold: 1%
         informational: true
+  ignore:
+    - "arbiter-core/contracts/*"
+    - "arbiter/arbiter-core/benches*"
+    - "arbiter/arbiter-core/src/bindings"
     


### PR DESCRIPTION
This PR tells codcov to ignore the bindings, solidity contracts, and benches for analyzing coverage.

Closes #623 
