### PR TITLE
feat(arbiter-core): Add `AnvilDump`

### DIFF
--- a/arbiter-core/src/database.rs
+++ b/arbiter-core/src/database.rs
@@ -8,7 +8,7 @@ use std::{
     fmt::Debug,
     fs,
     io::{self, Read, Write},
-    sync::{Arc, RwLock},
+    sync::{Arc, RwLock}, collections::BTreeMap,
 };
 
 use revm::{
@@ -16,7 +16,7 @@ use revm::{
     primitives::{AccountInfo, B256, U256},
     Database, DatabaseCommit,
 };
-use revm_primitives::{db::DatabaseRef, Bytecode};
+use revm_primitives::{db::DatabaseRef, Bytecode, Bytes, Address, keccak256};
 use serde::{Deserialize, Serialize};
 use serde_json;
 
@@ -131,8 +131,49 @@ impl DatabaseCommit for ArbiterDB {
     }
 }
 
+/// [AnvilDump] models the schema of an [anvil](https://github.com/foundry-rs/foundry) state dump.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AnvilDump {
+    /// Mapping of account addresses to [AccountRecord]s stored in the dump file.
+    pub accounts: BTreeMap<Address, AccountRecord>,
+}
+
+/// [AccountRecord] describes metadata about an account within the state trie.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AccountRecord {
+    /// The nonce of the account.
+    pub nonce: u64,
+    /// The balance of the account.
+    pub balance: U256,
+    /// The bytecode of the account. If empty, the account is an EOA.
+    pub code: Bytes,
+    /// The storage mapping of the account.
+    pub storage: revm_primitives::HashMap<U256, U256>,
+}
+
+impl TryFrom<AnvilDump> for CacheDB<EmptyDB> {
+    type Error = <CacheDB<EmptyDB> as Database>::Error;
+
+    fn try_from(dump: AnvilDump) -> Result<Self, Self::Error> {
+        let mut db = CacheDB::default();
+
+        dump.accounts.into_iter().try_for_each(|(address, account_record)| {
+            db.insert_account_info(address, AccountInfo {
+                balance: account_record.balance,
+                nonce: account_record.nonce,
+                code_hash: keccak256(account_record.code.as_ref()),
+                code: (!account_record.code.is_empty()).then(|| Bytecode::new_raw(account_record.code)),
+            });
+            db.replace_account_storage(address, account_record.storage)
+        })?;
+
+        Ok(db)
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use revm_primitives::{address, bytes};
     use super::*;
 
     #[test]
@@ -142,5 +183,48 @@ mod tests {
         let db = ArbiterDB::read_from_file("test.json").unwrap();
         assert_eq!(db, ArbiterDB::new());
         fs::remove_file("test.json").unwrap();
+    }
+
+    #[test]
+    fn load_anvil_dump_cachedb() {
+        const RAW_DUMP: &str = r#"
+        {
+            "accounts": {
+                "0x0000000000000000000000000000000000000000": {
+                    "nonce": 1234,
+                    "balance": "0xfacade",
+                    "code": "0x",
+                    "storage": {}
+                },
+                "0x0000000000000000000000000000000000000001": {
+                    "nonce": 555,
+                    "balance": "0xc0ffee",
+                    "code": "0xbadc0de0",
+                    "storage": {
+                        "0x0000000000000000000000000000000000000000000000000000000000000000": "0x000000000000000000000000000000000000000000000000000000000000deAD",
+                        "0x0000000000000000000000000000000000000000000000000000000000000001": "0x000000000000000000000000000000000000000000000000000000000000babe"
+                    }
+                }
+            }
+        }
+        "#;
+
+        let dump: AnvilDump = serde_json::from_str(RAW_DUMP).unwrap();
+        let mut db: CacheDB<EmptyDB> = dump.try_into().unwrap();
+
+        let account_a = db.load_account(address!("0000000000000000000000000000000000000000")).unwrap();
+        assert_eq!(account_a.info.nonce, 1234);
+        assert_eq!(account_a.info.balance, U256::from(0xfacade));
+        assert_eq!(account_a.info.code, None);
+        assert_eq!(account_a.info.code_hash, keccak256(&[]));
+
+        let account_b = db.load_account(address!("0000000000000000000000000000000000000001")).unwrap();
+        let b_bytecode = bytes!("badc0de0");
+        assert_eq!(account_b.info.nonce, 555);
+        assert_eq!(account_b.info.balance, U256::from(0xc0ffee));
+        assert_eq!(account_b.info.code_hash, keccak256(b_bytecode.as_ref()));
+        assert_eq!(account_b.info.code, Some(Bytecode::new_raw(b_bytecode)));
+        assert_eq!(account_b.storage.get(&U256::ZERO), Some(&U256::from(0xdead)));
+        assert_eq!(account_b.storage.get(&U256::from(1)), Some(&U256::from(0xbabe)));
     }
 }

--- a/arbiter-engine/src/world.rs
+++ b/arbiter-engine/src/world.rs
@@ -70,13 +70,24 @@ pub struct World {
 }
 
 impl World {
-    /// Creates a new world with the given identifier and provider.
+    /// Creates a new [World] with the given identifier and provider.
     pub fn new(id: &str) -> Self {
         Self {
             id: id.to_owned(),
             agents: Some(HashMap::new()),
             agent_tasks: None,
             environment: EnvironmentBuilder::new().build(),
+            messager: Messager::new(),
+        }
+    }
+
+    /// Creates a new [World] with the given identifier and provider.
+    pub fn new_with_env(id: &str, environment: Environment) -> Self {
+        Self {
+            id: id.to_owned(),
+            agents: Some(HashMap::new()),
+            agent_tasks: None,
+            environment,
             messager: Messager::new(),
         }
     }


### PR DESCRIPTION
## Overview

Adds a new method of creating a `World` with an existing `Environment`, as well as an `AnvilDump` data structure that can be deserialized from a raw dump file created by the `anvil_dumpState` end point.

### Rationale

Many projects deploy their smart contracts with `forge script`. When preparing an Arbiter simulation, these projects currently have to rewrite certain portions (or all) of their deploy scripts in Rust, which creates a possibility of divergent deployment specifications between the simulation and the live protocol.

To make this process smoother and more secure for teams, we can allow users to retain their current deployment scripts, and for Arbiter to load the initial state of an anvil chain after the deployment script has been ran on it.

### Semantics

Currently, the `EnvironmentBuilder` has the following function:
```rs
pub fn db(mut self, db: impl Into<CacheDB<EmptyDB>>) -> Self;
```

The `AnvilDump` type added in the `arbiter-core` crate's `database` module has a direct `Into<CacheDB<EmptyDB>>` implementation, so the user can now just do something along the lines of:

```rs
fn main() {
    let anvil_dump: AnvilDump = serde_json::from_str(<anvil_dump>).unwrap();
    let env = EnvironmentBuilder::new().db(anvil_dump.into()).build();
    let mut world = World::new_with_env("dispute_game", env);

    // ... and so on
}
```