### PR TITLE
feat(arbiter-engine): Run method for agents and messager echo example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,8 +241,6 @@ name = "arbiter-bindings"
 version = "0.1.1"
 dependencies = [
  "ethers",
- "revm",
- "revm-primitives",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,7 @@ dependencies = [
 [[package]]
 name = "artemis-core"
 version = "0.1.0"
+source = "git+https://github.com/paradigmxyz/artemis.git#4bb158070833ec2b789a2ece14c896c4b28ce3be"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,14 +297,17 @@ dependencies = [
  "arbiter-bindings",
  "arbiter-core",
  "artemis-core",
- "async-stream",
  "async-trait",
  "crossbeam-channel",
  "ethers",
+ "flume",
  "futures-util",
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "tracing-test",
 ]
 
 [[package]]
@@ -341,7 +344,6 @@ dependencies = [
 [[package]]
 name = "artemis-core"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/artemis.git#4bb158070833ec2b789a2ece14c896c4b28ce3be"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1935,6 +1937,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3238,6 +3252,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.11",
 ]
 
 [[package]]
@@ -5430,6 +5453,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "tracing-test",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ arbiter-core = { path = "./arbiter-core" }
 crossbeam-channel =  { version = "=0.5.8" }
 futures-util =  { version = "=0.3.29" }
 async-trait =  { version = "0.1.74" }
+tracing = "0.1.40"
 
 # Dependencies for the release build
 [dependencies]

--- a/arbiter-bindings/Cargo.toml
+++ b/arbiter-bindings/Cargo.toml
@@ -9,6 +9,4 @@ license = "Apache-2.0"
 
 [dependencies]
 ethers.workspace = true
-revm.workspace = true
-revm-primitives.workspace = true
 serde.workspace = true

--- a/arbiter-core/Cargo.toml
+++ b/arbiter-core/Cargo.toml
@@ -37,7 +37,7 @@ thiserror.workspace = true
 
 # Logging
 futures-util.workspace = true
-tracing = "0.1.40"
+tracing.workspace = true
 
 # File types
 polars = { version = "0.35.4", features = ["parquet", "csv", "json"] }

--- a/arbiter-core/src/environment/mod.rs
+++ b/arbiter-core/src/environment/mod.rs
@@ -45,7 +45,6 @@ use revm::{
     },
     EVM,
 };
-// use hashbrown::{hash_map, HashMap as HashMapBrown};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 

--- a/arbiter-core/src/middleware/mod.rs
+++ b/arbiter-core/src/middleware/mod.rs
@@ -42,11 +42,6 @@ use futures_timer::Delay;
 use rand::{rngs::StdRng, SeedableRng};
 use revm::primitives::{CreateScheme, Output, TransactTo, TxEnv, U256};
 use serde::{de::DeserializeOwned, Serialize};
-// use revm::primitives::{ExecutionResult, Output};
-// use super::cast::revm_logs_to_ethers_logs;
-// use super::errors::RevmMiddlewareError;
-
-// use async_trait::async_trait;
 use thiserror::Error;
 
 use super::*;

--- a/arbiter-engine/Cargo.toml
+++ b/arbiter-engine/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 ethers.workspace = true
 arbiter-core.workspace = true
 arbiter-bindings = { path = "../arbiter-bindings" }
-artemis-core = { path = "../../../artemis/crates/artemis-core" } # TODO: Change this later
+artemis-core = { git = "https://github.com/paradigmxyz/artemis.git" }
 crossbeam-channel.workspace = true
 futures-util.workspace = true
 async-trait.workspace = true

--- a/arbiter-engine/Cargo.toml
+++ b/arbiter-engine/Cargo.toml
@@ -24,5 +24,4 @@ tracing.workspace = true
 flume = "0.11.0"
 
 [dev-dependencies]
-tracing-test = "0.2.4"
 tracing-subscriber = "0.3.18"

--- a/arbiter-engine/Cargo.toml
+++ b/arbiter-engine/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 ethers.workspace = true
 arbiter-core.workspace = true
 arbiter-bindings = { path = "../arbiter-bindings" }
-artemis-core = { git = "https://github.com/paradigmxyz/artemis.git"}
+artemis-core = { path = "../../../artemis/crates/artemis-core" } # TODO: Change this later
 crossbeam-channel.workspace = true
 futures-util.workspace = true
 async-trait.workspace = true
@@ -20,4 +20,9 @@ serde_json.workspace = true
 serde.workspace = true
 tokio.workspace = true
 anyhow =  { version = "=1.0.75" }
-async-stream = "0.3.5"
+tracing.workspace = true
+flume = "0.11.0"
+
+[dev-dependencies]
+tracing-test = "0.2.4"
+tracing-subscriber = "0.3.18"

--- a/arbiter-engine/src/agent.rs
+++ b/arbiter-engine/src/agent.rs
@@ -101,6 +101,7 @@ mod tests {
 
     use super::*;
 
+    #[ignore]
     #[tokio::test]
     async fn test_agent() {
         // Startup

--- a/arbiter-engine/src/agent.rs
+++ b/arbiter-engine/src/agent.rs
@@ -12,7 +12,7 @@
 
 use artemis_core::{
     engine::Engine,
-    types::{Collector, Executor},
+    types::{Collector, Executor, Strategy},
 };
 
 /// An agent is an entity capable of processing events and producing actions.
@@ -55,7 +55,7 @@ where
     pub fn add_collector(&mut self, collector: impl Collector<E> + 'static) {
         self.engine
             .as_mut()
-            .unwrap()
+            .expect("Engine has already been taken by the `World::run()` method.")
             .add_collector(Box::new(collector));
     }
 
@@ -63,8 +63,16 @@ where
     pub fn add_executor(&mut self, executor: impl Executor<A> + 'static) {
         self.engine
             .as_mut()
-            .unwrap()
+            .expect("Engine has already been taken by the `World::run()` method.")
             .add_executor(Box::new(executor));
+    }
+
+    /// Adds a strategy to the agent's engine.
+    pub fn add_strategy(&mut self, strategy: impl Strategy<E, A> + 'static) {
+        self.engine
+            .as_mut()
+            .expect("Engine has already been taken by the `World::run()` method.")
+            .add_strategy(Box::new(strategy));
     }
 
     /// Adds a dependency to the agent.

--- a/arbiter-engine/src/agent.rs
+++ b/arbiter-engine/src/agent.rs
@@ -25,7 +25,8 @@ pub struct Agent<E, A> {
     pub id: String,
 
     /// The engine that this agent uses to process events and produce actions.
-    pub(crate) engine: Option<Engine<E, A>>, /* Note, agent shouldn't NEED a client as a field as the engine can
+    pub(crate) engine: Option<Engine<E, A>>, /* Note, agent shouldn't NEED a client as a field
+                                              * as the engine can
                                               * handle this. */
 
     /// Agents that this agent depends on.

--- a/arbiter-engine/src/agent.rs
+++ b/arbiter-engine/src/agent.rs
@@ -22,17 +22,17 @@ use artemis_core::{
 pub struct Agent<E, A> {
     /// Identifier for this agent.
     /// Used for routing messages.
-    _id: String,
+    pub id: String,
 
     /// The engine that this agent uses to process events and produce actions.
-    engine: Engine<E, A>, /* Note, agent shouldn't NEED a client as a field as the engine can
-                           * handle this. */
+    pub(crate) engine: Option<Engine<E, A>>, /* Note, agent shouldn't NEED a client as a field as the engine can
+                                              * handle this. */
 
     /// Agents that this agent depends on.
-    dependencies: Vec<String>,
+    pub dependencies: Vec<String>,
 
     /// Agents that depend on this agent.
-    dependents: Vec<String>,
+    pub dependents: Vec<String>,
 }
 
 impl<E, A> Agent<E, A>
@@ -44,8 +44,8 @@ where
     /// Produces a new agent with the given identifier.
     pub fn new(id: &str) -> Self {
         Self {
-            _id: id.to_owned(),
-            engine: Engine::new(),
+            id: id.to_owned(),
+            engine: Some(Engine::new()),
             dependencies: vec![],
             dependents: vec![],
         }
@@ -53,12 +53,18 @@ where
 
     /// Adds a collector to the agent's engine.
     pub fn add_collector(&mut self, collector: impl Collector<E> + 'static) {
-        self.engine.add_collector(Box::new(collector));
+        self.engine
+            .as_mut()
+            .unwrap()
+            .add_collector(Box::new(collector));
     }
 
     /// Adds an executor to the agent's engine.
     pub fn add_executor(&mut self, executor: impl Executor<A> + 'static) {
-        self.engine.add_executor(Box::new(executor));
+        self.engine
+            .as_mut()
+            .unwrap()
+            .add_executor(Box::new(executor));
     }
 
     /// Adds a dependency to the agent.

--- a/arbiter-engine/src/examples.rs
+++ b/arbiter-engine/src/examples.rs
@@ -120,7 +120,6 @@ mod tests {
     use arbiter_core::{
         environment::builder::EnvironmentBuilder, middleware::connection::Connection,
     };
-
     use ethers::providers::Provider;
 
     use super::*;

--- a/arbiter-engine/src/examples.rs
+++ b/arbiter-engine/src/examples.rs
@@ -132,13 +132,15 @@ mod tests {
 
     #[async_trait::async_trait]
     impl Strategy<Message, Message> for TimedMessage {
+        #[tracing::instrument(skip(self), level = "trace")]
         async fn sync_state(&mut self) -> Result<()> {
-            println!("sync_state");
+            trace!("Syncing state.");
             Ok(())
         }
 
+        #[tracing::instrument(skip(self, event), level = "trace")]
         async fn process_event(&mut self, event: Message) -> Vec<Message> {
-            println!("event: {:?}", event);
+            trace!("Processing event.");
             if event.to == self.message.to {
                 let message = Message {
                     from: "agent1".to_owned(),
@@ -193,7 +195,6 @@ mod tests {
             data: "Start".to_owned(),
         };
         let send_result = messager.execute(message).await;
-        println!("send_result: {send_result:?}");
 
         world_task.await.unwrap();
     }

--- a/arbiter-engine/src/examples.rs
+++ b/arbiter-engine/src/examples.rs
@@ -159,6 +159,7 @@ mod tests {
         }
     }
 
+    #[ignore]
     #[tokio::test]
     async fn base_simulation() {
         let subscriber = tracing_subscriber::FmtSubscriber::builder()

--- a/arbiter-engine/src/lib.rs
+++ b/arbiter-engine/src/lib.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
+use tracing::{debug, trace, warn};
+
 pub mod agent;
 pub mod examples;
 pub mod messager;

--- a/arbiter-engine/src/lib.rs
+++ b/arbiter-engine/src/lib.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-
 use tracing::{debug, trace, warn};
 
 pub mod agent;

--- a/arbiter-engine/src/world.rs
+++ b/arbiter-engine/src/world.rs
@@ -45,6 +45,8 @@ pub struct Interconnect {
 impl<P, E, A> World<P, E, A>
 where
     P: PubsubClient,
+    E: Send + Clone + 'static + std::fmt::Debug,
+    A: Send + Clone + 'static + std::fmt::Debug,
 {
     // TODO: May not need to take in the provider here, but rather get it from the
     // agents.
@@ -61,6 +63,13 @@ where
     /// Adds an agent to the world.
     pub fn add_agent(&mut self, agent: Agent<E, A>) {
         self.agents.push(agent);
+    }
+
+    /// Runs the agents in the world.
+    pub fn run(&mut self) {
+        for agent in self.agents.iter_mut() {
+            agent.engine.take().unwrap().run();
+        }
     }
 }
 

--- a/arbiter-engine/src/world.rs
+++ b/arbiter-engine/src/world.rs
@@ -93,7 +93,6 @@ mod tests {
         types::Address,
     };
     use futures_util::StreamExt;
-    use tracing_test::traced_test;
 
     use super::*;
     use crate::messager::Messager;


### PR DESCRIPTION
**Give an overview of the tasks completed**
This PR adds the ability to have a world ran via `World::run()`. To show how this works, see `arbiter_engine::examples::tests`, specifically the `base_simulation()` function. This will run a simulation that loads an agent's engine with a messager as both a collector and executor which allows for this agent to receive external stimulus and communicate within this layer (potentially to other agents). Externally, "Start" is sent to the agent which kicks off a loop where the agent repeatedly echoes "Hello, world!" every second. This does not exit gracefully yet, use `ctrl + c`. It is a POC.

**Link to issue(s) that this PR closes**
Closes #745 