### PR TITLE
migrate to anyhow::Result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+
+[[package]]
 name = "arbiter"
 version = "0.4.13"
 dependencies = [
@@ -273,6 +279,7 @@ dependencies = [
 name = "arbiter-engine"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "arbiter-bindings",
  "arbiter-core",
  "arbiter-macros",

--- a/arbiter-engine/Cargo.toml
+++ b/arbiter-engine/Cargo.toml
@@ -34,6 +34,7 @@ toml.workspace = true
 
 thiserror.workspace = true
 tracing.workspace = true
+anyhow = "1.0.79"
 
 crossbeam-channel.workspace = true
 

--- a/arbiter-engine/src/examples/minter/behaviors/mod.rs
+++ b/arbiter-engine/src/examples/minter/behaviors/mod.rs
@@ -1,3 +1,5 @@
 use super::*;
 pub(crate) mod token_admin;
 pub(crate) mod token_requester;
+
+use anyhow::Result;

--- a/arbiter-engine/src/examples/minter/behaviors/token_admin.rs
+++ b/arbiter-engine/src/examples/minter/behaviors/token_admin.rs
@@ -31,7 +31,7 @@ impl Behavior<Message> for TokenAdmin {
         &mut self,
         client: Arc<ArbiterMiddleware>,
         messager: Messager,
-    ) -> Result<EventStream<Message>, ArbiterEngineError> {
+    ) -> Result<EventStream<Message>> {
         self.messager = Some(messager.clone());
         self.client = Some(client.clone());
         for token_data in self.token_data.values_mut() {
@@ -53,12 +53,12 @@ impl Behavior<Message> for TokenAdmin {
                 .get_or_insert_with(HashMap::new)
                 .insert(token_data.name.clone(), token.clone());
         }
-        messager.stream()
+        Ok(messager.stream()?)
     }
 
     #[tracing::instrument(skip(self), fields(id =
  self.messager.as_ref().unwrap().id.as_deref()))]
-    async fn process(&mut self, event: Message) -> Result<ControlFlow, ArbiterEngineError> {
+    async fn process(&mut self, event: Message) -> Result<ControlFlow> {
         if self.tokens.is_none() {
             error!(
                 "There were no tokens to deploy! You must add tokens to

--- a/arbiter-engine/src/examples/minter/behaviors/token_requester.rs
+++ b/arbiter-engine/src/examples/minter/behaviors/token_requester.rs
@@ -15,7 +15,7 @@ impl Behavior<TransferFilter> for TokenRequester {
         &mut self,
         client: Arc<ArbiterMiddleware>,
         mut messager: Messager,
-    ) -> Result<EventStream<TransferFilter>, ArbiterEngineError> {
+    ) -> Result<EventStream<TransferFilter>> {
         messager
             .send(
                 To::Agent(self.request_to.clone()),
@@ -49,7 +49,7 @@ impl Behavior<TransferFilter> for TokenRequester {
 
     #[tracing::instrument(skip(self), fields(id =
  self.messager.as_ref().unwrap().id.as_deref()))]
-    async fn process(&mut self, event: TransferFilter) -> Result<ControlFlow, ArbiterEngineError> {
+    async fn process(&mut self, event: TransferFilter) -> Result<ControlFlow> {
         let messager = self.messager.as_ref().unwrap();
         while (self.count < self.max_count.unwrap()) {
             debug!("sending message from requester");

--- a/arbiter-engine/src/examples/timed_message/mod.rs
+++ b/arbiter-engine/src/examples/timed_message/mod.rs
@@ -4,13 +4,13 @@ const AGENT_ID: &str = "agent";
 
 use std::{pin::Pin, time::Duration};
 
+use super::*;
+use anyhow::Result;
 use arbiter_macros::Behaviors;
 use ethers::types::BigEndianHash;
 use futures_util::Stream;
 use serde::*;
 use tokio::time::timeout;
-
-use super::*;
 
 fn default_max_count() -> Option<u64> {
     Some(3)
@@ -56,15 +56,15 @@ impl Behavior<Message> for TimedMessage {
         &mut self,
         _client: Arc<ArbiterMiddleware>,
         messager: Messager,
-    ) -> Result<EventStream<Message>, ArbiterEngineError> {
+    ) -> Result<EventStream<Message>> {
         if let Some(startup_message) = &self.startup_message {
             messager.send(To::All, startup_message).await;
         }
         self.messager = Some(messager.clone());
-        messager.stream()
+        Ok(messager.stream()?)
     }
 
-    async fn process(&mut self, event: Message) -> Result<ControlFlow, ArbiterEngineError> {
+    async fn process(&mut self, event: Message) -> Result<ControlFlow> {
         if event.data == serde_json::to_string(&self.receive_data).unwrap() {
             let messager = self.messager.clone().unwrap();
             messager.send(To::All, self.send_data.clone()).await;

--- a/arbiter-engine/src/examples/timed_message/mod.rs
+++ b/arbiter-engine/src/examples/timed_message/mod.rs
@@ -4,13 +4,14 @@ const AGENT_ID: &str = "agent";
 
 use std::{pin::Pin, time::Duration};
 
-use super::*;
 use anyhow::Result;
 use arbiter_macros::Behaviors;
 use ethers::types::BigEndianHash;
 use futures_util::Stream;
 use serde::*;
 use tokio::time::timeout;
+
+use super::*;
 
 fn default_max_count() -> Option<u64> {
     Some(3)

--- a/arbiter-engine/src/lib.rs
+++ b/arbiter-engine/src/lib.rs
@@ -7,11 +7,12 @@
 
 use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
-use crate::{errors::ArbiterEngineError, messager::Messager};
 use futures_util::future::join_all;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tokio::task::{spawn, JoinError};
 use tracing::{debug, trace, warn};
+
+use crate::{errors::ArbiterEngineError, messager::Messager};
 
 pub mod agent;
 pub mod errors;

--- a/arbiter-engine/src/lib.rs
+++ b/arbiter-engine/src/lib.rs
@@ -7,12 +7,11 @@
 
 use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
+use crate::{errors::ArbiterEngineError, messager::Messager};
 use futures_util::future::join_all;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tokio::task::{spawn, JoinError};
 use tracing::{debug, trace, warn};
-
-use crate::{errors::ArbiterEngineError, messager::Messager};
 
 pub mod agent;
 pub mod errors;


### PR DESCRIPTION
**Give an overview of the tasks completed**
Some of the traits and their return types are not easily managed with custom errors, so they are replaced with `anyhow::Result` to make the end user's life easier.
