### PR TITLE
fix(bind): output directory outputs to src/bindings

### DIFF
--- a/bin/bind.rs
+++ b/bin/bind.rs
@@ -271,7 +271,7 @@ fn get_config() -> ArbiterConfig {
                 if let Some(bindings_workspace) = arbiter.get("bindings_workspace") {
                     if let Some(bindings_workspace_str) = bindings_workspace.as_str() {
                         path = PathBuf::from(bindings_workspace_str);
-                        path = path.join("src").join("bindings");
+                        path = path.join("src");
                     }
                 }
                 if let Some(submodules) = arbiter.get("submodules") {


### PR DESCRIPTION
With the arbiter config "bindings_workspace", it's taking the workspace as the root directory and adding "src/bindings", then at the end of the function it adds another "/bindings", so output for the workspace "simulation" is "simulation/src/bindings/bindings". 

I remove the first addition of bindings so we rely on the join at the end of the function.

![image](https://github.com/primitivefinance/arbiter/assets/38409137/797cd217-f74b-423c-bb68-53acefecb09d)
