### PR TITLE
chore version specification

### DIFF
--- a/arbiter-engine/Cargo.toml
+++ b/arbiter-engine/Cargo.toml
@@ -27,6 +27,6 @@ arbiter-bindings.workspace = true
 
 [dev-dependencies]
 arbiter-core.workspace = true
-arbiter-bindings = { path = "../arbiter-bindings" }
+arbiter-bindings = { version = "0.1.1", path = "../arbiter-bindings" }
 tracing-subscriber = "0.3.18"
 tracing-test = "0.2.4"

--- a/arbiter-engine/src/world.rs
+++ b/arbiter-engine/src/world.rs
@@ -179,7 +179,7 @@ mod tests {
     };
     use futures_util::StreamExt;
 
-    #[ignore = "This is unecessary to run on CI currently."]
+    #[ignore = "This is unnecessary to run on CI currently."]
     #[tokio::test]
     async fn mainnet_ws() {
         let ws_url = std::env::var("MAINNET_WS_URL").expect("MAINNET_WS_URL must be set");


### PR DESCRIPTION
Specifies the binding version to use in the engine to enable publishing release 