### PR TITLE
feat: make streams optional for behaviors for oneshot

### DIFF
--- a/engine/tests/common.rs
+++ b/engine/tests/common.rs
@@ -8,6 +8,12 @@ use arbiter_engine::{
 };
 use serde::{Deserialize, Serialize};
 
+#[allow(unused)]
+fn trace() {
+    std::env::set_var("RUST_LOG", "trace");
+    tracing_subscriber::fmt::init();
+}
+
 fn default_max_count() -> Option<u64> {
     Some(3)
 }
@@ -53,12 +59,12 @@ impl Behavior<Message> for TimedMessage {
         &mut self,
         _client: Arc<ArbiterMiddleware>,
         messager: Messager,
-    ) -> Result<EventStream<Message>> {
+    ) -> Result<Option<EventStream<Message>>> {
         if let Some(startup_message) = &self.startup_message {
             messager.send(To::All, startup_message).await?;
         }
         self.messager = Some(messager.clone());
-        Ok(messager.stream()?)
+        Ok(Some(messager.stream()?))
     }
 
     async fn process(&mut self, event: Message) -> Result<ControlFlow> {

--- a/engine/tests/machine_integration.rs
+++ b/engine/tests/machine_integration.rs
@@ -1,0 +1,28 @@
+use arbiter_engine::{agent::Agent, world::World};
+
+include!("common.rs");
+
+#[derive(Debug, Deserialize, Serialize)]
+struct MockBehavior;
+
+#[async_trait::async_trait]
+impl Behavior<()> for MockBehavior {
+    async fn startup(
+        &mut self,
+        _client: Arc<ArbiterMiddleware>,
+        _messager: Messager,
+    ) -> Result<Option<EventStream<()>>> {
+        Ok(None)
+    }
+}
+
+#[tokio::test]
+async fn behavior_no_stream() {
+    trace();
+    let mut world = World::new("test");
+    let behavior = MockBehavior;
+    let agent = Agent::builder("agent").with_behavior(behavior);
+    world.add_agent(agent);
+
+    world.run().await.unwrap();
+}


### PR DESCRIPTION
**Give an overview of the tasks completed**
To make "oneshot" behaviors easier, we can just have `startup()` return an optional stream and also have a default impl for the `process()` method. 

**Link to issue(s) that this PR closes**
Closes #897
