### PR TITLE
enhance(arbiter-engine): remove `<E, A>` generics from `World`

### DIFF
--- a/arbiter-core/src/tests/contracts.rs
+++ b/arbiter-core/src/tests/contracts.rs
@@ -1,5 +1,3 @@
-use chrono::format::parse;
-
 use super::*;
 
 #[tokio::test]

--- a/arbiter-core/src/tests/mod.rs
+++ b/arbiter-core/src/tests/mod.rs
@@ -10,9 +10,7 @@ use std::{str::FromStr, sync::Arc};
 
 use anyhow::Result;
 use arbiter_bindings::bindings::{
-    arbiter_math::ArbiterMath,
-    arbiter_token::{self, ArbiterToken},
-    liquid_exchange::LiquidExchange,
+    arbiter_math::ArbiterMath, arbiter_token::ArbiterToken, liquid_exchange::LiquidExchange,
 };
 use ethers::{
     prelude::{

--- a/arbiter-engine/src/agent.rs
+++ b/arbiter-engine/src/agent.rs
@@ -6,6 +6,8 @@
 // Need an init signal or something.
 // We can give agents a "calculator" evm to send "Actions" to when they are just
 // doing compute so they aren't blocking the main tx thread.
+// Maybe by default we should give agents a messager as part of their engine so we can call a
+// "start" and "stop" with them.
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 //! The agent module contains the core agent abstraction for the Arbiter Engine.

--- a/arbiter-engine/src/agent.rs
+++ b/arbiter-engine/src/agent.rs
@@ -18,8 +18,10 @@ use artemis_core::{
 };
 use tokio::task::JoinSet;
 
+/// An entity is a component that can be run by the engine.
 #[async_trait::async_trait]
-pub(crate) trait Entity: Send {
+pub trait Entity: Send {
+    /// Runs the entity.
     async fn run(&mut self) -> Result<JoinSet<()>, Box<dyn std::error::Error>>;
 }
 

--- a/arbiter-engine/src/examples.rs
+++ b/arbiter-engine/src/examples.rs
@@ -195,7 +195,7 @@ mod tests {
             to: "agent1".to_owned(),
             data: "Start".to_owned(),
         };
-        let send_result = messager.execute(message).await;
+        let _send_result = messager.execute(message).await;
 
         world_task.await.unwrap();
     }

--- a/arbiter-engine/src/world.rs
+++ b/arbiter-engine/src/world.rs
@@ -2,6 +2,10 @@
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // TODO: Notes ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //  Probably should move labels to world instead of on the environment.
+// One thing that is different about the Arbiter world is that give a bunch of different channels to
+// communicate with the Environment's tx thread. This is different from a connection to a blockchain
+// where you typically will just have a single HTTP/WS connection. What we want is some kind of way
+// of having the world own a reference to a provider or something
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 //! The world module contains the core world abstraction for the Arbiter Engine.
@@ -18,26 +22,21 @@ pub struct World<P> {
     pub id: String,
 
     /// The agents in the world.
-    pub agents: HashMap<String, Box<dyn Entity>>, //TODO: This should be a map of agents. We may also want to add a bit more to the Entity trait (e.g., the id of the agent). In which case, we could expose it as pub so those methods can be grabbed.
+    #[allow(private_interfaces)]
+    pub agents: HashMap<String, Box<dyn Entity>>, /* TODO: This should be a map of agents. We
+                                                   * may also want to add a bit more to the
+                                                   * Entity trait (e.g., the id of the agent).
+                                                   * In which case, we could expose it as pub so
+                                                   * those methods can be grabbed. */
 
     /// The provider for the world.
     pub provider: Provider<P>, /* TODO: The world itself may not need to carry around the
                                 * provider, but the agents should all use the same type of
                                 * provider. */
-                               // / The interconnects between different worlds.
-                               // / These can be used, for instance, to pass messages between agents running
-                               // / on different blockchain networks (e.g., Ethereum and Optimism).
-                               // pub interconnects: HashMap<String, Interconnect>,
 }
 
-// /// An interconnect is a connection between two worlds.
-// pub struct Interconnect {
-//     /// The message sender.
-//     _sender: Sender<Message>,
-
-//     /// The message receiver.
-//     _receiver: Receiver<Message>,
-// }
+// TODO: Can add a messager as an interconnect and have the manager give each
+// world it owns a clone of the same messager.
 
 impl<P> World<P>
 where
@@ -51,7 +50,6 @@ where
             id: id.to_owned(),
             agents: HashMap::new(),
             provider,
-            // interconnects: HashMap::new(),
         }
     }
 

--- a/arbiter-engine/src/world.rs
+++ b/arbiter-engine/src/world.rs
@@ -22,7 +22,6 @@ pub struct World<P> {
     pub id: String,
 
     /// The agents in the world.
-    #[allow(private_interfaces)]
     pub agents: HashMap<String, Box<dyn Entity>>, /* TODO: This should be a map of agents. We
                                                    * may also want to add a bit more to the
                                                    * Entity trait (e.g., the id of the agent).


### PR DESCRIPTION
**Give an overview of the tasks completed**
We wanted to not have the `World` struct have generics that come from the `Engine<E,A>` inside of the `Agent` struct. This PR fixes this by introducing a object-safe trait `Entity` that solely provides the interface to do `Agent::run()`. Minimal change with no breaks to tests. Changed the agent collection in `World` from `Vec<Agent>` to `HashMap<String, Agent>` while I was at it.

**Link to issue(s) that this PR closes**
Closes #747 