### PR TITLE
arbiter-engine: worlds and messaging layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,7 @@ dependencies = [
  "artemis-core",
  "crossbeam-channel",
  "ethers",
+ "futures-util",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,12 +293,17 @@ dependencies = [
 name = "arbiter-engine"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "arbiter-bindings",
  "arbiter-core",
  "artemis-core",
+ "async-stream",
+ "async-trait",
  "crossbeam-channel",
  "ethers",
  "futures-util",
+ "serde",
+ "serde_json",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tokio = { version = "1.34.0", features = ["macros", "full"] }
 arbiter-core = { path = "./arbiter-core" }
 crossbeam-channel =  { version = "=0.5.8" }
 futures-util =  { version = "=0.3.29" }
+async-trait =  { version = "0.1.74" }
 
 # Dependencies for the release build
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ proc-macro2 = { version = "=1.0.69" }
 tokio = { version = "1.34.0", features = ["macros", "full"] }
 arbiter-core = { path = "./arbiter-core" }
 crossbeam-channel =  { version = "=0.5.8" }
+futures-util =  { version = "=0.3.29" }
 
 # Dependencies for the release build
 [dependencies]

--- a/arbiter-core/Cargo.toml
+++ b/arbiter-core/Cargo.toml
@@ -37,7 +37,7 @@ statrs = { version = "=0.16.0" }
 thiserror.workspace = true
 
 # Logging
-futures-util =  { version = "=0.3.29" }
+futures-util.workspace = true
 tracing = "0.1.40"
 
 # File types

--- a/arbiter-core/Cargo.toml
+++ b/arbiter-core/Cargo.toml
@@ -21,9 +21,8 @@ serde.workspace = true
 serde_json.workspace = true
 
 # Concurrency/async
-# tokio = { version = "1.32.0", features = ["macros", "full"] }
 tokio.workspace = true
-async-trait =  { version = "0.1.74" }
+async-trait.workspace = true
 crossbeam-channel =  { version = "=0.5.8" }
 futures-timer = { version = "=3.0.2" }
 futures-locks = { version = "=0.7.1" }

--- a/arbiter-core/src/middleware/connection.rs
+++ b/arbiter-core/src/middleware/connection.rs
@@ -41,6 +41,20 @@ pub struct Connection {
     pub(crate) filter_receivers: Arc<Mutex<HashMap<ethers::types::U256, FilterReceiver>>>,
 }
 
+impl From<&Environment> for Connection {
+    fn from(environment: &Environment) -> Self {
+        let instruction_sender = &Arc::clone(&environment.socket.instruction_sender);
+        let (outcome_sender, outcome_receiver) = crossbeam_channel::unbounded();
+        Self {
+            instruction_sender: Arc::downgrade(instruction_sender),
+            outcome_sender,
+            outcome_receiver,
+            event_broadcaster: Arc::clone(&environment.socket.event_broadcaster),
+            filter_receivers: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
 #[async_trait::async_trait]
 impl JsonRpcClient for Connection {
     type Error = ProviderError;

--- a/arbiter-core/src/middleware/mod.rs
+++ b/arbiter-core/src/middleware/mod.rs
@@ -144,11 +144,10 @@ impl RevmMiddleware {
     /// Use a seed if you want to have a constant address across simulations as
     /// well as a label for a client. This can be useful for debugging.
     pub fn new(
-        environment: &Environment,
+        environment: impl Into<Connection>,
         seed_and_label: Option<&str>,
     ) -> Result<Arc<Self>, RevmMiddlewareError> {
-        let instruction_sender = &Arc::clone(&environment.socket.instruction_sender);
-        let (outcome_sender, outcome_receiver) = crossbeam_channel::unbounded();
+        let connection = environment.into();
         let wallet = if let Some(seed) = seed_and_label {
             let mut hasher = Sha256::new();
             hasher.update(seed);
@@ -159,26 +158,24 @@ impl RevmMiddleware {
             let mut rng = rand::thread_rng();
             Wallet::new(&mut rng)
         };
-        instruction_sender
+        connection
+            .instruction_sender
+            .upgrade()
+            .ok_or(errors::RevmMiddlewareError::Send(
+                "Environment is offline!".to_string(),
+            ))?
             .send(Instruction::AddAccount {
                 address: wallet.address(),
-                outcome_sender: outcome_sender.clone(),
+                outcome_sender: connection.outcome_sender.clone(),
             })
             .map_err(|e| RevmMiddlewareError::Send(e.to_string()))?;
-        outcome_receiver.recv()??;
+        connection.outcome_receiver.recv()??;
 
-        let connection = Connection {
-            instruction_sender: Arc::downgrade(instruction_sender),
-            outcome_sender,
-            outcome_receiver: outcome_receiver.clone(),
-            event_broadcaster: Arc::clone(&environment.socket.event_broadcaster),
-            filter_receivers: Arc::new(Mutex::new(HashMap::new())),
-        };
         let provider = Provider::new(connection);
-        info!(
-            "Created new `RevmMiddleware` instance attached to environment labeled: {:?}",
-            environment.parameters.label
-        );
+        // info!(
+        //     "Created new `RevmMiddleware` instance attached to environment labeled: {:?}",
+        //     environment.parameters.label
+        // );
         Ok(Arc::new(Self {
             wallet: EOA::Wallet(wallet),
             provider,

--- a/arbiter-core/src/middleware/mod.rs
+++ b/arbiter-core/src/middleware/mod.rs
@@ -144,10 +144,10 @@ impl RevmMiddleware {
     /// Use a seed if you want to have a constant address across simulations as
     /// well as a label for a client. This can be useful for debugging.
     pub fn new(
-        environment: impl Into<Connection>,
+        environment: &Environment,
         seed_and_label: Option<&str>,
     ) -> Result<Arc<Self>, RevmMiddlewareError> {
-        let connection = environment.into();
+        let connection = Connection::from(environment);
         let wallet = if let Some(seed) = seed_and_label {
             let mut hasher = Sha256::new();
             hasher.update(seed);
@@ -172,10 +172,11 @@ impl RevmMiddleware {
         connection.outcome_receiver.recv()??;
 
         let provider = Provider::new(connection);
-        // info!(
-        //     "Created new `RevmMiddleware` instance attached to environment labeled: {:?}",
-        //     environment.parameters.label
-        // );
+        info!(
+            "Created new `RevmMiddleware` instance attached to environment labeled:
+        {:?}",
+            environment.parameters.label
+        );
         Ok(Arc::new(Self {
             wallet: EOA::Wallet(wallet),
             provider,

--- a/arbiter-engine/Cargo.toml
+++ b/arbiter-engine/Cargo.toml
@@ -14,6 +14,7 @@ arbiter-core.workspace = true
 arbiter-bindings = { path = "../arbiter-bindings" }
 artemis-core = { git = "https://github.com/paradigmxyz/artemis.git"}
 crossbeam-channel.workspace = true
+futures-util.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true

--- a/arbiter-engine/Cargo.toml
+++ b/arbiter-engine/Cargo.toml
@@ -15,6 +15,9 @@ arbiter-bindings = { path = "../arbiter-bindings" }
 artemis-core = { git = "https://github.com/paradigmxyz/artemis.git"}
 crossbeam-channel.workspace = true
 futures-util.workspace = true
-
-[dev-dependencies]
+async-trait.workspace = true
+serde_json.workspace = true
+serde.workspace = true
 tokio.workspace = true
+anyhow =  { version = "=1.0.75" }
+async-stream = "0.3.5"

--- a/arbiter-engine/src/agent.rs
+++ b/arbiter-engine/src/agent.rs
@@ -1,29 +1,22 @@
 // NOTES: Each agent essentially has its own engine. We can collect all of the
 // engines together into a world.
 
-// AGENT SHOULD BE A STRUCT WITH A STRATEGY
-
 // CAN GIVE AGENT A CALCULATOR EVM TOO!
 
-// Can probably use the MempoolExecutor from artemis
-
-use std::collections::HashMap;
+// TODO: We may need traits for Events and Actions (e.g., "Event" and "Action"
+// which have a method like "parse()" and "produce()" or something.). TODO: Need
+// an init signal or something.
 
 use artemis_core::{
     engine::Engine,
     types::{Collector, Executor},
 };
-use crossbeam_channel::{Receiver, Sender};
-
-struct Instruction(String);
 
 pub struct Agent<E, A> {
-    id: String,
-    engine: Engine<E, A>,
+    id: String, // TODO: We might not really need an ID here specifically. Hard to say right now.
+    engine: Engine<E, A>, // Note, agent shouldn't need a client as the engine will handle this.
     dependencies: Vec<String>,
     dependents: Vec<String>,
-    receivers: HashMap<String, Receiver<Instruction>>,
-    senders: HashMap<String, Sender<Instruction>>,
 }
 
 impl<E, A> Agent<E, A>
@@ -38,8 +31,6 @@ where
             engine: Engine::new(),
             dependencies: vec![],
             dependents: vec![],
-            receivers: HashMap::new(),
-            senders: HashMap::new(),
         }
     }
 
@@ -52,8 +43,11 @@ where
     }
 
     pub fn add_dependency(&mut self, dependency: &str) {
-        // TODO: This isn't giving a receiver or anyhthing.
         self.dependencies.push(dependency.to_owned());
+    }
+
+    pub fn add_dependent(&mut self, dependent: &str) {
+        self.dependents.push(dependent.to_owned());
     }
 }
 

--- a/arbiter-engine/src/agent.rs
+++ b/arbiter-engine/src/agent.rs
@@ -1,21 +1,37 @@
-// NOTES: Each agent essentially has its own engine. We can collect all of the
-// engines together into a world.
+#![warn(missing_docs)]
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// TODO: Notes ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// We may need traits for Events and Actions (e.g., "Event" and "Action"
+// which have a method like "parse()" and "produce()" or something.).
+// Need an init signal or something.
+// We can give agents a "calculator" evm to send "Actions" to when they are just
+// doing compute so they aren't blocking the main tx thread.
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-// CAN GIVE AGENT A CALCULATOR EVM TOO!
-
-// TODO: We may need traits for Events and Actions (e.g., "Event" and "Action"
-// which have a method like "parse()" and "produce()" or something.). TODO: Need
-// an init signal or something.
+//! The agent module contains the core agent abstraction for the Arbiter Engine.
 
 use artemis_core::{
     engine::Engine,
     types::{Collector, Executor},
 };
 
+/// An agent is an entity capable of processing events and producing actions.
+/// These are the core actors in simulations or in onchain systems.
+/// Agents can be connected of other agents either as a dependent, or a
+/// dependency.
 pub struct Agent<E, A> {
-    id: String, // TODO: We might not really need an ID here specifically. Hard to say right now.
-    engine: Engine<E, A>, // Note, agent shouldn't need a client as the engine will handle this.
+    /// Identifier for this agent.
+    /// Used for routing messages.
+    _id: String,
+
+    /// The engine that this agent uses to process events and produce actions.
+    engine: Engine<E, A>, /* Note, agent shouldn't NEED a client as a field as the engine can
+                           * handle this. */
+
+    /// Agents that this agent depends on.
     dependencies: Vec<String>,
+
+    /// Agents that depend on this agent.
     dependents: Vec<String>,
 }
 
@@ -25,27 +41,34 @@ where
     A: Send + Clone + 'static + std::fmt::Debug,
 {
     #[allow(clippy::new_without_default)]
+    /// Produces a new agent with the given identifier.
     pub fn new(id: &str) -> Self {
         Self {
-            id: id.to_owned(),
+            _id: id.to_owned(),
             engine: Engine::new(),
             dependencies: vec![],
             dependents: vec![],
         }
     }
 
+    /// Adds a collector to the agent's engine.
     pub fn add_collector(&mut self, collector: impl Collector<E> + 'static) {
         self.engine.add_collector(Box::new(collector));
     }
 
+    /// Adds an executor to the agent's engine.
     pub fn add_executor(&mut self, executor: impl Executor<A> + 'static) {
         self.engine.add_executor(Box::new(executor));
     }
 
+    /// Adds a dependency to the agent.
+    /// Dependencies are agents that this agent depends on.
     pub fn add_dependency(&mut self, dependency: &str) {
         self.dependencies.push(dependency.to_owned());
     }
 
+    /// Adds a dependent to the agent.
+    /// Dependents are agents that depend on this agent.
     pub fn add_dependent(&mut self, dependent: &str) {
         self.dependents.push(dependent.to_owned());
     }
@@ -89,8 +112,5 @@ mod tests {
             tx,
             gas_bid_info: None,
         };
-
-        // TODO: We should write a test that runs the agent's engine in some
-        // meaningful way.
     }
 }

--- a/arbiter-engine/src/examples.rs
+++ b/arbiter-engine/src/examples.rs
@@ -1,0 +1,93 @@
+// TODO: Create a BlockAdmin and a TokenAdmin. Create a Orchestrator that sends
+// instructions to both BlockAdmin and TokenAdmin
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arbiter_bindings::bindings::arbiter_token::ArbiterToken;
+use arbiter_core::{environment::cheatcodes::Cheatcodes, middleware::RevmMiddleware};
+use artemis_core::{
+    executors::mempool_executor::SubmitTxToMempool,
+    types::{Collector, Executor, Strategy},
+};
+use ethers::types::{Address, U256};
+
+use crate::messager::Message;
+
+use super::*;
+
+pub struct BlockExecutor {
+    client: Arc<RevmMiddleware>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct NewBlock {
+    timestamp: u64,
+    number: u64,
+}
+
+// TODO: Consider replacing this with a cheatcode executor.
+#[async_trait::async_trait]
+impl Executor<NewBlock> for BlockExecutor {
+    async fn execute(&self, new_block: NewBlock) -> Result<()> {
+        let _receipt_data = self
+            .client
+            .update_block(new_block.number, new_block.timestamp)?;
+        Ok(())
+    }
+}
+
+pub struct BlockAdmin {
+    pub id: String,
+}
+
+#[async_trait::async_trait]
+impl Strategy<Message, NewBlock> for BlockAdmin {
+    async fn sync_state(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn process_event(&mut self, event: Message) -> Vec<NewBlock> {
+        if event.to == self.id {
+            let new_block: NewBlock = serde_json::from_str(&event.data).unwrap();
+            vec![new_block]
+        } else {
+            vec![]
+        }
+    }
+}
+
+pub struct TokenAdmin {
+    pub id: String,
+    pub tokens: HashMap<String, ArbiterToken<RevmMiddleware>>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TokenRequest {
+    pub token: String,
+    pub mint_to: Address,
+    pub mint_amount: u64,
+}
+
+#[async_trait::async_trait]
+impl Strategy<Message, SubmitTxToMempool> for TokenAdmin {
+    async fn sync_state(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn process_event(&mut self, event: Message) -> Vec<SubmitTxToMempool> {
+        if event.to == self.id {
+            let token_request: TokenRequest = serde_json::from_str(&event.data).unwrap();
+            let token = self.tokens.get(&token_request.token).unwrap();
+            let tx = SubmitTxToMempool {
+                tx: token
+                    .mint(token_request.mint_to, U256::from(token_request.mint_amount))
+                    .tx,
+                gas_bid_info: None,
+            };
+            vec![tx]
+        } else {
+            vec![]
+        }
+    }
+}

--- a/arbiter-engine/src/examples.rs
+++ b/arbiter-engine/src/examples.rs
@@ -1,25 +1,33 @@
-// TODO: Create a BlockAdmin and a TokenAdmin. Create a Orchestrator that sends
-// instructions to both BlockAdmin and TokenAdmin
+#![warn(missing_docs)]
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// TODO: Notes ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Create a BlockAdmin and a TokenAdmin.
+// Potentially create an `Orchestrator`` that sends instructions to both
+// BlockAdmin and TokenAdmin.
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use std::collections::HashMap;
-use std::sync::Arc;
+//! The examples module contains example strategies.
+
+use std::{collections::HashMap, sync::Arc};
 
 use arbiter_bindings::bindings::arbiter_token::ArbiterToken;
-use arbiter_core::{environment::cheatcodes::Cheatcodes, middleware::RevmMiddleware};
+use arbiter_core::middleware::RevmMiddleware;
 use artemis_core::{
     executors::mempool_executor::SubmitTxToMempool,
-    types::{Collector, Executor, Strategy},
+    types::{Executor, Strategy},
 };
 use ethers::types::{Address, U256};
 
+use super::*;
 use crate::messager::Message;
 
-use super::*;
-
+/// A block executor that updates the block number and timestamp in the
+/// database.
 pub struct BlockExecutor {
     client: Arc<RevmMiddleware>,
 }
 
+/// Used as an action to set new block number and timestamp.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct NewBlock {
     timestamp: u64,
@@ -37,8 +45,12 @@ impl Executor<NewBlock> for BlockExecutor {
     }
 }
 
+// TODO: This may not be necessary in this way.
+/// The block admin is responsible for sending new block events to the block
+/// executor.
 pub struct BlockAdmin {
-    pub id: String,
+    /// The identifier of the block admin.
+    pub id: String, // TODO: The strategies should not really need an ID.
 }
 
 #[async_trait::async_trait]
@@ -57,15 +69,25 @@ impl Strategy<Message, NewBlock> for BlockAdmin {
     }
 }
 
+/// The token admin is responsible for handling token minting requests.
 pub struct TokenAdmin {
-    pub id: String,
+    /// The identifier of the token admin.
+    pub id: String, // TODO: The strategies should not really need an ID.
+
+    /// The tokens that the token admin has control over.
     pub tokens: HashMap<String, ArbiterToken<RevmMiddleware>>,
 }
 
+/// Used as an action to mint tokens.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TokenRequest {
+    /// The token to mint.
     pub token: String,
+
+    /// The address to mint to.
     pub mint_to: Address,
+
+    /// The amount to mint.
     pub mint_amount: u64,
 }
 

--- a/arbiter-engine/src/lib.rs
+++ b/arbiter-engine/src/lib.rs
@@ -1,4 +1,8 @@
-use std::sync::Arc;
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 pub mod agent;
+pub mod examples;
+pub mod messager;
 pub mod world;

--- a/arbiter-engine/src/lib.rs
+++ b/arbiter-engine/src/lib.rs
@@ -1,1 +1,4 @@
+use std::sync::Arc;
+
 pub mod agent;
+pub mod world;

--- a/arbiter-engine/src/lib.rs
+++ b/arbiter-engine/src/lib.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 pub mod agent;
 pub mod examples;

--- a/arbiter-engine/src/messager.rs
+++ b/arbiter-engine/src/messager.rs
@@ -1,20 +1,33 @@
+#![warn(missing_docs)]
+
+//! The messager module contains the core messager layer for the Arbiter Engine.
+
 use artemis_core::types::{Collector, CollectorStream, Executor};
 use tokio::sync::broadcast::Sender;
 
 use super::*;
 
+/// A message that can be sent between agents.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Message {
+    /// The sender of the message.
     pub from: String,
+
+    /// The recipient of the message.
     pub to: String,
+
+    /// The data of the message.
+    /// This can be a struct serialized into JSON.
     pub data: String,
 }
 
+/// A messager that can be used to send messages between agents.
 pub struct Messager {
     broadcaster: Sender<Message>,
 }
 
 impl Messager {
+    /// Creates a new messager with the given capacity.
     pub fn new(capacity: usize) -> Self {
         Self {
             broadcaster: Sender::new(capacity),

--- a/arbiter-engine/src/messager.rs
+++ b/arbiter-engine/src/messager.rs
@@ -1,0 +1,50 @@
+use artemis_core::types::{Collector, CollectorStream, Executor};
+use tokio::sync::broadcast::Sender;
+
+use super::*;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Message {
+    pub from: String,
+    pub to: String,
+    pub data: String,
+}
+
+pub struct Messager {
+    broadcaster: Sender<Message>,
+}
+
+impl Messager {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            broadcaster: Sender::new(capacity),
+        }
+    }
+}
+
+impl Default for Messager {
+    fn default() -> Self {
+        Self::new(32)
+    }
+}
+
+#[async_trait::async_trait]
+impl Collector<Message> for Messager {
+    async fn get_event_stream(&self) -> Result<CollectorStream<'_, Message>> {
+        let mut subscription = self.broadcaster.subscribe();
+        let stream = async_stream::stream! {
+            while let Ok(message) = subscription.recv().await {
+                yield message;
+            }
+        };
+        Ok(Box::pin(stream))
+    }
+}
+
+#[async_trait::async_trait]
+impl Executor<Message> for Messager {
+    async fn execute(&self, message: Message) -> Result<()> {
+        let _buf_len = self.broadcaster.send(message)?;
+        Ok(())
+    }
+}

--- a/arbiter-engine/src/world.rs
+++ b/arbiter-engine/src/world.rs
@@ -1,0 +1,75 @@
+// TODO: Probalby should move labels to world instead of environment.
+
+use crate::agent::Agent;
+
+// In order to add dependencies and what not, we need all the agents to be in the world or something probably.
+use super::*;
+
+use ethers::providers::{Provider, PubsubClient};
+
+pub struct World<P, E, A> {
+    pub agents: Vec<Agent<E, A>>,
+    pub provider: Provider<P>,
+    // pub interconnects: Vec<World>,
+}
+
+impl<P, E, A> World<P, E, A>
+where
+    P: PubsubClient,
+{
+    pub fn new(provider: Provider<P>) -> Self {
+        Self {
+            agents: vec![],
+            provider,
+        }
+    }
+
+    pub fn add_agent(&mut self, agent: Agent<E, A>) {
+        self.agents.push(agent);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arbiter_core::{
+        environment::builder::EnvironmentBuilder, middleware::connection::Connection,
+    };
+
+    use ethers::{
+        providers::{Middleware, Provider, Ws},
+        types::Address,
+    };
+    use std::str::FromStr;
+
+    use arbiter_bindings::bindings::weth::WETH;
+    use futures_util::StreamExt;
+
+    #[test]
+    fn arbiter_world() {
+        let environment = EnvironmentBuilder::new().build();
+        let connection = Connection::from(&environment);
+        let provider = Provider::new(connection);
+        // let mut world = World::new(provider);
+
+        // let client = RevmMiddleware::new(connection, Some("testname"));
+        // let agent = Agent::new("agent1");
+        // world.add_agent(agent);
+    }
+
+    #[tokio::test]
+    async fn mainnet_world() {
+        let ws_url = std::env::var("MAINNET_WS_URL").expect("MAINNET_WS_URL must be set");
+        let ws = Ws::connect(ws_url).await.unwrap();
+        let provider = Provider::new(ws);
+        // let mut world = World::new(provider);
+        let client = Arc::new(provider);
+        let weth = WETH::new(
+            Address::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").unwrap(),
+            client.clone(),
+        );
+        let filter = weth.approval_filter().filter;
+        let mut subscription = client.subscribe_logs(&filter).await.unwrap();
+        println!("next: {:?}", subscription.next().await);
+    }
+}

--- a/arbiter-engine/src/world.rs
+++ b/arbiter-engine/src/world.rs
@@ -1,26 +1,35 @@
 // TODO: Probalby should move labels to world instead of environment.
 
-use crate::agent::Agent;
+use crate::{agent::Agent, messager::Message};
 
 // In order to add dependencies and what not, we need all the agents to be in the world or something probably.
 use super::*;
 
+use crossbeam_channel::{Receiver, Sender};
 use ethers::providers::{Provider, PubsubClient};
 
 pub struct World<P, E, A> {
+    pub id: String,
     pub agents: Vec<Agent<E, A>>,
     pub provider: Provider<P>,
-    // pub interconnects: Vec<World>,
+    pub interconnects: HashMap<String, Interconnect>,
+}
+
+pub struct Interconnect {
+    sender: Sender<Message>,
+    receiver: Receiver<Message>,
 }
 
 impl<P, E, A> World<P, E, A>
 where
     P: PubsubClient,
 {
-    pub fn new(provider: Provider<P>) -> Self {
+    pub fn new(id: &str, provider: Provider<P>) -> Self {
         Self {
+            id: id.to_owned(),
             agents: vec![],
             provider,
+            interconnects: HashMap::new(),
         }
     }
 
@@ -31,11 +40,15 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::messager::Messager;
+
     use super::*;
     use arbiter_core::{
-        environment::builder::EnvironmentBuilder, middleware::connection::Connection,
+        environment::builder::EnvironmentBuilder,
+        middleware::{connection::Connection, RevmMiddleware},
     };
 
+    use artemis_core::executors::mempool_executor::MempoolExecutor;
     use ethers::{
         providers::{Middleware, Provider, Ws},
         types::Address,
@@ -44,19 +57,25 @@ mod tests {
 
     use arbiter_bindings::bindings::weth::WETH;
     use futures_util::StreamExt;
+    use std::sync::Arc;
 
+    #[ignore]
     #[test]
     fn arbiter_world() {
         let environment = EnvironmentBuilder::new().build();
         let connection = Connection::from(&environment);
         let provider = Provider::new(connection);
-        // let mut world = World::new(provider);
+        let mut world = World::new("test_world", provider);
 
-        // let client = RevmMiddleware::new(connection, Some("testname"));
-        // let agent = Agent::new("agent1");
-        // world.add_agent(agent);
+        let client = RevmMiddleware::new(&environment, Some("testname")).unwrap();
+        let mut agent = Agent::new("agent1");
+        let messager = Messager::default();
+        agent.add_collector(messager);
+        agent.add_executor(MempoolExecutor::new(client.clone()));
+        world.add_agent(agent);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn mainnet_world() {
         let ws_url = std::env::var("MAINNET_WS_URL").expect("MAINNET_WS_URL must be set");


### PR DESCRIPTION
**Give an overview of the tasks completed**
Creates some more abstractions to be used in `arbiter-engine` with some starter examples that don't yet run. Main things are:
- Agent messaging layer.
- Beginning of `World` abstraction.

**Link to issue(s) that this PR closes**
Closes #738 
