### PR TITLE
feat: Expose underlying cache_db with env.db() function

### DIFF
--- a/core/src/environment/mod.rs
+++ b/core/src/environment/mod.rs
@@ -634,6 +634,15 @@ impl Environment {
         self
     }
 
+    /// Obtains the current underlying [`CacheDB`] instance
+    /// after a read lock was acquired to inspect the current execution state
+    pub fn db(&self) -> Result<CacheDB<EmptyDB>, ArbiterCoreError> {
+        match self.db.state.read() {
+            Ok(cache_db) => Ok(cache_db.clone()),
+            Err(err) => Err(ArbiterCoreError::RwLockError(err.to_string())),
+        }
+    }
+
     /// Stops the execution of the environment and returns the [`ArbiterDB`] in
     /// its final state.
     pub fn stop(mut self) -> Result<ArbiterDB, ArbiterCoreError> {

--- a/core/tests/environment_integration.rs
+++ b/core/tests/environment_integration.rs
@@ -142,11 +142,18 @@ async fn middleware_from_forked_eo() {
 }
 
 #[tokio::test]
-async fn env_returns_db() {
+async fn env_returns_db_after_stop() {
     let (environment, client) = startup();
     deploy_arbx(client).await;
     let db = environment.stop().unwrap();
     assert!(!db.state.read().unwrap().accounts.is_empty())
+}
+
+#[tokio::test]
+async fn env_returns_db_mid_execution() {
+    let (environment, client) = startup();
+    deploy_arbx(client).await;
+    assert!(!environment.db().unwrap().accounts.is_empty())
 }
 
 #[tokio::test]


### PR DESCRIPTION
**Give an overview of the tasks completed**
Expose underlying cache_db with `env.db()` function. This is useful to check the execution state and environment re-creation without stopping the simulation.

**Link to issue(s) that this PR closes**

**REMINDER! Please check that you have done the following prior to submitting this PR:**
- [x] Checked that the relevant version(s) have been incremented if necessary.
     - please advise if version is to be incremented
- [x] Ran both and made any changes necessary for:
    - `cargo +nightly fmt --all`
    - `cargo clippy --all`
    
You can install the nightly toolchain on your system by:
```bash
rustup toolchain install nightly
```
