### PR TITLE
Engine/world from config

### DIFF
--- a/arbiter-engine/src/examples/minter/config.toml
+++ b/arbiter-engine/src/examples/minter/config.toml
@@ -1,3 +1,6 @@
+# id for the world
+id = "minter_world"
+
 # top level id for the `TokenAdmin` agent
 [[admin]]
 # named struct and arguments for initializing the `TokenAdmin` agent

--- a/arbiter-engine/src/examples/minter/mod.rs
+++ b/arbiter-engine/src/examples/minter/mod.rs
@@ -86,8 +86,6 @@ enum Behaviors {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn config_test() {
-    let mut world = World::new("world");
-    world.from_config::<Behaviors>("src/examples/minter/config.toml");
-
+    let mut world = World::from_config::<Behaviors>("src/examples/minter/config.toml").unwrap();
     world.run().await;
 }

--- a/arbiter-engine/src/examples/minter/mod.rs
+++ b/arbiter-engine/src/examples/minter/mod.rs
@@ -87,5 +87,6 @@ enum Behaviors {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn config_test() {
     let mut world = World::from_config::<Behaviors>("src/examples/minter/config.toml").unwrap();
+    assert_eq!(world.id, "minter_world");
     world.run().await;
 }

--- a/arbiter-engine/src/examples/timed_message/config.toml
+++ b/arbiter-engine/src/examples/timed_message/config.toml
@@ -1,3 +1,5 @@
+id = "timed_message_world"
+
 [[ping]]
 TimedMessage = { delay = 1, send_data = "ping", receive_data = "pong", startup_message = "ping" }
 

--- a/arbiter-engine/src/examples/timed_message/mod.rs
+++ b/arbiter-engine/src/examples/timed_message/mod.rs
@@ -203,8 +203,7 @@ enum Behaviors {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn config_test() {
-    let mut world = World::new("world");
-    world.from_config::<Behaviors>("src/examples/timed_message/config.toml");
-
+    let mut world =
+        World::from_config::<Behaviors>("src/examples/timed_message/config.toml").unwrap();
     world.run().await;
 }

--- a/arbiter-engine/src/examples/timed_message/mod.rs
+++ b/arbiter-engine/src/examples/timed_message/mod.rs
@@ -205,5 +205,6 @@ enum Behaviors {
 async fn config_test() {
     let mut world =
         World::from_config::<Behaviors>("src/examples/timed_message/config.toml").unwrap();
+    assert_eq!(world.id, "timed_message_world");
     world.run().await;
 }

--- a/arbiter-macros/src/lib.rs
+++ b/arbiter-macros/src/lib.rs
@@ -158,8 +158,7 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
             match &args.command {
                 Some(Commands::Simulate { config_path }) => {
                     println!("Simulating configuration: {}", config_path);
-                    let mut world = World::new("world");
-                    world.from_config::<#behaviors>(config_path);
+                    let mut world = World::from_config::<#behaviors>(config_path)?;
                     world.run().await?;
                 },
                 None => {


### PR DESCRIPTION
**Give an overview of the tasks completed**
Allows for a world to be more simply created from a config. Now we just do `World::from_config("path/to/config.toml");`
