### PR TITLE
feat: Change types from ethers types to alloy types in cheatcodes

### DIFF
--- a/arbiter-core/src/environment/cheatcodes.rs
+++ b/arbiter-core/src/environment/cheatcodes.rs
@@ -3,7 +3,7 @@
 
 #![warn(missing_docs)]
 
-use revm_primitives::{AccountInfo, HashMap, U256};
+use revm_primitives::{alloy_primitives, AccountInfo, HashMap, U256};
 
 /// Cheatcodes are a direct way to access the underlying [`EVM`] environment and
 /// database.
@@ -12,17 +12,18 @@ pub enum Cheatcodes {
     /// A `Deal` is used to increase the balance of an account in the [`EVM`].
     Deal {
         /// The address of the account to increase the balance of.
-        address: ethers::types::Address,
+        address: alloy_primitives::Address,
 
         /// The amount to increase the balance of the account by.
-        amount: ethers::types::U256,
+        amount: alloy_primitives::U256,
     },
     /// Fetches the value of a storage slot of an account.
     Load {
         /// The address of the account to fetch the storage slot from.
-        account: ethers::types::Address,
+        account: alloy_primitives::Address,
         /// The storage slot to fetch.
-        key: ethers::types::H256,
+        key: alloy_primitives::B256,
+
         /// The block to fetch the storage slot from.
         /// todo: implement storage slots at blocks.
         block: Option<ethers::types::BlockId>,
@@ -32,16 +33,16 @@ pub enum Cheatcodes {
     /// to do.
     Store {
         /// The address of the account to overwrite the storage slot of.
-        account: ethers::types::Address,
+        account: alloy_primitives::Address,
         /// The storage slot to overwrite.
-        key: ethers::types::H256,
+        key: alloy_primitives::B256,
         /// The value to overwrite the storage slot with.
-        value: ethers::types::H256,
+        value: alloy_primitives::B256,
     },
     /// Fetches the `DbAccount` account at the given address.
     Access {
         /// The address of the account to fetch.
-        address: ethers::types::Address,
+        address: alloy_primitives::Address,
     },
 }
 
@@ -68,7 +69,7 @@ pub enum CheatcodesReturn {
     /// A `Load` returns the value of a storage slot of an account.
     Load {
         /// The value of the storage slot.
-        value: revm::primitives::U256,
+        value: revm_primitives::alloy_primitives::U256,
     },
     /// A `Store` returns nothing.
     Store,

--- a/arbiter-core/src/environment/cheatcodes.rs
+++ b/arbiter-core/src/environment/cheatcodes.rs
@@ -69,7 +69,7 @@ pub enum CheatcodesReturn {
     /// A `Load` returns the value of a storage slot of an account.
     Load {
         /// The value of the storage slot.
-        value: revm_primitives::alloy_primitives::U256,
+        value: alloy_primitives::U256,
     },
     /// A `Store` returns nothing.
     Store,

--- a/arbiter-core/src/environment/cheatcodes.rs
+++ b/arbiter-core/src/environment/cheatcodes.rs
@@ -26,7 +26,7 @@ pub enum Cheatcodes {
 
         /// The block to fetch the storage slot from.
         /// todo: implement storage slots at blocks.
-        block: Option<ethers::types::BlockId>,
+        block: Option<alloy_primitives::BlockNumber>,
     },
     /// Overwrites a storage slot of an account.
     /// TODO: for more complicated data types, like structs, there's more work

--- a/arbiter-core/src/environment/mod.rs
+++ b/arbiter-core/src/environment/mod.rs
@@ -41,7 +41,8 @@ use ethers::core::types::U64;
 use revm::{
     db::{CacheDB, EmptyDB},
     primitives::{
-        AccountInfo, EVMError, ExecutionResult, HashMap, InvalidTransaction, Log, TxEnv, U256,
+        alloy_primitives, AccountInfo, EVMError, ExecutionResult, HashMap, InvalidTransaction, Log,
+        TxEnv, U256,
     },
     EVM,
 };
@@ -322,15 +323,14 @@ impl Environment {
                             match db.accounts.get_mut(&account) {
                                 Some(account) => {
                                     // Returns zero if the account is missing.
-                                    let value: revm::primitives::U256 =
-                                        match account
-                                            .storage
-                                            .get::<revm_primitives::alloy_primitives::U256>(
-                                                &key.into(),
-                                            ) {
-                                            Some(value) => *value,
-                                            None => revm::primitives::U256::ZERO,
-                                        };
+                                    let value: revm::primitives::U256 = match account
+                                        .storage
+                                        .get::<alloy_primitives::U256>(
+                                        &key.into(),
+                                    ) {
+                                        Some(value) => *value,
+                                        None => revm::primitives::U256::ZERO,
+                                    };
 
                                     // Sends the revm::primitives::U256 storage value back to the
                                     // sender via CheatcodeReturn(revm::primitives::U256).

--- a/arbiter-core/src/middleware/mod.rs
+++ b/arbiter-core/src/middleware/mod.rs
@@ -34,14 +34,14 @@ use ethers::{
     },
     signers::{Signer, Wallet},
     types::{
-        transaction::eip2718::TypedTransaction, Address, BlockId, Bloom, Bytes, Filter,
-        FilteredParams, Log, NameOrAddress, Transaction, TransactionReceipt, U256 as eU256, U64,
+        transaction::eip2718::TypedTransaction, Address, BlockId, BlockNumber, Bloom, Bytes,
+        Filter, FilteredParams, Log, NameOrAddress, Transaction, TransactionReceipt, U256 as eU256,
+        U64,
     },
 };
 use futures_timer::Delay;
 use rand::{rngs::StdRng, SeedableRng};
-use revm::primitives::{CreateScheme, Output, TransactTo, TxEnv, U256};
-use revm_primitives::alloy_primitives;
+use revm::primitives::{alloy_primitives, CreateScheme, Output, TransactTo, TxEnv, U256};
 use serde::{de::DeserializeOwned, Serialize};
 // use revm::primitives::{ExecutionResult, Output};
 // use super::cast::revm_logs_to_ethers_logs;
@@ -881,12 +881,21 @@ impl Middleware for RevmMiddleware {
             }
         };
         let recast_key: alloy_primitives::B256 = key.as_fixed_bytes().into();
+        let recast_block_number: alloy_primitives::BlockNumber;
+        if let Some(BlockId::Number(BlockNumber::Number(block_number))) = block {
+            recast_block_number = block_number.as_u64();
+        } else {
+            return Err(RevmMiddlewareError::MissingData(
+                "Querying storage using anything other than BlockNumber(Number) is not supported!"
+                    .to_string(),
+            ));
+        }
 
         let result = self
             .apply_cheatcode(Cheatcodes::Load {
                 account: address,
                 key: recast_key,
-                block,
+                block: Some(recast_block_number),
             })
             .await
             .unwrap();


### PR DESCRIPTION
This is a draft PR for the issue #606 

It seems like `BlockId` enum is no longer supported in alloy types. https://github.com/primitivefinance/arbiter/blob/c6ea6ab526afc1d9e349a501d2213d2b2d34115f/arbiter-core/src/environment/cheatcodes.rs#L28C9-L28C9

So what should be the approach here? Should I create a enum that wrappes both `BlockHash` and `BlockNumber` or do something else for that?