### PR TITLE
refactor(arbiter-engine): agent-behavior flow

### DIFF
--- a/arbiter-engine/src/examples/timed_message.rs
+++ b/arbiter-engine/src/examples/timed_message.rs
@@ -83,9 +83,6 @@ impl Behavior<Message> for TimedMessage {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn echoer() {
-    std::env::set_var("RUST_LOG", "trace");
-    tracing_subscriber::fmt::init();
-
     let mut world = World::new("world");
 
     let agent = Agent::new(AGENT_ID, &world);
@@ -129,9 +126,6 @@ async fn echoer() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn ping_pong() {
-    // std::env::set_var("RUST_LOG", "trace");
-    // tracing_subscriber::fmt::init();
-
     let mut world = World::new("world");
 
     let agent = Agent::new(AGENT_ID, &world);
@@ -176,9 +170,6 @@ async fn ping_pong() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn ping_pong_two_agent() {
-    // std::env::set_var("RUST_LOG", "trace");
-    // tracing_subscriber::fmt::init();
-
     let mut world = World::new("world");
 
     let agent_ping = Agent::new("agent_ping", &world);

--- a/arbiter-engine/src/examples/token_minter.rs
+++ b/arbiter-engine/src/examples/token_minter.rs
@@ -1,384 +1,386 @@
-use std::{str::FromStr, time::Duration};
+// use std::{str::FromStr, time::Duration};
 
-use anyhow::Context;
-use arbiter_bindings::bindings::arbiter_token;
-use arbiter_core::data_collection::EventLogger;
-use ethers::{
-    abi::token,
-    types::{transaction::request, Filter},
-};
-use tokio::time::timeout;
-use tracing::error;
+// use anyhow::Context;
+// use arbiter_bindings::bindings::arbiter_token;
+// use arbiter_core::data_collection::EventLogger;
+// use ethers::{
+//     abi::token,
+//     types::{transaction::request, Filter},
+// };
+// use tokio::time::timeout;
+// use tracing::error;
 
-use self::machine::MachineHalt;
-use super::*;
-use crate::{
-    agent::Agent,
-    machine::{Behavior, MachineInstruction, StateMachine},
-    messager::To,
-    world::World,
-};
+// use self::machine::MachineHalt;
+// use super::*;
+// use crate::{
+//     agent::Agent,
+//     machine::{Behavior, MachineInstruction, StateMachine},
+//     messager::To,
+//     world::World,
+// };
 
-const TOKEN_ADMIN_ID: &str = "token_admin";
-const REQUESTER_ID: &str = "requester";
-const TOKEN_NAME: &str = "Arbiter Token";
-const TOKEN_SYMBOL: &str = "ARB";
-const TOKEN_DECIMALS: u8 = 18;
+// const TOKEN_ADMIN_ID: &str = "token_admin";
+// const REQUESTER_ID: &str = "requester";
+// const TOKEN_NAME: &str = "Arbiter Token";
+// const TOKEN_SYMBOL: &str = "ARB";
+// const TOKEN_DECIMALS: u8 = 18;
 
-/// The token admin is responsible for handling token minting requests.
-#[derive(Debug)]
-pub struct TokenAdmin {
-    /// The identifier of the token admin.
-    pub token_data: HashMap<String, TokenData>,
+// /// The token admin is responsible for handling token minting requests.
+// #[derive(Debug)]
+// pub struct TokenAdmin {
+//     /// The identifier of the token admin.
+//     pub token_data: HashMap<String, TokenData>,
 
-    pub tokens: Option<HashMap<String, ArbiterToken<RevmMiddleware>>>,
+//     pub tokens: Option<HashMap<String, ArbiterToken<RevmMiddleware>>>,
 
-    // TODO: We should not have to have a client or a messager put here
-    // explicitly, they should come from the Agent the behavior is given to.
-    pub client: Arc<RevmMiddleware>,
-    pub messager: Messager,
+//     // TODO: We should not have to have a client or a messager put here
+//     // explicitly, they should come from the Agent the behavior is given to.
+//     pub client: Arc<RevmMiddleware>,
+//     pub messager: Messager,
 
-    count: u64,
+//     count: u64,
 
-    max_count: Option<u64>,
-}
+//     max_count: Option<u64>,
+// }
 
-impl TokenAdmin {
-    pub fn new(
-        client: Arc<RevmMiddleware>,
-        messager: Messager,
-        count: u64,
-        max_count: Option<u64>,
-    ) -> Self {
-        Self {
-            token_data: HashMap::new(),
-            tokens: None,
-            client,
-            messager,
-            count,
-            max_count,
-        }
-    }
+// impl TokenAdmin {
+//     pub fn new(
+//         client: Arc<RevmMiddleware>,
+//         messager: Messager,
+//         count: u64,
+//         max_count: Option<u64>,
+//     ) -> Self {
+//         Self {
+//             token_data: HashMap::new(),
+//             tokens: None,
+//             client,
+//             messager,
+//             count,
+//             max_count,
+//         }
+//     }
 
-    /// Adds a token to the token admin.
-    pub fn add_token(&mut self, token_data: TokenData) {
-        self.token_data.insert(token_data.name.clone(), token_data);
-    }
-}
+//     /// Adds a token to the token admin.
+//     pub fn add_token(&mut self, token_data: TokenData) {
+//         self.token_data.insert(token_data.name.clone(), token_data);
+//     }
+// }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct TokenData {
-    pub name: String,
-    pub symbol: String,
-    pub decimals: u8,
-    pub address: Option<Address>,
-}
+// #[derive(Clone, Debug, Deserialize, Serialize)]
+// pub struct TokenData {
+//     pub name: String,
+//     pub symbol: String,
+//     pub decimals: u8,
+//     pub address: Option<Address>,
+// }
 
-/// Used as an action to ask what tokens are available.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum TokenAdminQuery {
-    /// Get the address of the token.
-    AddressOf(String),
+// /// Used as an action to ask what tokens are available.
+// #[derive(Clone, Debug, Deserialize, Serialize)]
+// pub enum TokenAdminQuery {
+//     /// Get the address of the token.
+//     AddressOf(String),
 
-    /// Mint tokens.
-    MintRequest(MintRequest),
-}
+//     /// Mint tokens.
+//     MintRequest(MintRequest),
+// }
 
-/// Used as an action to mint tokens.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct MintRequest {
-    /// The token to mint.
-    pub token: String,
+// /// Used as an action to mint tokens.
+// #[derive(Clone, Debug, Deserialize, Serialize)]
+// pub struct MintRequest {
+//     /// The token to mint.
+//     pub token: String,
 
-    /// The address to mint to.
-    pub mint_to: Address,
+//     /// The address to mint to.
+//     pub mint_to: Address,
 
-    /// The amount to mint.
-    pub mint_amount: u64,
-}
+//     /// The amount to mint.
+//     pub mint_amount: u64,
+// }
 
-#[async_trait::async_trait]
-impl Behavior<Message> for TokenAdmin {
-    #[tracing::instrument(skip(self), fields(id =
-self.messager.id.as_deref()))]
-    async fn sync(&mut self) {
-        for token_data in self.token_data.values_mut() {
-            let token = ArbiterToken::deploy(
-                self.client.clone(),
-                (
-                    token_data.name.clone(),
-                    token_data.symbol.clone(),
-                    token_data.decimals,
-                ),
-            )
-            .unwrap()
-            .send()
-            .await
-            .unwrap();
-            token_data.address = Some(token.address());
-            self.tokens
-                .get_or_insert_with(HashMap::new)
-                .insert(token_data.name.clone(), token.clone());
-            debug!("Deployed token: {:?}", token);
-        }
-    }
+// #[async_trait::async_trait]
+// impl Behavior<Message> for TokenAdmin {
+//     #[tracing::instrument(skip(self), fields(id =
+// self.messager.id.as_deref()))]
+//     async fn sync(&mut self) {
+//         for token_data in self.token_data.values_mut() {
+//             let token = ArbiterToken::deploy(
+//                 self.client.clone(),
+//                 (
+//                     token_data.name.clone(),
+//                     token_data.symbol.clone(),
+//                     token_data.decimals,
+//                 ),
+//             )
+//             .unwrap()
+//             .send()
+//             .await
+//             .unwrap();
+//             token_data.address = Some(token.address());
+//             self.tokens
+//                 .get_or_insert_with(HashMap::new)
+//                 .insert(token_data.name.clone(), token.clone());
+//             debug!("Deployed token: {:?}", token);
+//         }
+//     }
 
-    #[tracing::instrument(skip(self), fields(id =
-self.messager.id.as_deref()))]
-    async fn process(&mut self, event: Message) -> Option<MachineHalt> {
-        if self.tokens.is_none() {
-            error!(
-                "There were no tokens to deploy! You must add tokens to
-the token admin before running the simulation."
-            );
-        }
+//     #[tracing::instrument(skip(self), fields(id =
+// self.messager.id.as_deref()))]
+//     async fn process(&mut self, event: Message) -> Option<MachineHalt> {
+//         if self.tokens.is_none() {
+//             error!(
+//                 "There were no tokens to deploy! You must add tokens to
+// the token admin before running the simulation."
+//             );
+//         }
 
-        let query: TokenAdminQuery = serde_json::from_str(&event.data).unwrap();
-        trace!("Got query: {:?}", query);
-        match query {
-            TokenAdminQuery::AddressOf(token_name) => {
-                trace!(
-                    "Getting address of token with name: {:?}",
-                    token_name.clone()
-                );
-                let token_data = self.token_data.get(&token_name).unwrap();
-                let message = Message {
-                    from: self.messager.id.clone().unwrap(),
-                    to: To::Agent(event.from.clone()), // Reply back to sender
-                    data: serde_json::to_string(token_data).unwrap(),
-                };
-                self.messager.send(message).await;
-            }
-            TokenAdminQuery::MintRequest(mint_request) => {
-                trace!("Minting tokens: {:?}", mint_request);
-                let token = self
-                    .tokens
-                    .as_ref()
-                    .unwrap()
-                    .get(&mint_request.token)
-                    .unwrap();
-                token
-                    .mint(mint_request.mint_to, U256::from(mint_request.mint_amount))
-                    .send()
-                    .await
-                    .unwrap()
-                    .await
-                    .unwrap();
-                self.count += 1;
-                if self.count == self.max_count.unwrap_or(u64::MAX) {
-                    warn!("Reached max count. Halting behavior.");
-                    return Some(MachineHalt);
-                }
-            }
-        }
-        None
-    }
-}
+//         let query: TokenAdminQuery =
+// serde_json::from_str(&event.data).unwrap();         trace!("Got query: {:?}",
+// query);         match query {
+//             TokenAdminQuery::AddressOf(token_name) => {
+//                 trace!(
+//                     "Getting address of token with name: {:?}",
+//                     token_name.clone()
+//                 );
+//                 let token_data = self.token_data.get(&token_name).unwrap();
+//                 let message = Message {
+//                     from: self.messager.id.clone().unwrap(),
+//                     to: To::Agent(event.from.clone()), // Reply back to
+// sender                     data: serde_json::to_string(token_data).unwrap(),
+//                 };
+//                 self.messager.send(message).await;
+//             }
+//             TokenAdminQuery::MintRequest(mint_request) => {
+//                 trace!("Minting tokens: {:?}", mint_request);
+//                 let token = self
+//                     .tokens
+//                     .as_ref()
+//                     .unwrap()
+//                     .get(&mint_request.token)
+//                     .unwrap();
+//                 token
+//                     .mint(mint_request.mint_to,
+// U256::from(mint_request.mint_amount))                     .send()
+//                     .await
+//                     .unwrap()
+//                     .await
+//                     .unwrap();
+//                 self.count += 1;
+//                 if self.count == self.max_count.unwrap_or(u64::MAX) {
+//                     warn!("Reached max count. Halting behavior.");
+//                     return Some(MachineHalt);
+//                 }
+//             }
+//         }
+//         None
+//     }
+// }
 
-/// The token requester is responsible for requesting tokens from the token
-/// admin. This agents is purely for testing purposes as far as I can tell.
-#[derive(Debug)]
-pub struct TokenRequester {
-    /// The tokens that the token requester has requested.
-    pub token_data: TokenData,
+// /// The token requester is responsible for requesting tokens from the token
+// /// admin. This agents is purely for testing purposes as far as I can tell.
+// #[derive(Debug)]
+// pub struct TokenRequester {
+//     /// The tokens that the token requester has requested.
+//     pub token_data: TokenData,
 
-    /// The agent ID to request tokens to.
-    pub request_to: String,
+//     /// The agent ID to request tokens to.
+//     pub request_to: String,
 
-    /// Client to have an address to receive token mint to and check balance
-    pub client: Arc<RevmMiddleware>,
+//     /// Client to have an address to receive token mint to and check balance
+//     pub client: Arc<RevmMiddleware>,
 
-    /// The messaging layer for the token requester.
-    pub messager: Messager,
+//     /// The messaging layer for the token requester.
+//     pub messager: Messager,
 
-    pub count: u64,
+//     pub count: u64,
 
-    pub max_count: Option<u64>,
-}
+//     pub max_count: Option<u64>,
+// }
 
-impl TokenRequester {
-    pub fn new(
-        client: Arc<RevmMiddleware>,
-        messager: Messager,
-        count: u64,
-        max_count: Option<u64>,
-    ) -> Self {
-        Self {
-            token_data: TokenData {
-                name: TOKEN_NAME.to_owned(),
-                symbol: TOKEN_SYMBOL.to_owned(),
-                decimals: TOKEN_DECIMALS,
-                address: None,
-            },
-            request_to: TOKEN_ADMIN_ID.to_owned(),
-            client,
-            messager,
-            count,
-            max_count,
-        }
-    }
-}
+// impl TokenRequester {
+//     pub fn new(
+//         client: Arc<RevmMiddleware>,
+//         messager: Messager,
+//         count: u64,
+//         max_count: Option<u64>,
+//     ) -> Self {
+//         Self {
+//             token_data: TokenData {
+//                 name: TOKEN_NAME.to_owned(),
+//                 symbol: TOKEN_SYMBOL.to_owned(),
+//                 decimals: TOKEN_DECIMALS,
+//                 address: None,
+//             },
+//             request_to: TOKEN_ADMIN_ID.to_owned(),
+//             client,
+//             messager,
+//             count,
+//             max_count,
+//         }
+//     }
+// }
 
-#[async_trait::async_trait]
-impl Behavior<Message> for TokenRequester {
-    #[tracing::instrument(skip(self), fields(id =
-self.messager.id.as_deref()))]
-    async fn startup(&mut self) {
-        trace!("Requesting address of token: {:?}", self.token_data.name);
-        let message = Message {
-            from: self.messager.id.clone().unwrap(),
-            to: To::Agent(self.request_to.clone()),
-            data: serde_json::to_string(&TokenAdminQuery::AddressOf(self.token_data.name.clone()))
-                .unwrap(),
-        };
-        self.messager.send(message).await;
-    }
+// #[async_trait::async_trait]
+// impl Behavior<Message> for TokenRequester {
+//     #[tracing::instrument(skip(self), fields(id =
+// self.messager.id.as_deref()))]
+//     async fn startup(&mut self) {
+//         trace!("Requesting address of token: {:?}", self.token_data.name);
+//         let message = Message {
+//             from: self.messager.id.clone().unwrap(),
+//             to: To::Agent(self.request_to.clone()),
+//             data:
+// serde_json::to_string(&TokenAdminQuery::AddressOf(self.token_data.name.
+// clone()))                 .unwrap(),
+//         };
+//         self.messager.send(message).await;
+//     }
 
-    #[tracing::instrument(skip(self), fields(id =
-self.messager.id.as_deref()))]
-    async fn process(&mut self, event: Message) -> Option<MachineHalt> {
-        if let Ok(token_data) = serde_json::from_str::<TokenData>(&event.data) {
-            trace!(
-                "Got
-token data: {:?}",
-                token_data
-            );
-            trace!(
-                "Requesting first mint of
-token: {:?}",
-                self.token_data.name
-            );
-            let message = Message {
-                from: self.messager.id.clone().unwrap(),
-                to: To::Agent(self.request_to.clone()),
-                data: serde_json::to_string(&TokenAdminQuery::MintRequest(MintRequest {
-                    token: self.token_data.name.clone(),
-                    mint_to: self.client.address(),
-                    mint_amount: 1,
-                }))
-                .unwrap(),
-            };
-            self.messager.send(message).await;
-        }
-        Some(MachineHalt)
-    }
-}
+//     #[tracing::instrument(skip(self), fields(id =
+// self.messager.id.as_deref()))]
+//     async fn process(&mut self, event: Message) -> Option<MachineHalt> {
+//         if let Ok(token_data) =
+// serde_json::from_str::<TokenData>(&event.data) {             trace!(
+//                 "Got
+// token data: {:?}",
+//                 token_data
+//             );
+//             trace!(
+//                 "Requesting first mint of
+// token: {:?}",
+//                 self.token_data.name
+//             );
+//             let message = Message {
+//                 from: self.messager.id.clone().unwrap(),
+//                 to: To::Agent(self.request_to.clone()),
+//                 data:
+// serde_json::to_string(&TokenAdminQuery::MintRequest(MintRequest {            
+// token: self.token_data.name.clone(),                     mint_to:
+// self.client.address(),                     mint_amount: 1,
+//                 }))
+//                 .unwrap(),
+//             };
+//             self.messager.send(message).await;
+//         }
+//         Some(MachineHalt)
+//     }
+// }
 
-#[async_trait::async_trait]
-impl Behavior<arbiter_token::TransferFilter> for TokenRequester {
-    #[tracing::instrument(skip(self), fields(id =
-self.messager.id.as_deref()))]
-    async fn process(&mut self, event: arbiter_token::TransferFilter) -> Option<MachineHalt> {
-        trace!(
-            "Got event for
-`TokenRequester` logger: {:?}",
-            event
-        );
-        std::thread::sleep(std::time::Duration::from_secs(1));
-        let message = Message {
-            from: self.messager.id.clone().unwrap(),
-            to: To::Agent(self.request_to.clone()),
-            data: serde_json::to_string(&TokenAdminQuery::MintRequest(MintRequest {
-                token: self.token_data.name.clone(),
-                mint_to: self.client.address(),
-                mint_amount: 1,
-            }))
-            .unwrap(),
-        };
-        self.messager.send(message).await;
-        self.count += 1;
-        if self.count == self.max_count.unwrap_or(u64::MAX) {
-            warn!("Reached max count. Halting behavior.");
-            return Some(MachineHalt);
-        }
-        None
-    }
-}
+// #[async_trait::async_trait]
+// impl Behavior<arbiter_token::TransferFilter> for TokenRequester {
+//     #[tracing::instrument(skip(self), fields(id =
+// self.messager.id.as_deref()))]
+//     async fn process(&mut self, event: arbiter_token::TransferFilter) ->
+// Option<MachineHalt> {         trace!(
+//             "Got event for
+// `TokenRequester` logger: {:?}",
+//             event
+//         );
+//         std::thread::sleep(std::time::Duration::from_secs(1));
+//         let message = Message {
+//             from: self.messager.id.clone().unwrap(),
+//             to: To::Agent(self.request_to.clone()),
+//             data:
+// serde_json::to_string(&TokenAdminQuery::MintRequest(MintRequest {            
+// token: self.token_data.name.clone(),                 mint_to:
+// self.client.address(),                 mint_amount: 1,
+//             }))
+//             .unwrap(),
+//         };
+//         self.messager.send(message).await;
+//         self.count += 1;
+//         if self.count == self.max_count.unwrap_or(u64::MAX) {
+//             warn!("Reached max count. Halting behavior.");
+//             return Some(MachineHalt);
+//         }
+//         None
+//     }
+// }
 
-#[ignore]
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn token_minter_simulation() {
-    // std::env::set_var("RUST_LOG", "trace");
-    // tracing_subscriber::fmt::init();
+// #[ignore]
+// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// async fn token_minter_simulation() {
+//     // std::env::set_var("RUST_LOG", "trace");
+//     // tracing_subscriber::fmt::init();
 
-    let mut world = World::new("test_world");
+//     let mut world = World::new("test_world");
 
-    // Create the token admin agent
-    let token_admin = Agent::new(TOKEN_ADMIN_ID, &world);
-    let mut token_admin_behavior = TokenAdmin::new(
-        token_admin.client.clone(),
-        token_admin
-            .messager
-            .as_ref()
-            .unwrap()
-            .join_with_id(Some(TOKEN_ADMIN_ID.to_owned())),
-        0,
-        Some(4),
-    );
-    token_admin_behavior.add_token(TokenData {
-        name: TOKEN_NAME.to_owned(),
-        symbol: TOKEN_SYMBOL.to_owned(),
-        decimals: TOKEN_DECIMALS,
-        address: None,
-    });
-    world.add_agent(token_admin.with_behavior(token_admin_behavior));
+//     // Create the token admin agent
+//     let token_admin = Agent::new(TOKEN_ADMIN_ID, &world);
+//     let mut token_admin_behavior = TokenAdmin::new(
+//         token_admin.client.clone(),
+//         token_admin
+//             .messager
+//             .as_ref()
+//             .unwrap()
+//             .join_with_id(Some(TOKEN_ADMIN_ID.to_owned())),
+//         0,
+//         Some(4),
+//     );
+//     token_admin_behavior.add_token(TokenData {
+//         name: TOKEN_NAME.to_owned(),
+//         symbol: TOKEN_SYMBOL.to_owned(),
+//         decimals: TOKEN_DECIMALS,
+//         address: None,
+//     });
+//     world.add_agent(token_admin.with_behavior(token_admin_behavior));
 
-    // Create the token requester agent
-    let token_requester = Agent::new(REQUESTER_ID, &world);
-    let token_requester_behavior = TokenRequester::new(
-        token_requester.client.clone(),
-        token_requester
-            .messager
-            .as_ref()
-            .unwrap()
-            .join_with_id(Some(REQUESTER_ID.to_owned())),
-        0,
-        Some(4),
-    );
-    let arb = ArbiterToken::new(
-        Address::from_str("0x240a76d4c8a7dafc6286db5fa6b589e8b21fc00f").unwrap(),
-        token_requester.client.clone(),
-    );
-    let transfer_event = arb.transfer_filter();
+//     // Create the token requester agent
+//     let token_requester = Agent::new(REQUESTER_ID, &world);
+//     let token_requester_behavior = TokenRequester::new(
+//         token_requester.client.clone(),
+//         token_requester
+//             .messager
+//             .as_ref()
+//             .unwrap()
+//             .join_with_id(Some(REQUESTER_ID.to_owned())),
+//         0,
+//         Some(4),
+//     );
+//     let arb = ArbiterToken::new(
+//         Address::from_str("0x240a76d4c8a7dafc6286db5fa6b589e8b21fc00f").
+// unwrap(),         token_requester.client.clone(),
+//     );
+//     let transfer_event = arb.transfer_filter();
 
-    let token_requester_behavior_again = TokenRequester::new(
-        token_requester.client.clone(),
-        token_requester
-            .messager
-            .as_ref()
-            .unwrap()
-            .join_with_id(Some(REQUESTER_ID.to_owned())),
-        0,
-        Some(4),
-    );
-    world.add_agent(
-        token_requester
-            .with_behavior::<Message>(token_requester_behavior)
-            .with_behavior::<arbiter_token::TransferFilter>(token_requester_behavior_again)
-            .with_event(transfer_event),
-    );
+//     let token_requester_behavior_again = TokenRequester::new(
+//         token_requester.client.clone(),
+//         token_requester
+//             .messager
+//             .as_ref()
+//             .unwrap()
+//             .join_with_id(Some(REQUESTER_ID.to_owned())),
+//         0,
+//         Some(4),
+//     );
+//     world.add_agent(
+//         token_requester
+//             .with_behavior::<Message>(token_requester_behavior)
+//             
+// .with_behavior::<arbiter_token::TransferFilter>(token_requester_behavior_again)
+//             .with_event(transfer_event),
+//     );
 
-    let transfer_stream = EventLogger::builder()
-        .add_stream(arb.transfer_filter())
-        .stream()
-        .unwrap();
-    let mut stream = Box::pin(transfer_stream);
-    let mut idx = 0;
+//     let transfer_stream = EventLogger::builder()
+//         .add_stream(arb.transfer_filter())
+//         .stream()
+//         .unwrap();
+//     let mut stream = Box::pin(transfer_stream);
+//     let mut idx = 0;
 
-    world.run().await;
+//     world.run().await;
 
-    loop {
-        match timeout(Duration::from_secs(1), stream.next()).await {
-            Ok(Some(event)) => {
-                println!("Event received in outside world: {:?}", event);
-                idx += 1;
-                if idx == 4 {
-                    break;
-                }
-            }
-            _ => {
-                panic!("Timeout reached. Test failed.");
-            }
-        }
-    }
-}
+//     loop {
+//         match timeout(Duration::from_secs(1), stream.next()).await {
+//             Ok(Some(event)) => {
+//                 println!("Event received in outside world: {:?}", event);
+//                 idx += 1;
+//                 if idx == 4 {
+//                     break;
+//                 }
+//             }
+//             _ => {
+//                 panic!("Timeout reached. Test failed.");
+//             }
+//         }
+//     }
+// }

--- a/arbiter-engine/src/examples/token_minter.rs
+++ b/arbiter-engine/src/examples/token_minter.rs
@@ -1,386 +1,378 @@
-// use std::{str::FromStr, time::Duration};
+use std::{str::FromStr, time::Duration};
 
-// use anyhow::Context;
-// use arbiter_bindings::bindings::arbiter_token;
-// use arbiter_core::data_collection::EventLogger;
-// use ethers::{
-//     abi::token,
-//     types::{transaction::request, Filter},
-// };
-// use tokio::time::timeout;
-// use tracing::error;
+use anyhow::Context;
+use arbiter_bindings::bindings::arbiter_token;
+use arbiter_core::data_collection::EventLogger;
+use ethers::{
+    abi::token,
+    types::{transaction::request, Filter},
+};
+use tokio::time::timeout;
+use tracing::error;
 
-// use self::machine::MachineHalt;
-// use super::*;
-// use crate::{
-//     agent::Agent,
-//     machine::{Behavior, MachineInstruction, StateMachine},
-//     messager::To,
-//     world::World,
-// };
+use self::machine::MachineHalt;
+use super::*;
+use crate::{
+    agent::Agent,
+    machine::{Behavior, MachineInstruction, StateMachine},
+    messager::To,
+    world::World,
+};
 
-// const TOKEN_ADMIN_ID: &str = "token_admin";
-// const REQUESTER_ID: &str = "requester";
-// const TOKEN_NAME: &str = "Arbiter Token";
-// const TOKEN_SYMBOL: &str = "ARB";
-// const TOKEN_DECIMALS: u8 = 18;
+const TOKEN_ADMIN_ID: &str = "token_admin";
+const REQUESTER_ID: &str = "requester";
+const TOKEN_NAME: &str = "Arbiter Token";
+const TOKEN_SYMBOL: &str = "ARB";
+const TOKEN_DECIMALS: u8 = 18;
 
-// /// The token admin is responsible for handling token minting requests.
-// #[derive(Debug)]
-// pub struct TokenAdmin {
-//     /// The identifier of the token admin.
-//     pub token_data: HashMap<String, TokenData>,
+/// The token admin is responsible for handling token minting requests.
+#[derive(Debug)]
+pub struct TokenAdmin {
+    /// The identifier of the token admin.
+    pub token_data: HashMap<String, TokenData>,
 
-//     pub tokens: Option<HashMap<String, ArbiterToken<RevmMiddleware>>>,
+    pub tokens: Option<HashMap<String, ArbiterToken<RevmMiddleware>>>,
 
-//     // TODO: We should not have to have a client or a messager put here
-//     // explicitly, they should come from the Agent the behavior is given to.
-//     pub client: Arc<RevmMiddleware>,
-//     pub messager: Messager,
+    pub client: Option<Arc<RevmMiddleware>>,
 
-//     count: u64,
+    pub messager: Option<Messager>,
 
-//     max_count: Option<u64>,
-// }
+    count: u64,
 
-// impl TokenAdmin {
-//     pub fn new(
-//         client: Arc<RevmMiddleware>,
-//         messager: Messager,
-//         count: u64,
-//         max_count: Option<u64>,
-//     ) -> Self {
-//         Self {
-//             token_data: HashMap::new(),
-//             tokens: None,
-//             client,
-//             messager,
-//             count,
-//             max_count,
-//         }
-//     }
+    max_count: Option<u64>,
+}
 
-//     /// Adds a token to the token admin.
-//     pub fn add_token(&mut self, token_data: TokenData) {
-//         self.token_data.insert(token_data.name.clone(), token_data);
-//     }
-// }
+impl TokenAdmin {
+    pub fn new(count: u64, max_count: Option<u64>) -> Self {
+        Self {
+            token_data: HashMap::new(),
+            tokens: None,
+            client: None,
+            messager: None,
+            count,
+            max_count,
+        }
+    }
 
-// #[derive(Clone, Debug, Deserialize, Serialize)]
-// pub struct TokenData {
-//     pub name: String,
-//     pub symbol: String,
-//     pub decimals: u8,
-//     pub address: Option<Address>,
-// }
+    /// Adds a token to the token admin.
+    pub fn add_token(&mut self, token_data: TokenData) {
+        self.token_data.insert(token_data.name.clone(), token_data);
+    }
+}
 
-// /// Used as an action to ask what tokens are available.
-// #[derive(Clone, Debug, Deserialize, Serialize)]
-// pub enum TokenAdminQuery {
-//     /// Get the address of the token.
-//     AddressOf(String),
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TokenData {
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+    pub address: Option<Address>,
+}
 
-//     /// Mint tokens.
-//     MintRequest(MintRequest),
-// }
+/// Used as an action to ask what tokens are available.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum TokenAdminQuery {
+    /// Get the address of the token.
+    AddressOf(String),
 
-// /// Used as an action to mint tokens.
-// #[derive(Clone, Debug, Deserialize, Serialize)]
-// pub struct MintRequest {
-//     /// The token to mint.
-//     pub token: String,
+    /// Mint tokens.
+    MintRequest(MintRequest),
+}
 
-//     /// The address to mint to.
-//     pub mint_to: Address,
+/// Used as an action to mint tokens.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MintRequest {
+    /// The token to mint.
+    pub token: String,
 
-//     /// The amount to mint.
-//     pub mint_amount: u64,
-// }
+    /// The address to mint to.
+    pub mint_to: Address,
 
-// #[async_trait::async_trait]
-// impl Behavior<Message> for TokenAdmin {
-//     #[tracing::instrument(skip(self), fields(id =
-// self.messager.id.as_deref()))]
-//     async fn sync(&mut self) {
-//         for token_data in self.token_data.values_mut() {
-//             let token = ArbiterToken::deploy(
-//                 self.client.clone(),
-//                 (
-//                     token_data.name.clone(),
-//                     token_data.symbol.clone(),
-//                     token_data.decimals,
-//                 ),
-//             )
-//             .unwrap()
-//             .send()
-//             .await
-//             .unwrap();
-//             token_data.address = Some(token.address());
-//             self.tokens
-//                 .get_or_insert_with(HashMap::new)
-//                 .insert(token_data.name.clone(), token.clone());
-//             debug!("Deployed token: {:?}", token);
-//         }
-//     }
+    /// The amount to mint.
+    pub mint_amount: u64,
+}
 
-//     #[tracing::instrument(skip(self), fields(id =
-// self.messager.id.as_deref()))]
-//     async fn process(&mut self, event: Message) -> Option<MachineHalt> {
-//         if self.tokens.is_none() {
-//             error!(
-//                 "There were no tokens to deploy! You must add tokens to
-// the token admin before running the simulation."
-//             );
-//         }
+#[async_trait::async_trait]
+impl Behavior<Message> for TokenAdmin {
+    #[tracing::instrument(skip(self), fields(id = messager.id.as_deref()))]
+    async fn sync(&mut self, messager: Messager, client: Arc<RevmMiddleware>) {
+        for token_data in self.token_data.values_mut() {
+            let token = ArbiterToken::deploy(
+                client.clone(),
+                (
+                    token_data.name.clone(),
+                    token_data.symbol.clone(),
+                    token_data.decimals,
+                ),
+            )
+            .unwrap()
+            .send()
+            .await
+            .unwrap();
+            token_data.address = Some(token.address());
+            self.tokens
+                .get_or_insert_with(HashMap::new)
+                .insert(token_data.name.clone(), token.clone());
+            debug!("Deployed token: {:?}", token);
+        }
+        self.messager = Some(messager);
+        self.client = Some(client);
+    }
 
-//         let query: TokenAdminQuery =
-// serde_json::from_str(&event.data).unwrap();         trace!("Got query: {:?}",
-// query);         match query {
-//             TokenAdminQuery::AddressOf(token_name) => {
-//                 trace!(
-//                     "Getting address of token with name: {:?}",
-//                     token_name.clone()
-//                 );
-//                 let token_data = self.token_data.get(&token_name).unwrap();
-//                 let message = Message {
-//                     from: self.messager.id.clone().unwrap(),
-//                     to: To::Agent(event.from.clone()), // Reply back to
-// sender                     data: serde_json::to_string(token_data).unwrap(),
-//                 };
-//                 self.messager.send(message).await;
-//             }
-//             TokenAdminQuery::MintRequest(mint_request) => {
-//                 trace!("Minting tokens: {:?}", mint_request);
-//                 let token = self
-//                     .tokens
-//                     .as_ref()
-//                     .unwrap()
-//                     .get(&mint_request.token)
-//                     .unwrap();
-//                 token
-//                     .mint(mint_request.mint_to,
-// U256::from(mint_request.mint_amount))                     .send()
-//                     .await
-//                     .unwrap()
-//                     .await
-//                     .unwrap();
-//                 self.count += 1;
-//                 if self.count == self.max_count.unwrap_or(u64::MAX) {
-//                     warn!("Reached max count. Halting behavior.");
-//                     return Some(MachineHalt);
-//                 }
-//             }
-//         }
-//         None
-//     }
-// }
+    #[tracing::instrument(skip(self), fields(id = self.messager.as_ref().unwrap().id.as_deref()))]
+    async fn process(&mut self, event: Message) -> Option<MachineHalt> {
+        if self.tokens.is_none() {
+            error!(
+                "There were no tokens to deploy! You must add tokens to
+the token admin before running the simulation."
+            );
+        }
 
-// /// The token requester is responsible for requesting tokens from the token
-// /// admin. This agents is purely for testing purposes as far as I can tell.
-// #[derive(Debug)]
-// pub struct TokenRequester {
-//     /// The tokens that the token requester has requested.
-//     pub token_data: TokenData,
+        let query: TokenAdminQuery = serde_json::from_str(&event.data).unwrap();
+        trace!("Got query: {:?}", query);
+        let messager = self.messager.as_ref().unwrap();
+        match query {
+            TokenAdminQuery::AddressOf(token_name) => {
+                trace!(
+                    "Getting address of token with name: {:?}",
+                    token_name.clone()
+                );
+                let token_data = self.token_data.get(&token_name).unwrap();
+                let message = Message {
+                    from: messager.id.clone().unwrap(),
+                    to: To::Agent(event.from.clone()), // Reply back to sender
+                    data: serde_json::to_string(token_data).unwrap(),
+                };
+                messager.send(message).await;
+            }
+            TokenAdminQuery::MintRequest(mint_request) => {
+                trace!("Minting tokens: {:?}", mint_request);
+                let token = self
+                    .tokens
+                    .as_ref()
+                    .unwrap()
+                    .get(&mint_request.token)
+                    .unwrap();
+                token
+                    .mint(mint_request.mint_to, U256::from(mint_request.mint_amount))
+                    .send()
+                    .await
+                    .unwrap()
+                    .await
+                    .unwrap();
+                self.count += 1;
+                if self.count == self.max_count.unwrap_or(u64::MAX) {
+                    warn!("Reached max count. Halting behavior.");
+                    return Some(MachineHalt);
+                }
+            }
+        }
+        None
+    }
+}
 
-//     /// The agent ID to request tokens to.
-//     pub request_to: String,
+/// The token requester is responsible for requesting tokens from the token
+/// admin. This agents is purely for testing purposes as far as I can tell.
+#[derive(Debug)]
+pub struct TokenRequester {
+    /// The tokens that the token requester has requested.
+    pub token_data: TokenData,
 
-//     /// Client to have an address to receive token mint to and check balance
-//     pub client: Arc<RevmMiddleware>,
+    /// The agent ID to request tokens to.
+    pub request_to: String,
 
-//     /// The messaging layer for the token requester.
-//     pub messager: Messager,
+    /// Client to have an address to receive token mint to and check balance
+    pub client: Option<Arc<RevmMiddleware>>,
 
-//     pub count: u64,
+    /// The messaging layer for the token requester.
+    pub messager: Option<Messager>,
 
-//     pub max_count: Option<u64>,
-// }
+    pub count: u64,
 
-// impl TokenRequester {
-//     pub fn new(
-//         client: Arc<RevmMiddleware>,
-//         messager: Messager,
-//         count: u64,
-//         max_count: Option<u64>,
-//     ) -> Self {
-//         Self {
-//             token_data: TokenData {
-//                 name: TOKEN_NAME.to_owned(),
-//                 symbol: TOKEN_SYMBOL.to_owned(),
-//                 decimals: TOKEN_DECIMALS,
-//                 address: None,
-//             },
-//             request_to: TOKEN_ADMIN_ID.to_owned(),
-//             client,
-//             messager,
-//             count,
-//             max_count,
-//         }
-//     }
-// }
+    pub max_count: Option<u64>,
+}
 
-// #[async_trait::async_trait]
-// impl Behavior<Message> for TokenRequester {
-//     #[tracing::instrument(skip(self), fields(id =
-// self.messager.id.as_deref()))]
-//     async fn startup(&mut self) {
-//         trace!("Requesting address of token: {:?}", self.token_data.name);
-//         let message = Message {
-//             from: self.messager.id.clone().unwrap(),
-//             to: To::Agent(self.request_to.clone()),
-//             data:
-// serde_json::to_string(&TokenAdminQuery::AddressOf(self.token_data.name.
-// clone()))                 .unwrap(),
-//         };
-//         self.messager.send(message).await;
-//     }
+impl TokenRequester {
+    pub fn new(
+        client: Arc<RevmMiddleware>,
+        messager: Messager,
+        count: u64,
+        max_count: Option<u64>,
+    ) -> Self {
+        Self {
+            token_data: TokenData {
+                name: TOKEN_NAME.to_owned(),
+                symbol: TOKEN_SYMBOL.to_owned(),
+                decimals: TOKEN_DECIMALS,
+                address: None,
+            },
+            request_to: TOKEN_ADMIN_ID.to_owned(),
+            client: None,
+            messager: None,
+            count,
+            max_count,
+        }
+    }
+}
 
-//     #[tracing::instrument(skip(self), fields(id =
-// self.messager.id.as_deref()))]
-//     async fn process(&mut self, event: Message) -> Option<MachineHalt> {
-//         if let Ok(token_data) =
-// serde_json::from_str::<TokenData>(&event.data) {             trace!(
-//                 "Got
-// token data: {:?}",
-//                 token_data
-//             );
-//             trace!(
-//                 "Requesting first mint of
-// token: {:?}",
-//                 self.token_data.name
-//             );
-//             let message = Message {
-//                 from: self.messager.id.clone().unwrap(),
-//                 to: To::Agent(self.request_to.clone()),
-//                 data:
-// serde_json::to_string(&TokenAdminQuery::MintRequest(MintRequest {            
-// token: self.token_data.name.clone(),                     mint_to:
-// self.client.address(),                     mint_amount: 1,
-//                 }))
-//                 .unwrap(),
-//             };
-//             self.messager.send(message).await;
-//         }
-//         Some(MachineHalt)
-//     }
-// }
+#[async_trait::async_trait]
+impl Behavior<Message> for TokenRequester {
+    #[tracing::instrument(skip(self), fields(id = messager.id.as_deref()))]
+    async fn sync(&mut self, messager: Messager, client: Arc<RevmMiddleware>) {
+        self.messager = Some(messager);
+        self.client = Some(client);
+    }
 
-// #[async_trait::async_trait]
-// impl Behavior<arbiter_token::TransferFilter> for TokenRequester {
-//     #[tracing::instrument(skip(self), fields(id =
-// self.messager.id.as_deref()))]
-//     async fn process(&mut self, event: arbiter_token::TransferFilter) ->
-// Option<MachineHalt> {         trace!(
-//             "Got event for
-// `TokenRequester` logger: {:?}",
-//             event
-//         );
-//         std::thread::sleep(std::time::Duration::from_secs(1));
-//         let message = Message {
-//             from: self.messager.id.clone().unwrap(),
-//             to: To::Agent(self.request_to.clone()),
-//             data:
-// serde_json::to_string(&TokenAdminQuery::MintRequest(MintRequest {            
-// token: self.token_data.name.clone(),                 mint_to:
-// self.client.address(),                 mint_amount: 1,
-//             }))
-//             .unwrap(),
-//         };
-//         self.messager.send(message).await;
-//         self.count += 1;
-//         if self.count == self.max_count.unwrap_or(u64::MAX) {
-//             warn!("Reached max count. Halting behavior.");
-//             return Some(MachineHalt);
-//         }
-//         None
-//     }
-// }
+    #[tracing::instrument(skip(self), fields(id = self.messager.as_ref().unwrap().id.as_deref()))]
+    async fn startup(&mut self) {
+        let messager = self.messager.as_ref().unwrap();
+        trace!("Requesting address of token: {:?}", self.token_data.name);
+        let message = Message {
+            from: messager.id.clone().unwrap(),
+            to: To::Agent(self.request_to.clone()),
+            data: serde_json::to_string(&TokenAdminQuery::AddressOf(self.token_data.name.clone()))
+                .unwrap(),
+        };
+        messager.send(message).await;
+    }
 
-// #[ignore]
-// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-// async fn token_minter_simulation() {
-//     // std::env::set_var("RUST_LOG", "trace");
-//     // tracing_subscriber::fmt::init();
+    #[tracing::instrument(skip(self), fields(id = self.messager.as_ref().unwrap().id.as_deref()))]
+    async fn process(&mut self, event: Message) -> Option<MachineHalt> {
+        if let Ok(token_data) = serde_json::from_str::<TokenData>(&event.data) {
+            let messager = self.messager.as_ref().unwrap();
+            trace!(
+                "Got
+token data: {:?}",
+                token_data
+            );
+            trace!(
+                "Requesting first mint of
+token: {:?}",
+                self.token_data.name
+            );
+            let message = Message {
+                from: messager.id.clone().unwrap(),
+                to: To::Agent(self.request_to.clone()),
+                data: serde_json::to_string(&TokenAdminQuery::MintRequest(MintRequest {
+                    token: self.token_data.name.clone(),
+                    mint_to: self.client.as_ref().unwrap().address(),
+                    mint_amount: 1,
+                }))
+                .unwrap(),
+            };
+            messager.send(message).await;
+        }
+        Some(MachineHalt)
+    }
+}
 
-//     let mut world = World::new("test_world");
+#[async_trait::async_trait]
+impl Behavior<arbiter_token::TransferFilter> for TokenRequester {
+    async fn sync(&mut self, messager: Messager, client: Arc<RevmMiddleware>) {
+        self.client = Some(client);
+        self.messager = Some(messager);
+    }
 
-//     // Create the token admin agent
-//     let token_admin = Agent::new(TOKEN_ADMIN_ID, &world);
-//     let mut token_admin_behavior = TokenAdmin::new(
-//         token_admin.client.clone(),
-//         token_admin
-//             .messager
-//             .as_ref()
-//             .unwrap()
-//             .join_with_id(Some(TOKEN_ADMIN_ID.to_owned())),
-//         0,
-//         Some(4),
-//     );
-//     token_admin_behavior.add_token(TokenData {
-//         name: TOKEN_NAME.to_owned(),
-//         symbol: TOKEN_SYMBOL.to_owned(),
-//         decimals: TOKEN_DECIMALS,
-//         address: None,
-//     });
-//     world.add_agent(token_admin.with_behavior(token_admin_behavior));
+    #[tracing::instrument(skip(self), fields(id = self.messager.as_ref().unwrap().id.as_deref()))]
+    async fn process(&mut self, event: arbiter_token::TransferFilter) -> Option<MachineHalt> {
+        let messager = self.messager.as_ref().unwrap();
+        trace!(
+            "Got event for
+`TokenRequester` logger: {:?}",
+            event
+        );
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        let message = Message {
+            from: messager.id.clone().unwrap(),
+            to: To::Agent(self.request_to.clone()),
+            data: serde_json::to_string(&TokenAdminQuery::MintRequest(MintRequest {
+                token: self.token_data.name.clone(),
+                mint_to: self.client.as_ref().unwrap().address(),
+                mint_amount: 1,
+            }))
+            .unwrap(),
+        };
+        messager.send(message).await;
+        self.count += 1;
+        if self.count == self.max_count.unwrap_or(u64::MAX) {
+            warn!("Reached max count. Halting behavior.");
+            return Some(MachineHalt);
+        }
+        None
+    }
+}
 
-//     // Create the token requester agent
-//     let token_requester = Agent::new(REQUESTER_ID, &world);
-//     let token_requester_behavior = TokenRequester::new(
-//         token_requester.client.clone(),
-//         token_requester
-//             .messager
-//             .as_ref()
-//             .unwrap()
-//             .join_with_id(Some(REQUESTER_ID.to_owned())),
-//         0,
-//         Some(4),
-//     );
-//     let arb = ArbiterToken::new(
-//         Address::from_str("0x240a76d4c8a7dafc6286db5fa6b589e8b21fc00f").
-// unwrap(),         token_requester.client.clone(),
-//     );
-//     let transfer_event = arb.transfer_filter();
+#[ignore]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn token_minter_simulation() {
+    let mut world = World::new("test_world");
 
-//     let token_requester_behavior_again = TokenRequester::new(
-//         token_requester.client.clone(),
-//         token_requester
-//             .messager
-//             .as_ref()
-//             .unwrap()
-//             .join_with_id(Some(REQUESTER_ID.to_owned())),
-//         0,
-//         Some(4),
-//     );
-//     world.add_agent(
-//         token_requester
-//             .with_behavior::<Message>(token_requester_behavior)
-//             
-// .with_behavior::<arbiter_token::TransferFilter>(token_requester_behavior_again)
-//             .with_event(transfer_event),
-//     );
+    // Create the token admin agent
+    let token_admin = Agent::new(TOKEN_ADMIN_ID, &world);
+    let mut token_admin_behavior = TokenAdmin::new(0, Some(4));
+    token_admin_behavior.add_token(TokenData {
+        name: TOKEN_NAME.to_owned(),
+        symbol: TOKEN_SYMBOL.to_owned(),
+        decimals: TOKEN_DECIMALS,
+        address: None,
+    });
+    world.add_agent(token_admin.with_behavior(token_admin_behavior));
 
-//     let transfer_stream = EventLogger::builder()
-//         .add_stream(arb.transfer_filter())
-//         .stream()
-//         .unwrap();
-//     let mut stream = Box::pin(transfer_stream);
-//     let mut idx = 0;
+    // Create the token requester agent
+    let token_requester = Agent::new(REQUESTER_ID, &world);
+    let token_requester_behavior = TokenRequester::new(
+        token_requester.client.clone(),
+        token_requester
+            .messager
+            .as_ref()
+            .unwrap()
+            .join_with_id(Some(REQUESTER_ID.to_owned())),
+        0,
+        Some(4),
+    );
+    let arb = ArbiterToken::new(
+        Address::from_str("0x240a76d4c8a7dafc6286db5fa6b589e8b21fc00f").unwrap(),
+        token_requester.client.clone(),
+    );
+    let transfer_event = arb.transfer_filter();
 
-//     world.run().await;
+    let token_requester_behavior_again = TokenRequester::new(
+        token_requester.client.clone(),
+        token_requester
+            .messager
+            .as_ref()
+            .unwrap()
+            .join_with_id(Some(REQUESTER_ID.to_owned())),
+        0,
+        Some(4),
+    );
+    world.add_agent(
+        token_requester
+            .with_behavior::<Message>(token_requester_behavior)
+            .with_behavior::<arbiter_token::TransferFilter>(token_requester_behavior_again)
+            .with_event(transfer_event),
+    );
 
-//     loop {
-//         match timeout(Duration::from_secs(1), stream.next()).await {
-//             Ok(Some(event)) => {
-//                 println!("Event received in outside world: {:?}", event);
-//                 idx += 1;
-//                 if idx == 4 {
-//                     break;
-//                 }
-//             }
-//             _ => {
-//                 panic!("Timeout reached. Test failed.");
-//             }
-//         }
-//     }
-// }
+    let transfer_stream = EventLogger::builder()
+        .add_stream(arb.transfer_filter())
+        .stream()
+        .unwrap();
+    let mut stream = Box::pin(transfer_stream);
+    let mut idx = 0;
+
+    world.run().await;
+
+    loop {
+        match timeout(Duration::from_secs(1), stream.next()).await {
+            Ok(Some(event)) => {
+                println!("Event received in outside world: {:?}", event);
+                idx += 1;
+                if idx == 4 {
+                    break;
+                }
+            }
+            _ => {
+                panic!("Timeout reached. Test failed.");
+            }
+        }
+    }
+}

--- a/arbiter-engine/src/machine.rs
+++ b/arbiter-engine/src/machine.rs
@@ -6,6 +6,8 @@
 // and messager and then the user can decide if it wants to use those in their
 // behavior.
 
+// Could typestate pattern help here at all?
+
 use std::{fmt::Debug, sync::Arc};
 
 use arbiter_core::middleware::RevmMiddleware;
@@ -146,12 +148,12 @@ where
 {
     async fn execute(&mut self, instruction: MachineInstruction) {
         match instruction {
-            MachineInstruction::Sync => {
+            MachineInstruction::Sync(messager, client) => {
                 trace!("Behavior is syncing.");
                 self.state = State::Syncing;
                 let mut behavior = self.behavior.take().unwrap();
                 let behavior_task = tokio::spawn(async move {
-                    behavior.sync(messager, client).await;
+                    behavior.sync(messager.unwrap(), client.unwrap()).await;
                     behavior
                 });
                 self.behavior = Some(behavior_task.await.unwrap());

--- a/arbiter-engine/src/machine.rs
+++ b/arbiter-engine/src/machine.rs
@@ -6,7 +6,10 @@
 // and messager and then the user can decide if it wants to use those in their
 // behavior.
 
-// Could typestate pattern help here at all?
+// Could typestate pattern help here at all? Sync could produce a `Synced` state
+// behavior that can then not have options for client and messager. Then the
+// user can decide if they want to use those in their behavior and get a bit
+// simpler UX.
 
 use std::{fmt::Debug, sync::Arc};
 

--- a/arbiter-engine/src/machine.rs
+++ b/arbiter-engine/src/machine.rs
@@ -83,7 +83,7 @@ pub enum State {
 pub trait Behavior<E>: Send + Sync + 'static {
     /// Used to bring the agent back up to date with the latest state of the
     /// world. This could be used if the world was stopped and later restarted.
-    async fn sync(&mut self, messager: Messager, client: Arc<RevmMiddleware>) {}
+    async fn sync(&mut self, _messager: Messager, _client: Arc<RevmMiddleware>) {}
 
     /// Used to start the agent.
     /// This is where the agent can engage in its specific start up activities

--- a/arbiter-engine/src/messager.rs
+++ b/arbiter-engine/src/messager.rs
@@ -40,6 +40,16 @@ pub struct Messager {
     broadcast_receiver: Option<Receiver<Message>>,
 }
 
+impl Clone for Messager {
+    fn clone(&self) -> Self {
+        Self {
+            broadcast_sender: self.broadcast_sender.clone(),
+            broadcast_receiver: Some(self.broadcast_sender.subscribe()),
+            id: self.id.clone(),
+        }
+    }
+}
+
 impl Messager {
     // TODO: Allow for modulating the capacity of the messager.
     // TODO: It might be nice to have some kind of messaging header so that we can


### PR DESCRIPTION
**Give an overview of the tasks completed**
This PR adds the ability for the `sync()` stage of a `Behavior` to receive the client and messager from the agent the behavior is attached to. It should then be recommended to users to make these fields optional in their behaviors at some point down the road, but we are not done with this design yet. There could be better ways to address this problem, but I'll take this for now.

**Link to issue(s) that this PR closes**
Closes #819 